### PR TITLE
Adding helm charts for the snapshot-agent

### DIFF
--- a/deploy/snapshot-agent/Chart.yaml
+++ b/deploy/snapshot-agent/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: snapshot-agent
+description: A Helm chart for the snapshot-agent DaemonSet
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/deploy/snapshot-agent/templates/_helpers.tpl
+++ b/deploy/snapshot-agent/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "snapshot-agent.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "snapshot-agent.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "snapshot-agent.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "snapshot-agent.labels" -}}
+helm.sh/chart: {{ include "snapshot-agent.chart" . }}
+{{ include "snapshot-agent.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "snapshot-agent.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "snapshot-agent.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "snapshot-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "snapshot-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/snapshot-agent/templates/clusterrole.yaml
+++ b/deploy/snapshot-agent/templates/clusterrole.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "snapshot-agent.fullname" . }}
+  labels:
+    {{- include "snapshot-agent.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list", "watch"]
+  # Permission to query the kubelet via the API server proxy
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+{{- end }}

--- a/deploy/snapshot-agent/templates/clusterrolebinding.yaml
+++ b/deploy/snapshot-agent/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "snapshot-agent.fullname" . }}
+  labels:
+    {{- include "snapshot-agent.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "snapshot-agent.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "snapshot-agent.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/snapshot-agent/templates/daemonset.yaml
+++ b/deploy/snapshot-agent/templates/daemonset.yaml
@@ -1,0 +1,99 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ include "snapshot-agent.fullname" . }}
+  labels:
+    {{- include "snapshot-agent.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "snapshot-agent.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "snapshot-agent.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "snapshot-agent.serviceAccountName" . }}
+      hostNetwork: true
+      hostPID: true
+      initContainers:
+        - name: install-cuda-checkpoint
+          image: alpine:latest
+          command: ["sh", "-c", "apk add --no-cache wget && wget -qO /opt/bin/cuda-checkpoint https://raw.githubusercontent.com/NVIDIA/cuda-checkpoint/main/bin/x86_64_Linux/cuda-checkpoint && chmod +x /opt/bin/cuda-checkpoint && echo 'cuda-checkpoint installed'"]
+          volumeMounts:
+            - name: bin-dir
+              mountPath: /opt/bin
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PATH
+              value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: AGENT_PORT
+              value: {{ .Values.port | quote }}
+            {{- if .Values.nvidia.driver.enabled }}
+            - name: LD_LIBRARY_PATH
+              value: {{ join ":" .Values.nvidia.driver.libraryPaths }}
+            {{- end }}
+            - name: NVIDIA_VISIBLE_DEVICES
+              value: "all"
+            - name: NVIDIA_DRIVER_CAPABILITIES
+              value: "compute,utility"
+          ports:
+            - name: grpc
+              containerPort: {{ .Values.port }}
+              protocol: TCP
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: bin-dir
+              mountPath: /opt/bin
+            {{- if .Values.nvidia.driver.enabled }}
+            - name: nvidia-driver
+              mountPath: {{ .Values.nvidia.driver.mountPath }}
+              readOnly: true
+            {{- end }}
+            {{- if .Values.nvidia.devices.enabled }}
+            - name: nvidia-devices
+              mountPath: {{ .Values.nvidia.devices.mountPath }}
+            {{- end }}
+      volumes:
+        - name: bin-dir
+          emptyDir: {}
+        {{- if .Values.nvidia.driver.enabled }}
+        - name: nvidia-driver
+          hostPath:
+            path: {{ .Values.nvidia.driver.hostPath }}
+        {{- end }}
+        {{- if .Values.nvidia.devices.enabled }}
+        - name: nvidia-devices
+          hostPath:
+            path: {{ .Values.nvidia.devices.hostPath }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/snapshot-agent/templates/daemonset.yaml
+++ b/deploy/snapshot-agent/templates/daemonset.yaml
@@ -79,11 +79,13 @@ spec:
         - name: nvidia-driver
           hostPath:
             path: {{ .Values.nvidia.driver.hostPath }}
+            type: Directory
         {{- end }}
         {{- if .Values.nvidia.devices.enabled }}
         - name: nvidia-devices
           hostPath:
             path: {{ .Values.nvidia.devices.hostPath }}
+            type: Directory
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/deploy/snapshot-agent/templates/serviceaccount.yaml
+++ b/deploy/snapshot-agent/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "snapshot-agent.serviceAccountName" . }}
+  labels:
+    {{- include "snapshot-agent.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/deploy/snapshot-agent/values.yaml
+++ b/deploy/snapshot-agent/values.yaml
@@ -1,0 +1,56 @@
+# Default values for snapshot-agent.
+image:
+  repository: ghcr.io/llm-d/snapshot-agent
+  pullPolicy: IfNotPresent
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+podAnnotations: {}
+
+resources: {}
+#  limits:
+#    cpu: 500m
+#    memory: 1Gi
+#  requests:
+#    cpu: 100m
+#    memory: 256Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+port: 9001
+
+securityContext:
+  privileged: true
+
+nvidia:
+  driver:
+    enabled: true
+    hostPath: /home/kubernetes/bin/nvidia
+    # Path inside the container where the driver will be mounted
+    mountPath: /usr/local/nvidia
+    # List of library search paths inside the container
+    libraryPaths:
+      - /usr/local/nvidia/lib64
+  devices:
+    enabled: true
+    hostPath: /dev
+    mountPath: /dev
+
+rbac:
+  create: true
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and their purpose -->

## Why is this change needed? 

Adds the helm charts needed to deploy the snapshot daemon. 

Sample command:

```
helm upgrade --install snapshot-agent ./deploy/snapshot-agent   --set image.repository=<image>   --set image.tag=<tag>   --set "tolerations[0].key=nvidia.com/gpu"   --set "tolerations[0].operator=Equal"   --set "tolerations[0].value=present"   --set "tolerations[0].effect=NoSchedule"   --set serviceAccount.create=true   --set serviceAccount.name=snapshot-agent-new-sa
```

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
