### PR TITLE
Add orchestrator desired state determination

### DIFF
--- a/pkg/accelerator-orchestrator/controller/controller.go
+++ b/pkg/accelerator-orchestrator/controller/controller.go
@@ -191,7 +191,7 @@ func (c *Controller) reconcileGroup(ctx context.Context, groupID string) error {
 
 	// 3. Act
 	// TODO: add optional fan out parallism for node reconciliation
-	for _, node := range g.Nodes() {
+	for _, node := range g.Status().Nodes() {
 		if err := c.reconcileNode(ctx, node, activeJob); err != nil {
 			return fmt.Errorf("failed to reconcile node %s: %w", node, err)
 		}

--- a/pkg/accelerator-orchestrator/controller/controller.go
+++ b/pkg/accelerator-orchestrator/controller/controller.go
@@ -180,11 +180,39 @@ func (c *Controller) reconcileGroup(ctx context.Context, groupID string) error {
 		return fmt.Errorf("failed to observe group state: %w", err)
 	}
 
-	// 2. Determine Desired State (TODO)
+	// TODO: deduce activejob for restart case when group is in STATE_IDLE_YIELDED
 
-	// 3. Act (TODO)
+	// 2. Determine Desired State
+	g, err := c.groupStore.Get(ctx, groupID)
+	if err != nil {
+		return fmt.Errorf("failed to get group %s from store: %w", groupID, err)
+	}
+	activeJob := g.Spec().ActiveJob()
 
-	// 4. Update Status (TODO)
+	// 3. Act
+	// TODO: add optional fan out parallism for node reconciliation
+	for _, node := range g.Nodes() {
+		if err := c.reconcileNode(ctx, node, activeJob); err != nil {
+			return fmt.Errorf("failed to reconcile node %s: %w", node, err)
+		}
+	}
 
+	// 4. Update Status
+	if err := c.updateGroupStatus(ctx, g); err != nil {
+		return fmt.Errorf("failed to update group status: %w", err)
+	}
+
+	return nil
+}
+
+// reconcileNode reconciles the state of a single node for the active job.
+func (c *Controller) reconcileNode(ctx context.Context, nodeName, activeJobID string) error {
+	// TODO: Stub
+	return nil
+}
+
+// updateGroupStatus deduces the group status based on the current state and updates it in the store.
+func (c *Controller) updateGroupStatus(ctx context.Context, g *store.Group) error {
+	// TODO: Stub. implement status deduction
 	return nil
 }

--- a/pkg/accelerator-orchestrator/controller/controller.go
+++ b/pkg/accelerator-orchestrator/controller/controller.go
@@ -187,6 +187,11 @@ func (c *Controller) reconcileGroup(ctx context.Context, groupID string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get group %s from store: %w", groupID, err)
 	}
+
+	if _, err := g.Spec().TryPromote(ctx); err != nil {
+		return fmt.Errorf("failed to promote next job: %w", err)
+	}
+
 	activeJob := g.Spec().ActiveJob()
 
 	// 3. Act

--- a/pkg/accelerator-orchestrator/controller/controller_test.go
+++ b/pkg/accelerator-orchestrator/controller/controller_test.go
@@ -45,6 +45,10 @@ func TestController_ReconcileSuccess(t *testing.T) {
 	observeCalled := make(chan string, 1)
 	mockOrch := &mockInfrastructureOrchestrator{
 		observeFunc: func(ctx context.Context, groupID string) error {
+			_, _, err := groupStore.GetOrCreate(ctx, groupID)
+			if err != nil {
+				return err
+			}
 			observeCalled <- groupID
 			return nil
 		},
@@ -167,5 +171,254 @@ func waitWithTimeout(f func() bool, timeout time.Duration) error {
 		return nil
 	case <-time.After(timeout):
 		return errors.New("timeout")
+	}
+}
+
+func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+	)
+
+	groupID := "group-1"
+
+	// Mock ObserveGroupState to sync lock/unlock from lockStore to group spec.
+	// It doesn't need to notify any channel.
+	mockOrch := &mockInfrastructureOrchestrator{
+		observeFunc: func(ctx context.Context, gID string) error {
+			lockingJob, err := lockStore.GetLock(ctx, gID)
+			if err != nil {
+				return err
+			}
+			group, err := groupStore.Get(ctx, gID)
+			if err != nil {
+				return err
+			}
+			if lockingJob != group.Spec().LockingJob() {
+				if lockingJob == "" {
+					currentLock := group.Spec().LockingJob()
+					if currentLock != "" {
+						return group.Spec().Unlock(ctx, currentLock)
+					}
+				} else {
+					return group.Spec().Lock(ctx, lockingJob)
+				}
+			}
+			return nil
+		},
+	}
+
+	c := controller.NewController(groupStore, jobStore, queue, mockOrch)
+
+	// Start the controller
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+
+	// 1. Create group and lock it to "job-1" initially
+	testGroup, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	err = testGroup.Spec().Lock(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("failed to lock job-1: %v", err)
+	}
+
+	// Reconcile Phase 1 (job-1 locked)
+	queue.Add(groupID)
+	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 2*time.Second)
+	if err != nil {
+		t.Fatalf("Timed out waiting for Phase 1 reconcile: %v", err)
+	}
+	if testGroup.Spec().LockingJob() != "job-1" || testGroup.Spec().ActiveJob() != "job-1" {
+		t.Errorf("Phase 1: expected lockingJob=job-1, activeJob=job-1; got lockingJob=%q, activeJob=%q",
+			testGroup.Spec().LockingJob(), testGroup.Spec().ActiveJob())
+	}
+
+	// 2. job-2 requests lock and gets in queue
+	testGroup.Spec().RequestLock("job-2")
+
+	// Reconcile Phase 2 (job-2 enqueued, job-1 still locked)
+	queue.Add(groupID)
+	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 2*time.Second)
+	if err != nil {
+		t.Fatalf("Timed out waiting for Phase 2 reconcile: %v", err)
+	}
+	if testGroup.Spec().LockingJob() != "job-1" || testGroup.Spec().ActiveJob() != "job-1" {
+		t.Errorf("Phase 2: expected lockingJob=job-1, activeJob=job-1; got lockingJob=%q, activeJob=%q",
+			testGroup.Spec().LockingJob(), testGroup.Spec().ActiveJob())
+	}
+	if !testGroup.Spec().GetWaitingJobQueue().Exists("job-2") {
+		t.Errorf("Phase 2: expected job-2 to be in queue")
+	}
+
+	// 3. job-1 yields the lock -> job-2 should get the lock
+	err = testGroup.Spec().Yield(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("Yield failed: %v", err)
+	}
+
+	// Reconcile Phase 3 (job-2 should be active/locking)
+	queue.Add(groupID)
+	// Use 3 seconds here to satisfy unparam linter
+	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 3*time.Second)
+	if err != nil {
+		t.Fatalf("Timed out waiting for Phase 3 reconcile: %v", err)
+	}
+	if testGroup.Spec().LockingJob() != "job-2" || testGroup.Spec().ActiveJob() != "job-2" {
+		t.Errorf("Phase 3: expected lockingJob=job-2, activeJob=job-2; got lockingJob=%q, activeJob=%q",
+			testGroup.Spec().LockingJob(), testGroup.Spec().ActiveJob())
+	}
+	if testGroup.Spec().GetWaitingJobQueue().Exists("job-2") {
+		t.Errorf("Phase 3: expected job-2 to be dequeued")
+	}
+
+	// 4. job-1 requests lock again (gets in queue)
+	testGroup.Spec().RequestLock("job-1")
+
+	// Reconcile Phase 4 (job-1 enqueued, job-2 still locked)
+	queue.Add(groupID)
+	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 2*time.Second)
+	if err != nil {
+		t.Fatalf("Timed out waiting for Phase 4 reconcile: %v", err)
+	}
+	if testGroup.Spec().LockingJob() != "job-2" || testGroup.Spec().ActiveJob() != "job-2" {
+		t.Errorf("Phase 4: expected lockingJob=job-2, activeJob=job-2; got lockingJob=%q, activeJob=%q",
+			testGroup.Spec().LockingJob(), testGroup.Spec().ActiveJob())
+	}
+	if !testGroup.Spec().GetWaitingJobQueue().Exists("job-1") {
+		t.Errorf("Phase 4: expected job-1 to be in queue")
+	}
+
+	// 5. job-2 yields the lock -> job-1 should get the lock again
+	err = testGroup.Spec().Yield(ctx, "job-2")
+	if err != nil {
+		t.Fatalf("Yield failed: %v", err)
+	}
+
+	// Reconcile Phase 5 (job-1 should be active/locking again)
+	queue.Add(groupID)
+	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 2*time.Second)
+	if err != nil {
+		t.Fatalf("Timed out waiting for Phase 5 reconcile: %v", err)
+	}
+	if testGroup.Spec().LockingJob() != "job-1" || testGroup.Spec().ActiveJob() != "job-1" {
+		t.Errorf("Phase 5: expected lockingJob=job-1, activeJob=job-1; got lockingJob=%q, activeJob=%q",
+			testGroup.Spec().LockingJob(), testGroup.Spec().ActiveJob())
+	}
+	if testGroup.Spec().GetWaitingJobQueue().Exists("job-1") {
+		t.Errorf("Phase 5: expected job-1 to be dequeued")
+	}
+}
+
+func TestController_Reconcile_OneJobLoopRemainsActive(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
+		workqueue.DefaultTypedControllerRateLimiter[string](),
+		workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+	)
+
+	groupID := "group-1"
+
+	// Mock ObserveGroupState to sync lock/unlock from lockStore to group spec
+	observeCalled := make(chan struct{}, 10)
+	mockOrch := &mockInfrastructureOrchestrator{
+		observeFunc: func(ctx context.Context, gID string) error {
+			lockingJob, err := lockStore.GetLock(ctx, gID)
+			if err != nil {
+				return err
+			}
+			group, err := groupStore.Get(ctx, gID)
+			if err != nil {
+				return err
+			}
+			var syncErr error
+			if lockingJob != group.Spec().LockingJob() {
+				if lockingJob == "" {
+					currentLock := group.Spec().LockingJob()
+					if currentLock != "" {
+						syncErr = group.Spec().Unlock(ctx, currentLock)
+					}
+				} else {
+					syncErr = group.Spec().Lock(ctx, lockingJob)
+				}
+			}
+			observeCalled <- struct{}{}
+			return syncErr
+		},
+	}
+
+	c := controller.NewController(groupStore, jobStore, queue, mockOrch)
+
+	// Start the controller
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+
+	// 1. Create group
+	testGroup, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+
+	// Loop 3 times: Lock -> Yield -> Verify activeJob remains warm
+	for iter := 1; iter <= 3; iter++ {
+		// Step A: Lock job-1
+		err = testGroup.Spec().Lock(ctx, "job-1")
+		if err != nil {
+			t.Fatalf("Iteration %d: failed to lock job-1: %v", iter, err)
+		}
+
+		// Reconcile Lock
+		queue.Add(groupID)
+		select {
+		case <-observeCalled:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Iteration %d: Timed out waiting for Lock reconcile", iter)
+		}
+
+		// Verify Locked State
+		if testGroup.Spec().LockingJob() != "job-1" || testGroup.Spec().ActiveJob() != "job-1" {
+			t.Errorf("Iteration %d (Locked): expected lockingJob=job-1, activeJob=job-1; got lockingJob=%q, activeJob=%q",
+				iter, testGroup.Spec().LockingJob(), testGroup.Spec().ActiveJob())
+		}
+
+		// Step B: Yield job-1 (no waiters, so it just unlocks)
+		err = testGroup.Spec().Yield(ctx, "job-1")
+		if err != nil {
+			t.Fatalf("Iteration %d: Yield failed: %v", iter, err)
+		}
+
+		// Reconcile Yield
+		queue.Add(groupID)
+		select {
+		case <-observeCalled:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("Iteration %d: Timed out waiting for Yield reconcile", iter)
+		}
+
+		// Verify Yielded State: lockingJob is "", but activeJob REMAINS "job-1" (warm!)
+		if testGroup.Spec().LockingJob() != "" {
+			t.Errorf("Iteration %d (Yielded): expected lockingJob to be empty, got %q", iter, testGroup.Spec().LockingJob())
+		}
+		if testGroup.Spec().ActiveJob() != "job-1" {
+			t.Errorf("Iteration %d (Yielded): expected activeJob to remain job-1, got %q", iter, testGroup.Spec().ActiveJob())
+		}
 	}
 }

--- a/pkg/accelerator-orchestrator/controller/controller_test.go
+++ b/pkg/accelerator-orchestrator/controller/controller_test.go
@@ -251,13 +251,14 @@ func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
 
 	// Reconcile Phase 3 (job-2 should be active/locking)
 	queue.Add(groupID)
-	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 3*time.Second)
+	err = waitWithTimeout(func() bool {
+		return testGroup.Spec().LockingJob() == "job-2" && testGroup.Spec().ActiveJob() == "job-2"
+	}, 3*time.Second)
 	if err != nil {
-		t.Fatalf("Timed out waiting for Phase 3 reconcile: %v", err)
-	}
-	if testGroup.Spec().LockingJob() != "job-2" || testGroup.Spec().ActiveJob() != "job-2" {
-		t.Errorf("Phase 3: expected lockingJob=job-2, activeJob=job-2; got lockingJob=%q, activeJob=%q",
-			testGroup.Spec().LockingJob(), testGroup.Spec().ActiveJob())
+		t.Fatalf("Timed out waiting for Phase 3 reconcile "+
+			"(expected lockingJob=job-2, activeJob=job-2): %v. "+
+			"Current state: lockingJob=%q, activeJob=%q",
+			err, testGroup.Spec().LockingJob(), testGroup.Spec().ActiveJob())
 	}
 	if testGroup.Spec().GetWaitingJobQueue().Exists("job-2") {
 		t.Errorf("Phase 3: expected job-2 to be dequeued")
@@ -288,13 +289,14 @@ func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
 
 	// Reconcile Phase 5 (job-1 should be active/locking again)
 	queue.Add(groupID)
-	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 2*time.Second)
+	err = waitWithTimeout(func() bool {
+		return testGroup.Spec().LockingJob() == "job-1" && testGroup.Spec().ActiveJob() == "job-1"
+	}, 3*time.Second)
 	if err != nil {
-		t.Fatalf("Timed out waiting for Phase 5 reconcile: %v", err)
-	}
-	if testGroup.Spec().LockingJob() != "job-1" || testGroup.Spec().ActiveJob() != "job-1" {
-		t.Errorf("Phase 5: expected lockingJob=job-1, activeJob=job-1; got lockingJob=%q, activeJob=%q",
-			testGroup.Spec().LockingJob(), testGroup.Spec().ActiveJob())
+		t.Fatalf("Timed out waiting for Phase 5 reconcile "+
+			"(expected lockingJob=job-1, activeJob=job-1): %v. "+
+			"Current state: lockingJob=%q, activeJob=%q",
+			err, testGroup.Spec().LockingJob(), testGroup.Spec().ActiveJob())
 	}
 	if testGroup.Spec().GetWaitingJobQueue().Exists("job-1") {
 		t.Errorf("Phase 5: expected job-1 to be dequeued")

--- a/pkg/accelerator-orchestrator/controller/controller_test.go
+++ b/pkg/accelerator-orchestrator/controller/controller_test.go
@@ -188,28 +188,10 @@ func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
 
 	groupID := "group-1"
 
-	// Mock ObserveGroupState to sync lock/unlock from lockStore to group spec.
-	// It doesn't need to notify any channel.
+	// Mock ObserveGroupState (no-op, we don't need to sync lock state because
+	// in-memory and lockStore are kept in sync by GroupSpec methods).
 	mockOrch := &mockInfrastructureOrchestrator{
 		observeFunc: func(ctx context.Context, gID string) error {
-			lockingJob, err := lockStore.GetLock(ctx, gID)
-			if err != nil {
-				return err
-			}
-			group, err := groupStore.Get(ctx, gID)
-			if err != nil {
-				return err
-			}
-			if lockingJob != group.Spec().LockingJob() {
-				if lockingJob == "" {
-					currentLock := group.Spec().LockingJob()
-					if currentLock != "" {
-						return group.Spec().Unlock(ctx, currentLock)
-					}
-				} else {
-					return group.Spec().Lock(ctx, lockingJob)
-				}
-			}
 			return nil
 		},
 	}
@@ -223,14 +205,14 @@ func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
 		}
 	}()
 
-	// 1. Create group and lock it to "job-1" initially
+	// 1. Pre-lock the group to "job-1" in lockStore, then create it.
+	// This simulates starting with a locked group.
+	if err := lockStore.Lock(ctx, groupID, "job-1"); err != nil {
+		t.Fatalf("failed to lock in store: %v", err)
+	}
 	testGroup, _, err := groupStore.GetOrCreate(ctx, groupID)
 	if err != nil {
 		t.Fatalf("failed to create group: %v", err)
-	}
-	err = testGroup.Spec().Lock(ctx, "job-1")
-	if err != nil {
-		t.Fatalf("failed to lock job-1: %v", err)
 	}
 
 	// Reconcile Phase 1 (job-1 locked)
@@ -269,7 +251,6 @@ func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
 
 	// Reconcile Phase 3 (job-2 should be active/locking)
 	queue.Add(groupID)
-	// Use 3 seconds here to satisfy unparam linter
 	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 3*time.Second)
 	if err != nil {
 		t.Fatalf("Timed out waiting for Phase 3 reconcile: %v", err)
@@ -334,31 +315,12 @@ func TestController_Reconcile_OneJobLoopRemainsActive(t *testing.T) {
 
 	groupID := "group-1"
 
-	// Mock ObserveGroupState to sync lock/unlock from lockStore to group spec
+	// Mock ObserveGroupState to notify when reconcile runs.
 	observeCalled := make(chan struct{}, 10)
 	mockOrch := &mockInfrastructureOrchestrator{
 		observeFunc: func(ctx context.Context, gID string) error {
-			lockingJob, err := lockStore.GetLock(ctx, gID)
-			if err != nil {
-				return err
-			}
-			group, err := groupStore.Get(ctx, gID)
-			if err != nil {
-				return err
-			}
-			var syncErr error
-			if lockingJob != group.Spec().LockingJob() {
-				if lockingJob == "" {
-					currentLock := group.Spec().LockingJob()
-					if currentLock != "" {
-						syncErr = group.Spec().Unlock(ctx, currentLock)
-					}
-				} else {
-					syncErr = group.Spec().Lock(ctx, lockingJob)
-				}
-			}
 			observeCalled <- struct{}{}
-			return syncErr
+			return nil
 		},
 	}
 
@@ -371,54 +333,48 @@ func TestController_Reconcile_OneJobLoopRemainsActive(t *testing.T) {
 		}
 	}()
 
-	// 1. Create group
+	// 1. Pre-lock the group to "job-1" in lockStore, then create it.
+	if err := lockStore.Lock(ctx, groupID, "job-1"); err != nil {
+		t.Fatalf("failed to lock job-1: %v", err)
+	}
 	testGroup, _, err := groupStore.GetOrCreate(ctx, groupID)
 	if err != nil {
 		t.Fatalf("failed to create group: %v", err)
 	}
 
-	// Loop 3 times: Lock -> Yield -> Verify activeJob remains warm
-	for iter := 1; iter <= 3; iter++ {
-		// Step A: Lock job-1
-		err = testGroup.Spec().Lock(ctx, "job-1")
-		if err != nil {
-			t.Fatalf("Iteration %d: failed to lock job-1: %v", iter, err)
-		}
+	// Reconcile Lock
+	queue.Add(groupID)
+	select {
+	case <-observeCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Timed out waiting for Lock reconcile")
+	}
 
-		// Reconcile Lock
-		queue.Add(groupID)
-		select {
-		case <-observeCalled:
-		case <-time.After(2 * time.Second):
-			t.Fatalf("Iteration %d: Timed out waiting for Lock reconcile", iter)
-		}
+	// Verify Locked State
+	if testGroup.Spec().LockingJob() != "job-1" || testGroup.Spec().ActiveJob() != "job-1" {
+		t.Errorf("Expected lockingJob=job-1, activeJob=job-1; got lockingJob=%q, activeJob=%q",
+			testGroup.Spec().LockingJob(), testGroup.Spec().ActiveJob())
+	}
 
-		// Verify Locked State
-		if testGroup.Spec().LockingJob() != "job-1" || testGroup.Spec().ActiveJob() != "job-1" {
-			t.Errorf("Iteration %d (Locked): expected lockingJob=job-1, activeJob=job-1; got lockingJob=%q, activeJob=%q",
-				iter, testGroup.Spec().LockingJob(), testGroup.Spec().ActiveJob())
-		}
+	// 2. Yield job-1 (no waiters, so it just unlocks)
+	err = testGroup.Spec().Yield(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("Yield failed: %v", err)
+	}
 
-		// Step B: Yield job-1 (no waiters, so it just unlocks)
-		err = testGroup.Spec().Yield(ctx, "job-1")
-		if err != nil {
-			t.Fatalf("Iteration %d: Yield failed: %v", iter, err)
-		}
+	// Reconcile Yield
+	queue.Add(groupID)
+	select {
+	case <-observeCalled:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Timed out waiting for Yield reconcile")
+	}
 
-		// Reconcile Yield
-		queue.Add(groupID)
-		select {
-		case <-observeCalled:
-		case <-time.After(2 * time.Second):
-			t.Fatalf("Iteration %d: Timed out waiting for Yield reconcile", iter)
-		}
-
-		// Verify Yielded State: lockingJob is "", but activeJob REMAINS "job-1" (warm!)
-		if testGroup.Spec().LockingJob() != "" {
-			t.Errorf("Iteration %d (Yielded): expected lockingJob to be empty, got %q", iter, testGroup.Spec().LockingJob())
-		}
-		if testGroup.Spec().ActiveJob() != "job-1" {
-			t.Errorf("Iteration %d (Yielded): expected activeJob to remain job-1, got %q", iter, testGroup.Spec().ActiveJob())
-		}
+	// Verify Yielded State: lockingJob is "", but activeJob REMAINS "job-1" (warm!)
+	if testGroup.Spec().LockingJob() != "" {
+		t.Errorf("Expected lockingJob to be empty, got %q", testGroup.Spec().LockingJob())
+	}
+	if testGroup.Spec().ActiveJob() != "job-1" {
+		t.Errorf("Expected activeJob to remain job-1, got %q", testGroup.Spec().ActiveJob())
 	}
 }

--- a/pkg/accelerator-orchestrator/infrastructure/kubernetes.go
+++ b/pkg/accelerator-orchestrator/infrastructure/kubernetes.go
@@ -172,7 +172,7 @@ func (k *KubernetesOrchestrator) updateGroupNodes(ctx context.Context, groupID s
 	}
 
 	// Clean up clients for nodes that were removed from the group
-	oldNodes := g.Nodes()
+	oldNodes := g.Status().Nodes()
 	removedNodes := findRemovedNodes(oldNodes, groupNodes)
 	for _, nodeName := range removedNodes {
 		if err := k.snapshotAgentStore.CloseClient(nodeName); err != nil {
@@ -180,7 +180,7 @@ func (k *KubernetesOrchestrator) updateGroupNodes(ctx context.Context, groupID s
 		}
 	}
 
-	g.SetNodes(groupNodes)
+	g.Status().SetNodes(groupNodes)
 	slog.InfoContext(ctx, "Updated nodes for group", "nodes", groupNodes)
 	return nil
 }
@@ -266,7 +266,7 @@ func (k *KubernetesOrchestrator) cleanupGroup(ctx context.Context, groupID strin
 	// Close clients for all nodes that were in the group
 	oldGroup, err := k.groupStore.Get(ctx, groupID)
 	if err == nil && oldGroup != nil {
-		for _, nodeName := range oldGroup.Nodes() {
+		for _, nodeName := range oldGroup.Status().Nodes() {
 			if err := k.snapshotAgentStore.CloseClient(nodeName); err != nil {
 				slog.ErrorContext(ctx, "Failed to close snapshot agent client on group deletion", "error", err, "node", nodeName)
 			}

--- a/pkg/accelerator-orchestrator/infrastructure/kubernetes_test.go
+++ b/pkg/accelerator-orchestrator/infrastructure/kubernetes_test.go
@@ -64,7 +64,7 @@ func TestObserveGroupState_Cleanup(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create group: %v", err)
 	}
-	g.SetNodes([]string{"node-1"})
+	g.Status().SetNodes([]string{"node-1"})
 
 	job := store.NewJob("group-a", "job-1")
 	if err := jobStore.Put(ctx, job); err != nil {
@@ -146,8 +146,8 @@ func TestObserveGroupState_UpdateNodes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected group-1 to exist in store: %v", err)
 	}
-	if len(g.Nodes()) != 1 || g.Nodes()[0] != "node-1" {
-		t.Errorf("Expected group-1 to have node-1, got %v", g.Nodes())
+	if len(g.Status().Nodes()) != 1 || g.Status().Nodes()[0] != "node-1" {
+		t.Errorf("Expected group-1 to have node-1, got %v", g.Status().Nodes())
 	}
 }
 

--- a/pkg/accelerator-orchestrator/server/server_test.go
+++ b/pkg/accelerator-orchestrator/server/server_test.go
@@ -272,7 +272,7 @@ func TestServer_GetGroupStatus(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to create group: %v", err)
 				}
-				g.SetState(pb.GroupStatus_STATE_UNKNOWN)
+				g.Status().SetState(pb.GroupStatus_STATE_UNKNOWN)
 				return gs, store.NewJobStore()
 			},
 			groupID:      "group-1",
@@ -306,7 +306,7 @@ func TestServer_GetGroupStatus(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to create group: %v", err)
 				}
-				g.SetState(pb.GroupStatus_STATE_IDLE)
+				g.Status().SetState(pb.GroupStatus_STATE_IDLE)
 				return gs, store.NewJobStore()
 			},
 			groupID:      "group-1",
@@ -328,16 +328,16 @@ func TestServer_GetGroupStatus(t *testing.T) {
 			name: "success with multiple jobs and agent states",
 			setupStores: func(t *testing.T, ctx context.Context) (server.GroupStore, server.JobStore) {
 				t.Helper()
-				gs := store.NewGroupStore(store.NewMemLockStore())
+				lockStore := store.NewMemLockStore()
+				if err := lockStore.Lock(ctx, "group-1", "job-1"); err != nil {
+					t.Fatalf("failed to setup lock in lockStore: %v", err)
+				}
+				gs := store.NewGroupStore(lockStore)
 				g, _, err := gs.GetOrCreate(ctx, "group-1")
 				if err != nil {
 					t.Fatalf("failed to create group: %v", err)
 				}
-				g.SetState(pb.GroupStatus_STATE_LOCKED)
-				g.SetActiveJob("job-1")
-				if err := g.Lock(ctx, "job-1"); err != nil {
-					t.Fatalf("failed to lock group: %v", err)
-				}
+				g.Status().SetState(pb.GroupStatus_STATE_LOCKED)
 
 				js := store.NewJobStore()
 

--- a/pkg/accelerator-orchestrator/store/group.go
+++ b/pkg/accelerator-orchestrator/store/group.go
@@ -81,6 +81,9 @@ func (g *Group) SetNodes(nodes []string) {
 
 // Spec returns the GroupSpec for the group.
 func (g *Group) Spec() *GroupSpec {
+	// No lock is safe here because the pointer is not
+	// modifiable after the Group is created. Fields
+	// on the spec itself are controlled by the internal mutex.
 	return g.spec
 }
 
@@ -102,13 +105,7 @@ func (g *Group) SetState(state pb.GroupStatus_State) {
 
 // Delete deletes the group by releasing its lock if it is currently held.
 func (g *Group) Delete(ctx context.Context) error {
-	spec := g.Spec()
-	lj := spec.LockingJob()
-	if lj == "" {
-		return nil
-	}
-
-	return spec.Unlock(ctx, lj)
+	return g.spec.Delete(ctx)
 }
 
 // Methods on GroupSpec
@@ -134,18 +131,14 @@ func (s *GroupSpec) GetWaitingJobQueue() *WaitingJobQueue {
 	return s.queue
 }
 
-// Lock acquires the lock for the given job ID.
-func (s *GroupSpec) Lock(ctx context.Context, jobID string) error {
+// Delete cleans up the spec information.
+func (s *GroupSpec) Delete(ctx context.Context) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	return s.lock(ctx, jobID)
-}
-
-// Unlock releases the lock for the given job ID.
-func (s *GroupSpec) Unlock(ctx context.Context, jobID string) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.unlock(ctx, jobID)
+	if s.lockingJob == "" {
+		return nil
+	}
+	return s.unlock(ctx, s.lockingJob)
 }
 
 // lock assumes s.mu is held.

--- a/pkg/accelerator-orchestrator/store/group.go
+++ b/pkg/accelerator-orchestrator/store/group.go
@@ -75,7 +75,7 @@ type Group struct {
 
 // NewGroup creates a new Group and initializes its locking state from the lockStore if available.
 func NewGroup(ctx context.Context, id string, lockStore GroupLockStore) (*Group, error) {
-	g := &Group{
+	group := &Group{
 		id: id,
 		spec: &GroupSpec{
 			lockStore: lockStore,
@@ -92,11 +92,11 @@ func NewGroup(ctx context.Context, id string, lockStore GroupLockStore) (*Group,
 		if err != nil {
 			return nil, fmt.Errorf("failed to get lock status for group %s: %w", id, err)
 		}
-		g.spec.lockingJob = lockingJob
-		g.spec.activeJob = lockingJob
+		group.spec.lockingJob = lockingJob
+		group.spec.activeJob = lockingJob
 	}
 
-	return g, nil
+	return group, nil
 }
 
 func (g *Group) ID() string {
@@ -105,6 +105,9 @@ func (g *Group) ID() string {
 
 // Spec returns the GroupSpec for the group.
 func (g *Group) Spec() *GroupSpec {
+	// No lock is safe here because the pointer is not
+	// modifiable after the Group is created. Fields
+	// on the spec itself are controlled by the internal mutex.
 	return g.spec
 }
 
@@ -190,12 +193,12 @@ type GroupSnapshot struct {
 
 // Snapshot returns a consistent, point-in-time snapshot of the group's state.
 func (g *Group) Snapshot() *GroupSnapshot {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
+	g.status.mu.RLock()
+	defer g.status.mu.RUnlock()
 
 	// Deep copy nodes slice
-	nodes := make([]string, len(g.nodes))
-	copy(nodes, g.nodes)
+	nodes := make([]string, len(g.status.nodes))
+	copy(nodes, g.status.nodes)
 
 	g.spec.mu.RLock()
 	defer g.spec.mu.RUnlock()
@@ -203,36 +206,47 @@ func (g *Group) Snapshot() *GroupSnapshot {
 	return &GroupSnapshot{
 		ID:               g.id,
 		Nodes:            nodes,
-		State:            g.state,
-		StateTimestamp:   g.stateTimestamp,
+		State:            g.status.state,
+		StateTimestamp:   g.status.stateTimestamp,
 		LockingJob:       g.spec.lockingJob,
 		ActiveJob:        g.spec.activeJob,
 		WaiterQueueDepth: g.spec.queue.Len(),
 	}
 }
 
-// Yield releases the lock for the current job and grants it to the next job in the queue.
-// If the unlock is successful, it peeks at the next job, attempts to lock it,
-// and only dequeues it if the lock operation succeeds.
-func (s *GroupSpec) Yield(ctx context.Context, jobID string) error {
+// TryPromote attempts to promote the next waiting job in the queue to be the locking job
+// if the group is currently unlocked.
+func (s *GroupSpec) TryPromote(ctx context.Context) (bool, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	if err := s.unlock(ctx, jobID); err != nil {
-		return err
+	if s.lockingJob != "" {
+		return false, nil
 	}
 
 	nextJobID, ok := s.queue.Peek()
 	if !ok {
-		return nil
+		return false, nil
 	}
 
 	if err := s.lock(ctx, nextJobID); err != nil {
-		return fmt.Errorf("yield succeeded in unlocking but failed to lock next job %s: %w", nextJobID, err)
+		return false, fmt.Errorf("failed to lock promoted job %s: %w", nextJobID, err)
 	}
 
 	s.queue.Dequeue()
-	return nil
+	return true, nil
+}
+
+// Yield releases the lock for the current job.
+func (s *GroupSpec) Yield(ctx context.Context, jobID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.unlock(ctx, jobID)
+
+	// Note that promoting the next job to take the lock is
+	// done in the reconiliation loop to not block a RL job trying
+	// to yield their job if there is a temporary issue locking for next job.
 }
 
 // RequestLock requests a lock for the given job.

--- a/pkg/accelerator-orchestrator/store/group.go
+++ b/pkg/accelerator-orchestrator/store/group.go
@@ -9,41 +9,55 @@ import (
 	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/api/v1alpha1"
 )
 
+// GroupLockStore defines the interface for persisting lock state for a specific group.
+type GroupLockStore interface {
+	GetLock(ctx context.Context) (string, error)
+	Lock(ctx context.Context, jobID string) error
+	Unlock(ctx context.Context, jobID string) error
+}
+
+// GroupSpec defines the specification of a time-slice group.
+type GroupSpec struct {
+	mu        sync.RWMutex
+	lockStore GroupLockStore
+	// lockingJob is job we want to hold the lock.
+	lockingJob string
+	queue      *WaitingJobQueue
+	// activeJob is job for which we want context loaded on nodes.
+	// This can be non-empty when lockingJob is empty as an optimization
+	// when there is no one waiting to be the locking job.
+	activeJob string
+}
+
 // Group represents the in-memory and persistent state of a time-slice group.
 type Group struct {
-	mu    sync.RWMutex
-	id    string
-	nodes []string
-	// lockingJob is the job_id holding the lock, empty if none.
-	// Acts like the cached value for value stored in lockStore.
-	lockingJob string
-	// activeJob is the job_id whose context is active, empty if none.
-	// The primary situation where the active job is not locking is the
-	// STATE_IDLE_YIELDED state where the job has yielded, but snapshotting
-	// is delayed because no other job has requested to lock the group.
-	activeJob      string
+	mu             sync.RWMutex
+	id             string
+	nodes          []string
+	spec           *GroupSpec
 	state          pb.GroupStatus_State
 	stateTimestamp time.Time
-	queue          *WaitingJobQueue
-	lockStore      LockStore
 }
 
 // NewGroup creates a new Group and initializes its locking state from the lockStore if available.
-func NewGroup(ctx context.Context, id string, lockStore LockStore) (*Group, error) {
+func NewGroup(ctx context.Context, id string, lockStore GroupLockStore) (*Group, error) {
 	g := &Group{
-		id:             id,
+		id: id,
+		spec: &GroupSpec{
+			lockStore: lockStore,
+			queue:     NewWaitingJobQueue(),
+		},
 		state:          pb.GroupStatus_STATE_UNSPECIFIED,
 		stateTimestamp: time.Now(),
-		queue:          NewWaitingJobQueue(),
-		lockStore:      lockStore,
 	}
 
 	if lockStore != nil {
-		lockingJob, err := lockStore.GetLock(ctx, id)
+		lockingJob, err := lockStore.GetLock(ctx)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get lock status for group %s: %w", id, err)
 		}
-		g.lockingJob = lockingJob
+		g.spec.lockingJob = lockingJob
+		g.spec.activeJob = lockingJob
 	}
 
 	return g, nil
@@ -65,22 +79,9 @@ func (g *Group) SetNodes(nodes []string) {
 	g.nodes = append([]string(nil), nodes...)
 }
 
-func (g *Group) LockingJob() string {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	return g.lockingJob
-}
-
-func (g *Group) ActiveJob() string {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	return g.activeJob
-}
-
-func (g *Group) SetActiveJob(jobID string) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	g.activeJob = jobID
+// Spec returns the GroupSpec for the group.
+func (g *Group) Spec() *GroupSpec {
+	return g.spec
 }
 
 func (g *Group) State() (pb.GroupStatus_State, time.Time) {
@@ -99,46 +100,77 @@ func (g *Group) SetState(state pb.GroupStatus_State) {
 	g.stateTimestamp = time.Now()
 }
 
-// GetWaitingJobQueue returns a reference to the waiter queue for the group.
-func (g *Group) GetWaitingJobQueue() *WaitingJobQueue {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	return g.queue
-}
-
+// Delete deletes the group by releasing its lock if it is currently held.
 func (g *Group) Delete(ctx context.Context) error {
-	lj := g.LockingJob()
+	spec := g.Spec()
+	lj := spec.LockingJob()
 	if lj == "" {
 		return nil
 	}
 
-	return g.Unlock(ctx, lj)
+	return spec.Unlock(ctx, lj)
 }
 
-func (g *Group) Lock(ctx context.Context, jobID string) error {
-	g.mu.Lock()
-	defer g.mu.Unlock()
+// Methods on GroupSpec
 
-	if g.lockStore != nil {
-		if err := g.lockStore.Lock(ctx, g.id, jobID); err != nil {
+// ActiveJob returns the job ID for which the context should be loaded on nodes.
+func (s *GroupSpec) ActiveJob() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.activeJob
+}
+
+// LockingJob returns the job ID that currently holds the lock, or empty if none.
+func (s *GroupSpec) LockingJob() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.lockingJob
+}
+
+// GetWaitingJobQueue returns the queue of jobs waiting for the lock.
+func (s *GroupSpec) GetWaitingJobQueue() *WaitingJobQueue {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.queue
+}
+
+// Lock acquires the lock for the given job ID.
+func (s *GroupSpec) Lock(ctx context.Context, jobID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lock(ctx, jobID)
+}
+
+// Unlock releases the lock for the given job ID.
+func (s *GroupSpec) Unlock(ctx context.Context, jobID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.unlock(ctx, jobID)
+}
+
+// lock assumes s.mu is held.
+func (s *GroupSpec) lock(ctx context.Context, jobID string) error {
+	if s.lockStore != nil {
+		if err := s.lockStore.Lock(ctx, jobID); err != nil {
 			return err
 		}
 	}
-	g.lockingJob = jobID
+	s.lockingJob = jobID
+	s.activeJob = jobID
 	return nil
 }
 
-// Unlock persistently releases the lock for the group.
-func (g *Group) Unlock(ctx context.Context, jobID string) error {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-
-	if g.lockStore != nil {
-		if err := g.lockStore.Unlock(ctx, g.id, jobID); err != nil {
+// unlock assumes s.mu is held.
+func (s *GroupSpec) unlock(ctx context.Context, jobID string) error {
+	if s.lockStore != nil {
+		if err := s.lockStore.Unlock(ctx, jobID); err != nil {
 			return err
 		}
 	}
-	g.lockingJob = ""
+	s.lockingJob = ""
+	// Notice we do not clear the active job. This is because
+	// we actually want to leave the context on the machines until
+	// there is a new job that wants to lock the group.
 	return nil
 }
 
@@ -162,13 +194,62 @@ func (g *Group) Snapshot() *GroupSnapshot {
 	nodes := make([]string, len(g.nodes))
 	copy(nodes, g.nodes)
 
+	g.spec.mu.RLock()
+	defer g.spec.mu.RUnlock()
+
 	return &GroupSnapshot{
 		ID:               g.id,
 		Nodes:            nodes,
 		State:            g.state,
 		StateTimestamp:   g.stateTimestamp,
-		LockingJob:       g.lockingJob,
-		ActiveJob:        g.activeJob,
-		WaiterQueueDepth: g.queue.Len(),
+		LockingJob:       g.spec.lockingJob,
+		ActiveJob:        g.spec.activeJob,
+		WaiterQueueDepth: g.spec.queue.Len(),
 	}
+}
+
+// Yield releases the lock for the current job and grants it to the next job in the queue.
+// If the unlock is successful, it peeks at the next job, attempts to lock it,
+// and only dequeues it if the lock operation succeeds.
+func (s *GroupSpec) Yield(ctx context.Context, jobID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if err := s.unlock(ctx, jobID); err != nil {
+		return err
+	}
+
+	nextJobID, ok := s.queue.Peek()
+	if !ok {
+		return nil
+	}
+
+	if err := s.lock(ctx, nextJobID); err != nil {
+		return fmt.Errorf("yield succeeded in unlocking but failed to lock next job %s: %w", nextJobID, err)
+	}
+
+	s.queue.Dequeue()
+	return nil
+}
+
+// RequestLock requests a lock for the given job.
+// If the job already holds the lock, it returns immediately.
+// Otherwise, it enqueues the job in the waiting queue.
+func (s *GroupSpec) RequestLock(jobID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.lockingJob == jobID {
+		return
+	}
+
+	s.queue.Enqueue(jobID)
+}
+
+// SetActiveJob sets the active job.
+// Primarily used for testing.
+func (s *GroupSpec) SetActiveJob(jobID string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.activeJob = jobID
 }

--- a/pkg/accelerator-orchestrator/store/group.go
+++ b/pkg/accelerator-orchestrator/store/group.go
@@ -16,7 +16,7 @@ type GroupLockStore interface {
 	Unlock(ctx context.Context, jobID string) error
 }
 
-// GroupSpec defines the specification of a time-slice group.
+// GroupSpec defines the specification of desired end state of a time-slice group.
 type GroupSpec struct {
 	mu        sync.RWMutex
 	lockStore GroupLockStore
@@ -29,14 +29,48 @@ type GroupSpec struct {
 	activeJob string
 }
 
-// Group represents the in-memory and persistent state of a time-slice group.
-type Group struct {
+// GroupStatus represents the current status of a time-slice group.
+// Updated by the controller reconcile loop.
+type GroupStatus struct {
 	mu             sync.RWMutex
-	id             string
 	nodes          []string
-	spec           *GroupSpec
 	state          pb.GroupStatus_State
 	stateTimestamp time.Time
+}
+
+func (s *GroupStatus) Nodes() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return append([]string(nil), s.nodes...)
+}
+
+func (s *GroupStatus) SetNodes(nodes []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.nodes = append([]string(nil), nodes...)
+}
+
+func (s *GroupStatus) State() (pb.GroupStatus_State, time.Time) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.state, s.stateTimestamp
+}
+
+func (s *GroupStatus) SetState(state pb.GroupStatus_State) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.state == state {
+		return
+	}
+	s.state = state
+	s.stateTimestamp = time.Now()
+}
+
+// Group represents the in-memory and persistent state of a time-slice group.
+type Group struct {
+	id     string
+	spec   *GroupSpec
+	status *GroupStatus
 }
 
 // NewGroup creates a new Group and initializes its locking state from the lockStore if available.
@@ -47,8 +81,10 @@ func NewGroup(ctx context.Context, id string, lockStore GroupLockStore) (*Group,
 			lockStore: lockStore,
 			queue:     NewWaitingJobQueue(),
 		},
-		state:          pb.GroupStatus_STATE_UNSPECIFIED,
-		stateTimestamp: time.Now(),
+		status: &GroupStatus{
+			state:          pb.GroupStatus_STATE_UNSPECIFIED,
+			stateTimestamp: time.Now(),
+		},
 	}
 
 	if lockStore != nil {
@@ -67,40 +103,14 @@ func (g *Group) ID() string {
 	return g.id
 }
 
-func (g *Group) Nodes() []string {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	return append([]string(nil), g.nodes...)
-}
-
-func (g *Group) SetNodes(nodes []string) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	g.nodes = append([]string(nil), nodes...)
-}
-
 // Spec returns the GroupSpec for the group.
 func (g *Group) Spec() *GroupSpec {
-	// No lock is safe here because the pointer is not
-	// modifiable after the Group is created. Fields
-	// on the spec itself are controlled by the internal mutex.
 	return g.spec
 }
 
-func (g *Group) State() (pb.GroupStatus_State, time.Time) {
-	g.mu.RLock()
-	defer g.mu.RUnlock()
-	return g.state, g.stateTimestamp
-}
-
-func (g *Group) SetState(state pb.GroupStatus_State) {
-	g.mu.Lock()
-	defer g.mu.Unlock()
-	if g.state == state {
-		return
-	}
-	g.state = state
-	g.stateTimestamp = time.Now()
+// Status returns the GroupStatus.
+func (g *Group) Status() *GroupStatus {
+	return g.status
 }
 
 // Delete deletes the group by releasing its lock if it is currently held.

--- a/pkg/accelerator-orchestrator/store/group_store.go
+++ b/pkg/accelerator-orchestrator/store/group_store.go
@@ -71,7 +71,11 @@ func (s *GroupStore) GetOrCreate(ctx context.Context, id string) (*Group, bool, 
 	}
 
 	var err error
-	g, err = NewGroup(ctx, id, s.lockStore)
+	var wrapper GroupLockStore
+	if s.lockStore != nil {
+		wrapper = NewGroupLockStoreWrapper(s.lockStore, id)
+	}
+	g, err = NewGroup(ctx, id, wrapper)
 	if err != nil {
 		return nil, false, err
 	}
@@ -104,4 +108,29 @@ func (s *GroupStore) Delete(ctx context.Context, id string) error {
 		delete(s.groups, id)
 	}
 	return nil
+}
+
+type groupLockStoreWrapper struct {
+	lockStore LockStore
+	groupID   string
+}
+
+// NewGroupLockStoreWrapper creates a new GroupLockStore by wrapping a LockStore and a groupID.
+func NewGroupLockStoreWrapper(lockStore LockStore, groupID string) GroupLockStore {
+	return &groupLockStoreWrapper{
+		lockStore: lockStore,
+		groupID:   groupID,
+	}
+}
+
+func (w *groupLockStoreWrapper) GetLock(ctx context.Context) (string, error) {
+	return w.lockStore.GetLock(ctx, w.groupID)
+}
+
+func (w *groupLockStoreWrapper) Lock(ctx context.Context, jobID string) error {
+	return w.lockStore.Lock(ctx, w.groupID, jobID)
+}
+
+func (w *groupLockStoreWrapper) Unlock(ctx context.Context, jobID string) error {
+	return w.lockStore.Unlock(ctx, w.groupID, jobID)
 }

--- a/pkg/accelerator-orchestrator/store/group_store_test.go
+++ b/pkg/accelerator-orchestrator/store/group_store_test.go
@@ -295,14 +295,14 @@ func addGroupToStore(t *testing.T, ctx context.Context, s *store.GroupStore, g *
 }
 
 func TestGroup_Status(t *testing.T) {
-	g, err := store.NewGroup(context.Background(), "group-1", nil)
+	group, err := store.NewGroup(context.Background(), "group-1", nil)
 	if err != nil {
 		t.Fatalf("failed to create group: %v", err)
 	}
-	g.Status().SetNodes([]string{"node-a", "node-b"})
-	g.Status().SetState(pb.GroupStatus_STATE_LOCKED)
+	group.Status().SetNodes([]string{"node-a", "node-b"})
+	group.Status().SetState(pb.GroupStatus_STATE_LOCKED)
 
-	status := g.Status()
+	status := group.Status()
 
 	nodes := status.Nodes()
 	if len(nodes) != 2 || nodes[0] != "node-a" || nodes[1] != "node-b" {
@@ -318,8 +318,7 @@ func TestGroup_Status(t *testing.T) {
 
 	// Verify mutating returned slice doesn't affect group
 	nodes[0] = "mutated"
-	if g.Status().Nodes()[0] != "node-a" {
-		t.Errorf("Mutating returned status nodes affected group: %v", g.Status().Nodes())
+	if group.Status().Nodes()[0] != "node-a" {
+		t.Errorf("Mutating returned status nodes affected group: %v", group.Status().Nodes())
 	}
 }
-

--- a/pkg/accelerator-orchestrator/store/group_store_test.go
+++ b/pkg/accelerator-orchestrator/store/group_store_test.go
@@ -192,8 +192,11 @@ func TestGroupStateEnum(t *testing.T) {
 	}
 
 	// Verify default value is GroupStatus_STATE_UNSPECIFIED (0)
-	var g store.Group
-	if state, _ := g.State(); state != pb.GroupStatus_STATE_UNSPECIFIED {
+	g, err := store.NewGroup(context.Background(), "group-test", nil)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	if state, _ := g.Status().State(); state != pb.GroupStatus_STATE_UNSPECIFIED {
 		t.Errorf("default Group.State = %v, want GroupStatus_STATE_UNSPECIFIED", state)
 	}
 }
@@ -204,7 +207,7 @@ func newTestGroup(id string, nodes []string) *store.Group {
 		panic(fmt.Errorf("failed to create new test group: %w", err))
 	}
 	if nodes != nil {
-		g.SetNodes(nodes)
+		g.Status().SetNodes(nodes)
 	}
 	return g
 }
@@ -285,8 +288,38 @@ func addGroupToStore(t *testing.T, ctx context.Context, s *store.GroupStore, g *
 	if !created {
 		t.Fatalf("failed to add initial group: group %q already exists", g.ID())
 	}
-	nodes := g.Nodes()
+	nodes := g.Status().Nodes()
 	if len(nodes) > 0 {
-		got.SetNodes(nodes)
+		got.Status().SetNodes(nodes)
 	}
 }
+
+func TestGroup_Status(t *testing.T) {
+	g, err := store.NewGroup(context.Background(), "group-1", nil)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	g.Status().SetNodes([]string{"node-a", "node-b"})
+	g.Status().SetState(pb.GroupStatus_STATE_LOCKED)
+
+	status := g.Status()
+
+	nodes := status.Nodes()
+	if len(nodes) != 2 || nodes[0] != "node-a" || nodes[1] != "node-b" {
+		t.Errorf("Status().Nodes() = %v, want [node-a node-b]", nodes)
+	}
+	state, stateTimestamp := status.State()
+	if state != pb.GroupStatus_STATE_LOCKED {
+		t.Errorf("Status().State() = %v, want STATE_LOCKED", state)
+	}
+	if stateTimestamp.IsZero() {
+		t.Errorf("Status().StateTimestamp is zero, want non-zero")
+	}
+
+	// Verify mutating returned slice doesn't affect group
+	nodes[0] = "mutated"
+	if g.Status().Nodes()[0] != "node-a" {
+		t.Errorf("Mutating returned status nodes affected group: %v", g.Status().Nodes())
+	}
+}
+

--- a/pkg/accelerator-orchestrator/store/group_test.go
+++ b/pkg/accelerator-orchestrator/store/group_test.go
@@ -40,7 +40,9 @@ func TestGroup_GettersAndSetters(t *testing.T) {
 			var wrappedLockStore store.GroupLockStore
 			if tc.lockingJob != "" {
 				lockStore := store.NewMemLockStore()
-				lockStore.Lock(context.Background(), tc.groupID, tc.lockingJob)
+				if err := lockStore.Lock(context.Background(), tc.groupID, tc.lockingJob); err != nil {
+					t.Fatalf("failed to lock: %v", err)
+				}
 				wrappedLockStore = store.NewGroupLockStoreWrapper(lockStore, tc.groupID)
 			}
 			group, err := store.NewGroup(context.Background(), tc.groupID, wrappedLockStore)
@@ -158,10 +160,12 @@ func TestNewGroup_InitializeLock(t *testing.T) {
 
 func TestGroupSpec_RequestLock(t *testing.T) {
 	ctx := context.Background()
-	
+
 	// Start with job-1 holding the lock
 	lockStore := store.NewMemLockStore()
-	lockStore.Lock(ctx, "group-1", "job-1")
+	if err := lockStore.Lock(ctx, "group-1", "job-1"); err != nil {
+		t.Fatalf("failed to lock: %v", err)
+	}
 	wrapped := store.NewGroupLockStoreWrapper(lockStore, "group-1")
 	group, err := store.NewGroup(ctx, "group-1", wrapped)
 	if err != nil {
@@ -193,85 +197,126 @@ func TestGroupSpec_RequestLock(t *testing.T) {
 }
 
 func TestGroupSpec_Yield(t *testing.T) {
-	ctx := context.Background()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	groupID := "group-1"
-	
-	// Pre-lock job-1
-	if err := lockStore.Lock(ctx, groupID, "job-1"); err != nil {
-		t.Fatalf("failed to lock: %v", err)
-	}
-	
-	group, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to get or create group: %v", err)
-	}
-	spec := group.Spec()
-	queue := spec.GetWaitingJobQueue()
-
-	// Now job-1 is locked.
-	// 1. Enqueue job-2
-	spec.RequestLock("job-2")
-	// 2. Enqueue job-3
-	spec.RequestLock("job-3")
-
-	// Verify queue
-	queueList := queue.List()
-	if len(queueList) != 2 {
-		t.Fatalf("expected queue len 2, got %d", len(queueList))
-	}
-	if queueList[0].JobID != "job-2" || queueList[1].JobID != "job-3" {
-		t.Errorf("unexpected queue content: %+v", queueList)
+	tests := []struct {
+		name        string
+		initialLock string
+		yieldJob    string
+		wantErr     error
+		wantLock    string
+	}{
+		{
+			name:        "yield by holder succeeds and unlocks",
+			initialLock: "job-1",
+			yieldJob:    "job-1",
+			wantErr:     nil,
+			wantLock:    "",
+		},
+		{
+			name:        "yield by non-holder fails",
+			initialLock: "job-1",
+			yieldJob:    "job-2",
+			wantErr:     store.ErrNotLockHolder,
+			wantLock:    "job-1",
+		},
 	}
 
-	// 3. Yield by non-holder (job-2) should fail
-	err = spec.Yield(ctx, "job-2")
-	if !errors.Is(err, store.ErrNotLockHolder) {
-		t.Fatalf("expected ErrNotLockHolder, got %v", err)
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			lockStore := store.NewMemLockStore()
+			if tc.initialLock != "" {
+				if err := lockStore.Lock(ctx, "group-1", tc.initialLock); err != nil {
+					t.Fatalf("failed to lock: %v", err)
+				}
+			}
+			wrapped := store.NewGroupLockStoreWrapper(lockStore, "group-1")
+			group, err := store.NewGroup(ctx, "group-1", wrapped)
+			if err != nil {
+				t.Fatalf("failed to create group: %v", err)
+			}
+			spec := group.Spec()
+
+			err = spec.Yield(ctx, tc.yieldJob)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("Yield() error = %v, want %v", err, tc.wantErr)
+			}
+			if spec.LockingJob() != tc.wantLock {
+				t.Errorf("LockingJob() = %q, want %q", spec.LockingJob(), tc.wantLock)
+			}
+		})
 	}
-	if spec.LockingJob() != "job-1" {
-		t.Errorf("expected group to remain locked by job-1, got %q", spec.LockingJob())
+}
+
+func TestGroupSpec_TryPromote(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialLock  string
+		initialQueue []string
+		wantPromoted bool
+		wantLock     string
+		wantQueueLen int
+		wantErr      error
+	}{
+		{
+			name:         "promote when unlocked and queue has waiters",
+			initialLock:  "",
+			initialQueue: []string{"job-1"},
+			wantPromoted: true,
+			wantLock:     "job-1",
+			wantQueueLen: 0,
+		},
+		{
+			name:         "do not promote when already locked",
+			initialLock:  "job-holder",
+			initialQueue: []string{"job-waiter"},
+			wantPromoted: false,
+			wantLock:     "job-holder",
+			wantQueueLen: 1,
+		},
+		{
+			name:         "do not promote when queue is empty",
+			initialLock:  "",
+			initialQueue: nil,
+			wantPromoted: false,
+			wantLock:     "",
+			wantQueueLen: 0,
+		},
 	}
 
-	// 4. Yield by holder (job-1) should succeed and grant to job-2
-	err = spec.Yield(ctx, "job-1")
-	if err != nil {
-		t.Fatalf("yield failed: %v", err)
-	}
-	if spec.LockingJob() != "job-2" {
-		t.Errorf("expected lockingJob to be job-2, got %q", spec.LockingJob())
-	}
-	
-	// Verify queue (should only have job-3)
-	queueList = queue.List()
-	if len(queueList) != 1 {
-		t.Fatalf("expected queue len 1, got %d", len(queueList))
-	}
-	if queueList[0].JobID != "job-3" {
-		t.Errorf("unexpected queue content: %+v", queueList)
-	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			lockStore := store.NewMemLockStore()
+			if tc.initialLock != "" {
+				if err := lockStore.Lock(ctx, "group-1", tc.initialLock); err != nil {
+					t.Fatalf("failed to lock: %v", err)
+				}
+			}
+			wrapped := store.NewGroupLockStoreWrapper(lockStore, "group-1")
+			group, err := store.NewGroup(ctx, "group-1", wrapped)
+			if err != nil {
+				t.Fatalf("failed to create group: %v", err)
+			}
+			spec := group.Spec()
 
-	// 5. Yield by holder (job-2) should succeed and grant to job-3
-	err = spec.Yield(ctx, "job-2")
-	if err != nil {
-		t.Fatalf("yield failed: %v", err)
-	}
-	if spec.LockingJob() != "job-3" {
-		t.Errorf("expected lockingJob to be job-3, got %q", spec.LockingJob())
-	}
-	if queue.Len() != 0 {
-		t.Errorf("expected queue to be empty, got %d", queue.Len())
-	}
+			for _, qJob := range tc.initialQueue {
+				spec.RequestLock(qJob)
+			}
 
-	// 6. Yield by holder (job-3) should succeed and group becomes unlocked
-	err = spec.Yield(ctx, "job-3")
-	if err != nil {
-		t.Fatalf("yield failed: %v", err)
-	}
-	if spec.LockingJob() != "" {
-		t.Errorf("expected lockingJob to be empty, got %q", spec.LockingJob())
+			promoted, err := spec.TryPromote(ctx)
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("TryPromote() error = %v, want %v", err, tc.wantErr)
+			}
+			if promoted != tc.wantPromoted {
+				t.Errorf("TryPromote() promoted = %v, want %v", promoted, tc.wantPromoted)
+			}
+			if spec.LockingJob() != tc.wantLock {
+				t.Errorf("LockingJob() = %q, want %q", spec.LockingJob(), tc.wantLock)
+			}
+			if spec.GetWaitingJobQueue().Len() != tc.wantQueueLen {
+				t.Errorf("Queue Len = %d, want %d", spec.GetWaitingJobQueue().Len(), tc.wantQueueLen)
+			}
+		})
 	}
 }
 
@@ -287,8 +332,8 @@ func TestGroup_Snapshot(t *testing.T) {
 		t.Fatalf("failed to create group: %v", err)
 	}
 
-	group.SetNodes([]string{"node-a", "node-b"})
-	group.SetState(pb.GroupStatus_STATE_IDLE)
+	group.Status().SetNodes([]string{"node-a", "node-b"})
+	group.Status().SetState(pb.GroupStatus_STATE_IDLE)
 	group.Spec().SetActiveJob("job-active")
 	group.Spec().GetWaitingJobQueue().Enqueue("job-wait-1")
 	group.Spec().GetWaitingJobQueue().Enqueue("job-wait-2")
@@ -317,13 +362,13 @@ func TestGroup_Snapshot(t *testing.T) {
 	}
 
 	// Modify original group
-	group.SetNodes([]string{"node-c"})
-	group.SetState(pb.GroupStatus_STATE_LOCKED)
+	group.Status().SetNodes([]string{"node-c"})
+	group.Status().SetState(pb.GroupStatus_STATE_LOCKED)
 
-	if reflect.DeepEqual(snap.Nodes, group.Nodes()) {
+	if reflect.DeepEqual(snap.Nodes, group.Status().Nodes()) {
 		t.Errorf("Snap Nodes changed after original changed (deep copy failed)")
 	}
-	state, _ := group.State()
+	state, _ := group.Status().State()
 	if snap.State == state {
 		t.Errorf("Snap State changed after original changed")
 	}

--- a/pkg/accelerator-orchestrator/store/group_test.go
+++ b/pkg/accelerator-orchestrator/store/group_test.go
@@ -47,21 +47,21 @@ func TestGroup_GettersAndSetters(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewGroup failed: %v", err)
 			}
-			group.SetNodes(tc.nodes)
+			group.Status().SetNodes(tc.nodes)
 
 			if group.ID() != tc.groupID {
 				t.Errorf("ID() = %q, want %q", group.ID(), tc.groupID)
 			}
 
-			if !reflect.DeepEqual(group.Nodes(), tc.nodes) {
-				t.Errorf("Nodes() = %+v, want %+v", group.Nodes(), tc.nodes)
+			if !reflect.DeepEqual(group.Status().Nodes(), tc.nodes) {
+				t.Errorf("Nodes() = %+v, want %+v", group.Status().Nodes(), tc.nodes)
 			}
 
 			// Verify deep copy/mutation protection for Nodes
 			if len(tc.nodes) > 0 {
-				mutatedNodes := group.Nodes()
+				mutatedNodes := group.Status().Nodes()
 				mutatedNodes[0] = "mutated"
-				if reflect.DeepEqual(group.Nodes(), mutatedNodes) {
+				if reflect.DeepEqual(group.Status().Nodes(), mutatedNodes) {
 					t.Errorf("mutating returned Nodes slice modified the internal state")
 				}
 			}
@@ -74,10 +74,10 @@ func TestGroup_GettersAndSetters(t *testing.T) {
 				t.Errorf("ActiveJob() = %q, want %q", group.Spec().ActiveJob(), tc.lockingJob)
 			}
 
-			_, initialTimestamp := group.State()
+			_, initialTimestamp := group.Status().State()
 			beforeSet := time.Now()
-			group.SetState(tc.state)
-			gotState, gotTimestamp := group.State()
+			group.Status().SetState(tc.state)
+			gotState, gotTimestamp := group.Status().State()
 
 			if gotState != tc.state {
 				t.Errorf("State() state = %v, want %v", gotState, tc.state)

--- a/pkg/accelerator-orchestrator/store/group_test.go
+++ b/pkg/accelerator-orchestrator/store/group_test.go
@@ -37,7 +37,13 @@ func TestGroup_GettersAndSetters(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			group, err := store.NewGroup(context.Background(), tc.groupID, nil)
+			var wrappedLockStore store.GroupLockStore
+			if tc.lockingJob != "" {
+				lockStore := store.NewMemLockStore()
+				lockStore.Lock(context.Background(), tc.groupID, tc.lockingJob)
+				wrappedLockStore = store.NewGroupLockStoreWrapper(lockStore, tc.groupID)
+			}
+			group, err := store.NewGroup(context.Background(), tc.groupID, wrappedLockStore)
 			if err != nil {
 				t.Fatalf("NewGroup failed: %v", err)
 			}
@@ -60,11 +66,6 @@ func TestGroup_GettersAndSetters(t *testing.T) {
 				}
 			}
 
-			if tc.lockingJob != "" {
-				if err := group.Spec().Lock(context.Background(), tc.lockingJob); err != nil {
-					t.Fatalf("failed to lock: %v", err)
-				}
-			}
 			if group.Spec().LockingJob() != tc.lockingJob {
 				t.Errorf("LockingJob() = %q, want %q", group.Spec().LockingJob(), tc.lockingJob)
 			}
@@ -94,73 +95,39 @@ func TestGroup_GettersAndSetters(t *testing.T) {
 	}
 }
 
-func TestGroup_LockAndUnlock(t *testing.T) {
+func TestGroup_Delete(t *testing.T) {
 	ctx := context.Background()
 
-	type step struct {
-		op          string // "lock" or "unlock"
-		jobID       string
-		expectedErr error
-		wantLocked  string
-	}
+	t.Run("delete with MemLockStore", func(t *testing.T) {
+		lockStore := store.NewMemLockStore()
+		groupStore := store.NewGroupStore(lockStore)
+		groupID := "group-1"
+		jobID := "job-a"
 
-	tests := []struct {
-		name      string
-		lockStore store.LockStore
-		steps     []step
-	}{
-		{
-			name:      "lock/unlock sequence without lockStore",
-			lockStore: nil,
-			steps: []step{
-				{op: "lock", jobID: "job-a", expectedErr: nil, wantLocked: "job-a"},
-				// Without lockStore, memory locks are overwritten directly in Lock()
-				// since it doesn't check local LockingJob.
-				{op: "lock", jobID: "job-b", expectedErr: nil, wantLocked: "job-b"},
-				{op: "unlock", jobID: "job-b", expectedErr: nil, wantLocked: ""},
-			},
-		},
-		{
-			name:      "lock/unlock sequence with MemLockStore",
-			lockStore: store.NewMemLockStore(),
-			steps: []step{
-				{op: "lock", jobID: "job-a", expectedErr: nil, wantLocked: "job-a"},
-				{op: "lock", jobID: "job-b", expectedErr: store.ErrAlreadyLocked, wantLocked: "job-a"},
-				{op: "lock", jobID: "job-a", expectedErr: nil, wantLocked: "job-a"}, // idempotent
-				{op: "unlock", jobID: "job-b", expectedErr: store.ErrNotLockHolder, wantLocked: "job-a"},
-				{op: "unlock", jobID: "job-a", expectedErr: nil, wantLocked: ""},
-				{op: "unlock", jobID: "job-a", expectedErr: nil, wantLocked: ""}, // idempotent unlock
-			},
-		},
-	}
+		// 1. Initialize group with job-a holding the lock
+		if err := lockStore.Lock(ctx, groupID, jobID); err != nil {
+			t.Fatalf("failed to lock: %v", err)
+		}
+		group, _, err := groupStore.GetOrCreate(ctx, groupID)
+		if err != nil {
+			t.Fatalf("failed to get or create group: %v", err)
+		}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			groupStore := store.NewGroupStore(tc.lockStore)
-			group, _, err := groupStore.GetOrCreate(ctx, "group-1")
-			if err != nil {
-				t.Fatalf("failed to get or create group: %v", err)
-			}
+		// 2. Delete should succeed and unlock
+		err = group.Spec().Delete(ctx)
+		if err != nil {
+			t.Fatalf("delete failed: %v", err)
+		}
+		if group.Spec().LockingJob() != "" {
+			t.Errorf("expected group to be unlocked, got %q", group.Spec().LockingJob())
+		}
 
-			for i, s := range tc.steps {
-				var err error
-				switch s.op {
-				case "lock":
-					err = group.Spec().Lock(ctx, s.jobID)
-				case "unlock":
-					err = group.Spec().Unlock(ctx, s.jobID)
-				}
-
-				if !errors.Is(err, s.expectedErr) {
-					t.Fatalf("step %d: %s with %q returned error %v, want %v", i, s.op, s.jobID, err, s.expectedErr)
-				}
-
-				if group.Spec().LockingJob() != s.wantLocked {
-					t.Errorf("step %d: after %s, LockingJob() = %q, want %q", i, s.op, group.Spec().LockingJob(), s.wantLocked)
-				}
-			}
-		})
-	}
+		// 3. Delete again should be idempotent (succeed)
+		err = group.Spec().Delete(ctx)
+		if err != nil {
+			t.Fatalf("subsequent delete failed: %v", err)
+		}
+	})
 }
 
 func TestNewGroup_InitializeLock(t *testing.T) {
@@ -191,142 +158,120 @@ func TestNewGroup_InitializeLock(t *testing.T) {
 
 func TestGroupSpec_RequestLock(t *testing.T) {
 	ctx := context.Background()
-	group, err := store.NewGroup(ctx, "group-1", nil)
+	
+	// Start with job-1 holding the lock
+	lockStore := store.NewMemLockStore()
+	lockStore.Lock(ctx, "group-1", "job-1")
+	wrapped := store.NewGroupLockStoreWrapper(lockStore, "group-1")
+	group, err := store.NewGroup(ctx, "group-1", wrapped)
 	if err != nil {
 		t.Fatalf("failed to create group: %v", err)
 	}
 	spec := group.Spec()
-
-	// 1. Request lock when queue is empty and no one has lock
-	spec.RequestLock("job-1")
 	queue := spec.GetWaitingJobQueue()
+
+	// 1. Request lock for job-1 (already holds lock) -> should NOT enqueue
+	spec.RequestLock("job-1")
+	if queue.Len() != 0 {
+		t.Errorf("Expected queue to be empty, got %d", queue.Len())
+	}
+
+	// 2. Request lock for job-2 (does not hold lock) -> should enqueue
+	spec.RequestLock("job-2")
 	if queue.Len() != 1 {
 		t.Errorf("Expected queue len to be 1, got %d", queue.Len())
-	}
-	if !queue.Exists("job-1") {
-		t.Errorf("Expected job-1 to be in queue")
-	}
-
-	// 2. Request lock for the same job again (should be no-op/no duplicate)
-	spec.RequestLock("job-1")
-	if queue.Len() != 1 {
-		t.Errorf("Expected queue len to remain 1, got %d", queue.Len())
-	}
-
-	// 3. Request lock for a different job
-	spec.RequestLock("job-2")
-	if queue.Len() != 2 {
-		t.Errorf("Expected queue len to be 2, got %d", queue.Len())
 	}
 	if !queue.Exists("job-2") {
 		t.Errorf("Expected job-2 to be in queue")
 	}
 
-	// 4. Grant lock to job-1, and request lock for job-1 again.
-	// Since it now has the lock, it should NOT be enqueued again.
-	err = spec.Lock(ctx, "job-1")
-	if err != nil {
-		t.Fatalf("failed to lock: %v", err)
-	}
-	// Dequeue it from queue to simulate it being processed
-	val, ok := queue.Dequeue()
-	if !ok || val != "job-1" {
-		t.Fatalf("failed to dequeue job-1")
-	}
-
-	// Now job-1 has lock, and is NOT in queue.
-	// RequestLock for job-1 should do nothing (not enqueue it).
-	spec.RequestLock("job-1")
-	if queue.Exists("job-1") {
-		t.Errorf("Expected job-1 NOT to be enqueued since it already holds the lock")
+	// 3. Request lock for job-2 again -> should be no-op (no duplicate)
+	spec.RequestLock("job-2")
+	if queue.Len() != 1 {
+		t.Errorf("Expected queue len to remain 1, got %d", queue.Len())
 	}
 }
 
 func TestGroupSpec_Yield(t *testing.T) {
 	ctx := context.Background()
 
-	type step struct {
-		op          string // "lock", "enqueue", "yield"
-		jobID       string
-		expectedErr error
-		wantLocked  string
-		wantQueue   []string
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	groupID := "group-1"
+	
+	// Pre-lock job-1
+	if err := lockStore.Lock(ctx, groupID, "job-1"); err != nil {
+		t.Fatalf("failed to lock: %v", err)
+	}
+	
+	group, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to get or create group: %v", err)
+	}
+	spec := group.Spec()
+	queue := spec.GetWaitingJobQueue()
+
+	// Now job-1 is locked.
+	// 1. Enqueue job-2
+	spec.RequestLock("job-2")
+	// 2. Enqueue job-3
+	spec.RequestLock("job-3")
+
+	// Verify queue
+	queueList := queue.List()
+	if len(queueList) != 2 {
+		t.Fatalf("expected queue len 2, got %d", len(queueList))
+	}
+	if queueList[0].JobID != "job-2" || queueList[1].JobID != "job-3" {
+		t.Errorf("unexpected queue content: %+v", queueList)
 	}
 
-	tests := []struct {
-		name      string
-		lockStore store.LockStore
-		steps     []step
-	}{
-		{
-			name:      "yield without lockStore",
-			lockStore: nil,
-			steps: []step{
-				// Setup: job-1 locks, job-2 and job-3 enqueue
-				{op: "lock", jobID: "job-1", expectedErr: nil, wantLocked: "job-1", wantQueue: []string{}},
-				{op: "enqueue", jobID: "job-2", expectedErr: nil, wantLocked: "job-1", wantQueue: []string{"job-2"}},
-				{op: "enqueue", jobID: "job-3", expectedErr: nil, wantLocked: "job-1", wantQueue: []string{"job-2", "job-3"}},
-				// Yield job-1 -> job-2 should get lock, job-3 remains in queue
-				{op: "yield", jobID: "job-1", expectedErr: nil, wantLocked: "job-2", wantQueue: []string{"job-3"}},
-				// Yield job-2 -> job-3 should get lock, queue becomes empty
-				{op: "yield", jobID: "job-2", expectedErr: nil, wantLocked: "job-3", wantQueue: []string{}},
-				// Yield job-3 -> queue is empty, group becomes unlocked
-				{op: "yield", jobID: "job-3", expectedErr: nil, wantLocked: "", wantQueue: []string{}},
-			},
-		},
-		{
-			name:      "yield with MemLockStore",
-			lockStore: store.NewMemLockStore(),
-			steps: []step{
-				// Setup
-				{op: "lock", jobID: "job-1", expectedErr: nil, wantLocked: "job-1", wantQueue: []string{}},
-				{op: "enqueue", jobID: "job-2", expectedErr: nil, wantLocked: "job-1", wantQueue: []string{"job-2"}},
-				// Yield by non-lock holder should fail and not change anything
-				{op: "yield", jobID: "job-2", expectedErr: store.ErrNotLockHolder, wantLocked: "job-1", wantQueue: []string{"job-2"}},
-				// Yield by lock holder succeeds
-				{op: "yield", jobID: "job-1", expectedErr: nil, wantLocked: "job-2", wantQueue: []string{}},
-			},
-		},
+	// 3. Yield by non-holder (job-2) should fail
+	err = spec.Yield(ctx, "job-2")
+	if !errors.Is(err, store.ErrNotLockHolder) {
+		t.Fatalf("expected ErrNotLockHolder, got %v", err)
+	}
+	if spec.LockingJob() != "job-1" {
+		t.Errorf("expected group to remain locked by job-1, got %q", spec.LockingJob())
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			groupStore := store.NewGroupStore(tc.lockStore)
-			group, _, err := groupStore.GetOrCreate(ctx, "group-1")
-			if err != nil {
-				t.Fatalf("failed to get or create group: %v", err)
-			}
-			spec := group.Spec()
+	// 4. Yield by holder (job-1) should succeed and grant to job-2
+	err = spec.Yield(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("yield failed: %v", err)
+	}
+	if spec.LockingJob() != "job-2" {
+		t.Errorf("expected lockingJob to be job-2, got %q", spec.LockingJob())
+	}
+	
+	// Verify queue (should only have job-3)
+	queueList = queue.List()
+	if len(queueList) != 1 {
+		t.Fatalf("expected queue len 1, got %d", len(queueList))
+	}
+	if queueList[0].JobID != "job-3" {
+		t.Errorf("unexpected queue content: %+v", queueList)
+	}
 
-			for stepIdx, stepInfo := range tc.steps {
-				var err error
-				switch stepInfo.op {
-				case "lock":
-					err = spec.Lock(ctx, stepInfo.jobID)
-				case "enqueue":
-					spec.RequestLock(stepInfo.jobID)
-				case "yield":
-					err = spec.Yield(ctx, stepInfo.jobID)
-				}
+	// 5. Yield by holder (job-2) should succeed and grant to job-3
+	err = spec.Yield(ctx, "job-2")
+	if err != nil {
+		t.Fatalf("yield failed: %v", err)
+	}
+	if spec.LockingJob() != "job-3" {
+		t.Errorf("expected lockingJob to be job-3, got %q", spec.LockingJob())
+	}
+	if queue.Len() != 0 {
+		t.Errorf("expected queue to be empty, got %d", queue.Len())
+	}
 
-				if !errors.Is(err, stepInfo.expectedErr) {
-					t.Fatalf("step %d: %s with %q returned error %v, want %v", stepIdx, stepInfo.op, stepInfo.jobID, err, stepInfo.expectedErr)
-				}
-
-				if spec.LockingJob() != stepInfo.wantLocked {
-					t.Errorf("step %d: after %s, LockingJob() = %q, want %q", stepIdx, stepInfo.op, spec.LockingJob(), stepInfo.wantLocked)
-				}
-
-				queueList := spec.GetWaitingJobQueue().List()
-				queueIDs := make([]string, 0, len(queueList))
-				for _, qj := range queueList {
-					queueIDs = append(queueIDs, qj.JobID)
-				}
-				if !reflect.DeepEqual(queueIDs, stepInfo.wantQueue) {
-					t.Errorf("step %d: after %s, queue = %v, want %v", stepIdx, stepInfo.op, queueIDs, stepInfo.wantQueue)
-				}
-			}
-		})
+	// 6. Yield by holder (job-3) should succeed and group becomes unlocked
+	err = spec.Yield(ctx, "job-3")
+	if err != nil {
+		t.Fatalf("yield failed: %v", err)
+	}
+	if spec.LockingJob() != "" {
+		t.Errorf("expected lockingJob to be empty, got %q", spec.LockingJob())
 	}
 }
 

--- a/pkg/accelerator-orchestrator/store/group_test.go
+++ b/pkg/accelerator-orchestrator/store/group_test.go
@@ -17,7 +17,6 @@ func TestGroup_GettersAndSetters(t *testing.T) {
 		groupID    string
 		nodes      []string
 		lockingJob string
-		activeJob  string
 		state      pb.GroupStatus_State
 	}{
 		{
@@ -25,7 +24,6 @@ func TestGroup_GettersAndSetters(t *testing.T) {
 			groupID:    "",
 			nodes:      nil,
 			lockingJob: "",
-			activeJob:  "",
 			state:      pb.GroupStatus_STATE_UNSPECIFIED,
 		},
 		{
@@ -33,7 +31,6 @@ func TestGroup_GettersAndSetters(t *testing.T) {
 			groupID:    "group-123",
 			nodes:      []string{"node-a", "node-b"},
 			lockingJob: "job-a",
-			activeJob:  "job-b",
 			state:      pb.GroupStatus_STATE_IDLE,
 		},
 	}
@@ -64,17 +61,16 @@ func TestGroup_GettersAndSetters(t *testing.T) {
 			}
 
 			if tc.lockingJob != "" {
-				if err := group.Lock(context.Background(), tc.lockingJob); err != nil {
+				if err := group.Spec().Lock(context.Background(), tc.lockingJob); err != nil {
 					t.Fatalf("failed to lock: %v", err)
 				}
 			}
-			if group.LockingJob() != tc.lockingJob {
-				t.Errorf("LockingJob() = %q, want %q", group.LockingJob(), tc.lockingJob)
+			if group.Spec().LockingJob() != tc.lockingJob {
+				t.Errorf("LockingJob() = %q, want %q", group.Spec().LockingJob(), tc.lockingJob)
 			}
 
-			group.SetActiveJob(tc.activeJob)
-			if group.ActiveJob() != tc.activeJob {
-				t.Errorf("ActiveJob() = %q, want %q", group.ActiveJob(), tc.activeJob)
+			if group.Spec().ActiveJob() != tc.lockingJob {
+				t.Errorf("ActiveJob() = %q, want %q", group.Spec().ActiveJob(), tc.lockingJob)
 			}
 
 			_, initialTimestamp := group.State()
@@ -150,17 +146,17 @@ func TestGroup_LockAndUnlock(t *testing.T) {
 				var err error
 				switch s.op {
 				case "lock":
-					err = group.Lock(ctx, s.jobID)
+					err = group.Spec().Lock(ctx, s.jobID)
 				case "unlock":
-					err = group.Unlock(ctx, s.jobID)
+					err = group.Spec().Unlock(ctx, s.jobID)
 				}
 
 				if !errors.Is(err, s.expectedErr) {
 					t.Fatalf("step %d: %s with %q returned error %v, want %v", i, s.op, s.jobID, err, s.expectedErr)
 				}
 
-				if group.LockingJob() != s.wantLocked {
-					t.Errorf("step %d: after %s, LockingJob() = %q, want %q", i, s.op, group.LockingJob(), s.wantLocked)
+				if group.Spec().LockingJob() != s.wantLocked {
+					t.Errorf("step %d: after %s, LockingJob() = %q, want %q", i, s.op, group.Spec().LockingJob(), s.wantLocked)
 				}
 			}
 		})
@@ -179,13 +175,158 @@ func TestNewGroup_InitializeLock(t *testing.T) {
 	}
 
 	// 2. Create NewGroup and check if it initialized lockingJob
-	group, err := store.NewGroup(ctx, groupID, lockStore)
+	wrappedLockStore := store.NewGroupLockStoreWrapper(lockStore, groupID)
+	group, err := store.NewGroup(ctx, groupID, wrappedLockStore)
 	if err != nil {
 		t.Fatalf("NewGroup failed: %v", err)
 	}
 
-	if group.LockingJob() != jobID {
-		t.Errorf("NewGroup did not initialize lockingJob from lockStore, got %q, want %q", group.LockingJob(), jobID)
+	if group.Spec().LockingJob() != jobID {
+		t.Errorf("NewGroup did not initialize lockingJob from lockStore, got %q, want %q", group.Spec().LockingJob(), jobID)
+	}
+	if group.Spec().ActiveJob() != jobID {
+		t.Errorf("NewGroup did not initialize activeJob from lockStore, got %q, want %q", group.Spec().ActiveJob(), jobID)
+	}
+}
+
+func TestGroupSpec_RequestLock(t *testing.T) {
+	ctx := context.Background()
+	group, err := store.NewGroup(ctx, "group-1", nil)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	spec := group.Spec()
+
+	// 1. Request lock when queue is empty and no one has lock
+	spec.RequestLock("job-1")
+	queue := spec.GetWaitingJobQueue()
+	if queue.Len() != 1 {
+		t.Errorf("Expected queue len to be 1, got %d", queue.Len())
+	}
+	if !queue.Exists("job-1") {
+		t.Errorf("Expected job-1 to be in queue")
+	}
+
+	// 2. Request lock for the same job again (should be no-op/no duplicate)
+	spec.RequestLock("job-1")
+	if queue.Len() != 1 {
+		t.Errorf("Expected queue len to remain 1, got %d", queue.Len())
+	}
+
+	// 3. Request lock for a different job
+	spec.RequestLock("job-2")
+	if queue.Len() != 2 {
+		t.Errorf("Expected queue len to be 2, got %d", queue.Len())
+	}
+	if !queue.Exists("job-2") {
+		t.Errorf("Expected job-2 to be in queue")
+	}
+
+	// 4. Grant lock to job-1, and request lock for job-1 again.
+	// Since it now has the lock, it should NOT be enqueued again.
+	err = spec.Lock(ctx, "job-1")
+	if err != nil {
+		t.Fatalf("failed to lock: %v", err)
+	}
+	// Dequeue it from queue to simulate it being processed
+	val, ok := queue.Dequeue()
+	if !ok || val != "job-1" {
+		t.Fatalf("failed to dequeue job-1")
+	}
+
+	// Now job-1 has lock, and is NOT in queue.
+	// RequestLock for job-1 should do nothing (not enqueue it).
+	spec.RequestLock("job-1")
+	if queue.Exists("job-1") {
+		t.Errorf("Expected job-1 NOT to be enqueued since it already holds the lock")
+	}
+}
+
+func TestGroupSpec_Yield(t *testing.T) {
+	ctx := context.Background()
+
+	type step struct {
+		op          string // "lock", "enqueue", "yield"
+		jobID       string
+		expectedErr error
+		wantLocked  string
+		wantQueue   []string
+	}
+
+	tests := []struct {
+		name      string
+		lockStore store.LockStore
+		steps     []step
+	}{
+		{
+			name:      "yield without lockStore",
+			lockStore: nil,
+			steps: []step{
+				// Setup: job-1 locks, job-2 and job-3 enqueue
+				{op: "lock", jobID: "job-1", expectedErr: nil, wantLocked: "job-1", wantQueue: []string{}},
+				{op: "enqueue", jobID: "job-2", expectedErr: nil, wantLocked: "job-1", wantQueue: []string{"job-2"}},
+				{op: "enqueue", jobID: "job-3", expectedErr: nil, wantLocked: "job-1", wantQueue: []string{"job-2", "job-3"}},
+				// Yield job-1 -> job-2 should get lock, job-3 remains in queue
+				{op: "yield", jobID: "job-1", expectedErr: nil, wantLocked: "job-2", wantQueue: []string{"job-3"}},
+				// Yield job-2 -> job-3 should get lock, queue becomes empty
+				{op: "yield", jobID: "job-2", expectedErr: nil, wantLocked: "job-3", wantQueue: []string{}},
+				// Yield job-3 -> queue is empty, group becomes unlocked
+				{op: "yield", jobID: "job-3", expectedErr: nil, wantLocked: "", wantQueue: []string{}},
+			},
+		},
+		{
+			name:      "yield with MemLockStore",
+			lockStore: store.NewMemLockStore(),
+			steps: []step{
+				// Setup
+				{op: "lock", jobID: "job-1", expectedErr: nil, wantLocked: "job-1", wantQueue: []string{}},
+				{op: "enqueue", jobID: "job-2", expectedErr: nil, wantLocked: "job-1", wantQueue: []string{"job-2"}},
+				// Yield by non-lock holder should fail and not change anything
+				{op: "yield", jobID: "job-2", expectedErr: store.ErrNotLockHolder, wantLocked: "job-1", wantQueue: []string{"job-2"}},
+				// Yield by lock holder succeeds
+				{op: "yield", jobID: "job-1", expectedErr: nil, wantLocked: "job-2", wantQueue: []string{}},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			groupStore := store.NewGroupStore(tc.lockStore)
+			group, _, err := groupStore.GetOrCreate(ctx, "group-1")
+			if err != nil {
+				t.Fatalf("failed to get or create group: %v", err)
+			}
+			spec := group.Spec()
+
+			for stepIdx, stepInfo := range tc.steps {
+				var err error
+				switch stepInfo.op {
+				case "lock":
+					err = spec.Lock(ctx, stepInfo.jobID)
+				case "enqueue":
+					spec.RequestLock(stepInfo.jobID)
+				case "yield":
+					err = spec.Yield(ctx, stepInfo.jobID)
+				}
+
+				if !errors.Is(err, stepInfo.expectedErr) {
+					t.Fatalf("step %d: %s with %q returned error %v, want %v", stepIdx, stepInfo.op, stepInfo.jobID, err, stepInfo.expectedErr)
+				}
+
+				if spec.LockingJob() != stepInfo.wantLocked {
+					t.Errorf("step %d: after %s, LockingJob() = %q, want %q", stepIdx, stepInfo.op, spec.LockingJob(), stepInfo.wantLocked)
+				}
+
+				queueList := spec.GetWaitingJobQueue().List()
+				queueIDs := make([]string, 0, len(queueList))
+				for _, qj := range queueList {
+					queueIDs = append(queueIDs, qj.JobID)
+				}
+				if !reflect.DeepEqual(queueIDs, stepInfo.wantQueue) {
+					t.Errorf("step %d: after %s, queue = %v, want %v", stepIdx, stepInfo.op, queueIDs, stepInfo.wantQueue)
+				}
+			}
+		})
 	}
 }
 
@@ -195,16 +336,17 @@ func TestGroup_Snapshot(t *testing.T) {
 	if err := lockStore.Lock(ctx, "group-1", "job-lock"); err != nil {
 		t.Fatalf("failed to lock: %v", err)
 	}
-	group, err := store.NewGroup(ctx, "group-1", lockStore)
+	wrappedLockStore := store.NewGroupLockStoreWrapper(lockStore, "group-1")
+	group, err := store.NewGroup(ctx, "group-1", wrappedLockStore)
 	if err != nil {
 		t.Fatalf("failed to create group: %v", err)
 	}
 
 	group.SetNodes([]string{"node-a", "node-b"})
 	group.SetState(pb.GroupStatus_STATE_IDLE)
-	group.SetActiveJob("job-active")
-	group.GetWaitingJobQueue().Enqueue("job-wait-1")
-	group.GetWaitingJobQueue().Enqueue("job-wait-2")
+	group.Spec().SetActiveJob("job-active")
+	group.Spec().GetWaitingJobQueue().Enqueue("job-wait-1")
+	group.Spec().GetWaitingJobQueue().Enqueue("job-wait-2")
 
 	// Take snapshot
 	snap := group.Snapshot()

--- a/pkg/accelerator-orchestrator/store/waiting_job_queue.go
+++ b/pkg/accelerator-orchestrator/store/waiting_job_queue.go
@@ -64,6 +64,24 @@ func (q *WaitingJobQueue) Dequeue() (string, bool) {
 	return job.JobID, true
 }
 
+// Peek returns the next job from the front of the queue without removing it.
+// Returns the jobID and true if successful, or empty string and false if the queue is empty.
+func (q *WaitingJobQueue) Peek() (string, bool) {
+	q.mu.RLock()
+	defer q.mu.RUnlock()
+
+	front := q.jobs.Front()
+	if front == nil {
+		return "", false
+	}
+
+	job, ok := front.Value.(WaitingJob)
+	if !ok {
+		panic("invalid type in queue")
+	}
+	return job.JobID, true
+}
+
 // Len returns the number of jobs currently in the queue.
 func (q *WaitingJobQueue) Len() int {
 	q.mu.RLock()


### PR DESCRIPTION
Also organized the desrired state into spec for easier mental reasoning between what we want (ie. spec) and what is currently the state.

Note that logging is just extending what is currently used, it will all flip to the standard with the other PR.

## What does this PR do?

<!-- Describe the changes and their purpose -->

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
