### PR TITLE
Remove snapshot-agent:true as a requirement

### DIFF
--- a/pkg/snapshot-agent/utils/pod-utils.go
+++ b/pkg/snapshot-agent/utils/pod-utils.go
@@ -16,11 +16,8 @@ import (
 )
 
 const (
-	// SnapshotAgentLabel is the label used to identify pods that the snapshot agent should manage.
-	SnapshotAgentLabel = "snapshot-agent"
-	// SnapshotAgentValue is the value of the label for pods to be managed.
-	SnapshotAgentValue = "true"
-	JobIDLabel         = "timeslice.io/job-id"
+	// JobIDLabel is the label used to identify pods by their job ID.
+	JobIDLabel = "timeslice.io/job-id"
 )
 
 // GetLocalPods returns a list of pods running on the same node as the current pod.
@@ -47,7 +44,7 @@ func GetLocalPods(ctx context.Context, jobID string) ([]corev1.Pod, error) {
 	// List pods on the current node that have the snapshot-agent label
 	podList, err := clientset.CoreV1().Pods("").List(ctx, metav1.ListOptions{
 		FieldSelector: fmt.Sprintf("spec.nodeName=%s", nodeName),
-		LabelSelector: fmt.Sprintf("%s=%s,%s=%s", SnapshotAgentLabel, SnapshotAgentValue, JobIDLabel, jobID),
+		LabelSelector: fmt.Sprintf("%s=%s", JobIDLabel, jobID),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list pods on node %s: %w", nodeName, err)


### PR DESCRIPTION
## What does this PR do?
Removes the need for deployments wanting to use the snapshot-agent to add label `snapshot-agent: true`
<!-- Describe the changes and their purpose -->

## Why is this change needed?
Makes deploying workload that interacts with snapshot-agent simpler

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
