### PR TITLE
Making group field optional in Snapshot Agent 

### DIFF
--- a/pkg/client/python/timeslice/snapshot_agent/client.py
+++ b/pkg/client/python/timeslice/snapshot_agent/client.py
@@ -38,14 +38,14 @@ class SnapshotAgentInterface(ABC):
 
     @abstractmethod
     def snapshot(
-        self, job_id: str, group: str, backend: Union[str, int] = 0
+        self, job_id: str, group: str = "", backend: Union[str, int] = 0
     ) -> SnapshotResponse:
         """Triggers an asynchronous snapshot."""
         pass
 
     @abstractmethod
     def restore(
-        self, job_id: str, group: str, backend: Union[str, int] = 0
+        self, job_id: str, group: str = "", backend: Union[str, int] = 0
     ) -> RestoreResponse:
         """Triggers an asynchronous restoration."""
         pass
@@ -130,7 +130,7 @@ class SnapshotAgentClient(SnapshotAgentInterface):
                 return snapshot_agent_pb2.BACKEND_UNSPECIFIED
 
     def snapshot(
-        self, job_id: str, group: str, backend: Union[str, int] = 0
+        self, job_id: str, group: str = "", backend: Union[str, int] = 0
     ) -> SnapshotResponse:
         """
         Triggers an asynchronous snapshot.
@@ -160,7 +160,7 @@ class SnapshotAgentClient(SnapshotAgentInterface):
             raise SnapshotAgentError(f"Unexpected error: {e}") from e
 
     def restore(
-        self, job_id: str, group: str, backend: Union[str, int] = 0
+        self, job_id: str, group: str = "", backend: Union[str, int] = 0
     ) -> RestoreResponse:
         """
         Triggers an asynchronous restoration.
@@ -301,7 +301,7 @@ class SnapshotAgentClient(SnapshotAgentInterface):
     def snapshot_and_wait(
         self,
         job_id: str,
-        group: str,
+        group: str = "",
         backend: Union[str, int] = 0,
         poll_interval_sec: float = 1.0,
     ) -> GetOperationResponse:
@@ -312,7 +312,7 @@ class SnapshotAgentClient(SnapshotAgentInterface):
     def restore_and_wait(
         self,
         job_id: str,
-        group: str,
+        group: str = "",
         backend: Union[str, int] = 0,
         poll_interval_sec: float = 1.0,
     ) -> GetOperationResponse:

--- a/pkg/snapshot-agent/api/v1alpha1/snapshot_agent.proto
+++ b/pkg/snapshot-agent/api/v1alpha1/snapshot_agent.proto
@@ -25,6 +25,8 @@ enum Backend {
 }
 
 message SnapshotRequest {
+  // job_id is the unique identifier for the job. If group is specified,
+  // job_id should be unique within that group.
   string job_id = 1;
   // group is an optional identifier for a set of related jobs.
   string group = 2;
@@ -36,6 +38,8 @@ message SnapshotResponse {
 }
 
 message RestoreRequest {
+  // job_id is the unique identifier for the job. If group is specified,
+  // job_id should be unique within that group.
   string job_id = 1;
   // group is an optional identifier for a set of related jobs.
   string group = 2;

--- a/pkg/snapshot-agent/api/v1alpha1/snapshot_agent.proto
+++ b/pkg/snapshot-agent/api/v1alpha1/snapshot_agent.proto
@@ -26,6 +26,7 @@ enum Backend {
 
 message SnapshotRequest {
   string job_id = 1;
+  // group is an optional identifier for a set of related jobs.
   string group = 2;
   Backend backend = 3;
 }
@@ -36,6 +37,7 @@ message SnapshotResponse {
 
 message RestoreRequest {
   string job_id = 1;
+  // group is an optional identifier for a set of related jobs.
   string group = 2;
   Backend backend = 3;
 }

--- a/pkg/snapshot-agent/server/server_test.go
+++ b/pkg/snapshot-agent/server/server_test.go
@@ -65,6 +65,7 @@ func TestServer_Snapshot(t *testing.T) {
 	defer conn.Close()
 	client := pb.NewSnapshotAgentServiceClient(conn)
 
+	// Test with group
 	_, err = client.Snapshot(ctx, &pb.SnapshotRequest{
 		JobId:   "test-job",
 		Group:   "test-group",
@@ -72,6 +73,15 @@ func TestServer_Snapshot(t *testing.T) {
 	})
 	if err != nil {
 		t.Errorf("Expected success (using default noop backend), got error: %v", err)
+	}
+
+	// Test without group
+	_, err = client.Snapshot(ctx, &pb.SnapshotRequest{
+		JobId:   "test-job-no-group",
+		Backend: pb.Backend_BACKEND_UNSPECIFIED,
+	})
+	if err != nil {
+		t.Errorf("Expected success with empty group, got error: %v", err)
 	}
 }
 
@@ -87,6 +97,7 @@ func TestServer_Restore(t *testing.T) {
 	defer conn.Close()
 	client := pb.NewSnapshotAgentServiceClient(conn)
 
+	// Test with group
 	_, err = client.Restore(ctx, &pb.RestoreRequest{
 		JobId:   "test-job",
 		Group:   "test-group",
@@ -94,6 +105,15 @@ func TestServer_Restore(t *testing.T) {
 	})
 	if err != nil {
 		t.Errorf("Expected success (using default noop backend), got error: %v", err)
+	}
+
+	// Test without group
+	_, err = client.Restore(ctx, &pb.RestoreRequest{
+		JobId:   "test-job-no-group",
+		Backend: pb.Backend_BACKEND_UNSPECIFIED,
+	})
+	if err != nil {
+		t.Errorf("Expected success with empty group, got error: %v", err)
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?
Makes group field optional in Snapshot and Restore API calls in the Snapshot-Agent API. Replaces #50 

<!-- Describe the changes and their purpose -->

## Why is this change needed?
Group isn't needed for all use cases of the Snapshot-Agent, but it is needed for others (e.g the Orchestrator). Because of that, we need to keep it. 

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
