### PR TITLE
Add agent port to orchestrator routing

### DIFF
--- a/cmd/acceleratororchestrator/main.go
+++ b/cmd/acceleratororchestrator/main.go
@@ -39,6 +39,7 @@ func run() error {
 	port := flag.Int("port", 50051, "The server port")
 	kubeconfig := flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	controllerWorkers := flag.Int("controller-workers", 1, "The number of workers for the controller")
+	snapshotAgentPort := flag.Int("snapshot-agent-port", 9001, "The default port for snapshot agents")
 	flag.Parse()
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -64,7 +65,7 @@ func run() error {
 	lockStore := store.NewConfigMapLockStore(clientset)
 	groupStore := store.NewGroupStore(lockStore)
 	jobStore := store.NewJobStore()
-	snapshotAgentStore := store.NewGRPCSnapshotAgentStore(0)
+	snapshotAgentStore := store.NewGRPCSnapshotAgentStore(0, *snapshotAgentPort)
 	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
 		workqueue.DefaultTypedControllerRateLimiter[string](),
 		workqueue.TypedRateLimitingQueueConfig[string]{

--- a/pkg/accelerator-orchestrator/store/snapshot_agent_store.go
+++ b/pkg/accelerator-orchestrator/store/snapshot_agent_store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -32,19 +33,21 @@ type cacheEntry struct {
 
 // GRPCSnapshotAgentStore implements SnapshotAgentStore using gRPC.
 type GRPCSnapshotAgentStore struct {
-	mu       sync.Mutex
-	clients  map[string]*clientEntry
-	cache    map[string]*cacheEntry
-	cacheTTL time.Duration
+	mu          sync.Mutex
+	clients     map[string]*clientEntry
+	cache       map[string]*cacheEntry
+	cacheTTL    time.Duration
+	defaultPort int
 }
 
 // NewGRPCSnapshotAgentStore creates a new GRPCSnapshotAgentStore.
 // If ttl is <= 0, caching is disabled.
-func NewGRPCSnapshotAgentStore(ttl time.Duration) *GRPCSnapshotAgentStore {
+func NewGRPCSnapshotAgentStore(ttl time.Duration, defaultPort int) *GRPCSnapshotAgentStore {
 	return &GRPCSnapshotAgentStore{
-		clients:  make(map[string]*clientEntry),
-		cache:    make(map[string]*cacheEntry),
-		cacheTTL: ttl,
+		clients:     make(map[string]*clientEntry),
+		cache:       make(map[string]*cacheEntry),
+		cacheTTL:    ttl,
+		defaultPort: defaultPort,
 	}
 }
 
@@ -198,7 +201,10 @@ func (s *GRPCSnapshotAgentStore) CloseClient(nodeName string) error {
 }
 
 func (s *GRPCSnapshotAgentStore) resolveNodeAddress(nodeName string) string {
-	// TODO: Implement actual node name to address translation once we know the port and DNS choices.
-	// For now, assume they are the same for unit tests.
-	return nodeName
+	// If the nodeName already contains a port (e.g. "127.0.0.1:12345" in unit tests), use it as-is.
+	if strings.Contains(nodeName, ":") {
+		return nodeName
+	}
+	// Otherwise, append the default snapshot-agent port.
+	return fmt.Sprintf("%s:%d", nodeName, s.defaultPort)
 }

--- a/pkg/accelerator-orchestrator/store/snapshot_agent_store.go
+++ b/pkg/accelerator-orchestrator/store/snapshot_agent_store.go
@@ -3,7 +3,8 @@ package store
 import (
 	"context"
 	"fmt"
-	"strings"
+	"net"
+	"strconv"
 	"sync"
 	"time"
 
@@ -201,10 +202,10 @@ func (s *GRPCSnapshotAgentStore) CloseClient(nodeName string) error {
 }
 
 func (s *GRPCSnapshotAgentStore) resolveNodeAddress(nodeName string) string {
-	// If the nodeName already contains a port (e.g. "127.0.0.1:12345" in unit tests), use it as-is.
-	if strings.Contains(nodeName, ":") {
+	// If the nodeName already contains a port, use it as-is.
+	if _, _, err := net.SplitHostPort(nodeName); err == nil {
 		return nodeName
 	}
 	// Otherwise, append the default snapshot-agent port.
-	return fmt.Sprintf("%s:%d", nodeName, s.defaultPort)
+	return net.JoinHostPort(nodeName, strconv.Itoa(s.defaultPort))
 }

--- a/pkg/accelerator-orchestrator/store/snapshot_agent_store_internal_test.go
+++ b/pkg/accelerator-orchestrator/store/snapshot_agent_store_internal_test.go
@@ -1,0 +1,69 @@
+// Copyright 2025 The llm-d Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package store
+
+import (
+	"testing"
+)
+
+func TestResolveNodeAddress(t *testing.T) {
+	tests := []struct {
+		name        string
+		nodeName    string
+		defaultPort int
+		want        string
+	}{
+		{
+			name:        "without port",
+			nodeName:    "node-1",
+			defaultPort: 9001,
+			want:        "node-1:9001",
+		},
+		{
+			name:        "with port",
+			nodeName:    "node-1:12345",
+			defaultPort: 9001,
+			want:        "node-1:12345",
+		},
+		{
+			name:        "IP without port",
+			nodeName:    "127.0.0.1",
+			defaultPort: 9001,
+			want:        "127.0.0.1:9001",
+		},
+		{
+			name:        "IP with port",
+			nodeName:    "127.0.0.1:12345",
+			defaultPort: 9001,
+			want:        "127.0.0.1:12345",
+		},
+		{
+			name:        "different default port",
+			nodeName:    "node-2",
+			defaultPort: 8080,
+			want:        "node-2:8080",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewGRPCSnapshotAgentStore(0, tt.defaultPort)
+			got := s.resolveNodeAddress(tt.nodeName)
+			if got != tt.want {
+				t.Errorf("resolveNodeAddress() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/accelerator-orchestrator/store/snapshot_agent_store_internal_test.go
+++ b/pkg/accelerator-orchestrator/store/snapshot_agent_store_internal_test.go
@@ -34,26 +34,50 @@ func TestResolveNodeAddress(t *testing.T) {
 		{
 			name:        "with port",
 			nodeName:    "node-1:12345",
-			defaultPort: 9001,
+			defaultPort: 9002,
 			want:        "node-1:12345",
 		},
 		{
 			name:        "IP without port",
 			nodeName:    "127.0.0.1",
-			defaultPort: 9001,
-			want:        "127.0.0.1:9001",
+			defaultPort: 9003,
+			want:        "127.0.0.1:9003",
 		},
 		{
 			name:        "IP with port",
 			nodeName:    "127.0.0.1:12345",
-			defaultPort: 9001,
+			defaultPort: 9004,
 			want:        "127.0.0.1:12345",
 		},
 		{
 			name:        "different default port",
 			nodeName:    "node-2",
-			defaultPort: 8080,
-			want:        "node-2:8080",
+			defaultPort: 9005,
+			want:        "node-2:9005",
+		},
+		{
+			name:        "IPv6 without port",
+			nodeName:    "2001:db8::1",
+			defaultPort: 9006,
+			want:        "[2001:db8::1]:9006",
+		},
+		{
+			name:        "IPv6 with port",
+			nodeName:    "[2001:db8::1]:12345",
+			defaultPort: 9007,
+			want:        "[2001:db8::1]:12345",
+		},
+		{
+			name:        "IPv6 loopback without port",
+			nodeName:    "::1",
+			defaultPort: 9008,
+			want:        "[::1]:9008",
+		},
+		{
+			name:        "IPv6 loopback with port",
+			nodeName:    "[::1]:12345",
+			defaultPort: 9009,
+			want:        "[::1]:12345",
 		},
 	}
 

--- a/pkg/accelerator-orchestrator/store/snapshot_agent_store_test.go
+++ b/pkg/accelerator-orchestrator/store/snapshot_agent_store_test.go
@@ -61,7 +61,7 @@ func TestGRPCSnapshotAgentStore_GetStatus(t *testing.T) {
 	defer grpcServer.GracefulStop()
 
 	// Test with 5s TTL
-	s := store.NewGRPCSnapshotAgentStore(5 * time.Second)
+	s := store.NewGRPCSnapshotAgentStore(5*time.Second, 9001)
 	resp, err := s.GetStatus(context.Background(), addr)
 	if err != nil {
 		t.Fatalf("GetStatus failed: %v", err)
@@ -113,7 +113,7 @@ func TestGRPCSnapshotAgentStore_GetStatus_Caching(t *testing.T) {
 	defer grpcServer.GracefulStop()
 
 	// Create store with 100ms TTL
-	agentStore := store.NewGRPCSnapshotAgentStore(100 * time.Millisecond)
+	agentStore := store.NewGRPCSnapshotAgentStore(100*time.Millisecond, 9001)
 
 	// 1. First call - cache miss, calls server
 	resp1, err := agentStore.GetStatus(context.Background(), addr)
@@ -178,7 +178,7 @@ func TestGRPCSnapshotAgentStore_GetStatus_NoCaching(t *testing.T) {
 	defer grpcServer.GracefulStop()
 
 	// Create store with 0 TTL (no caching)
-	s := store.NewGRPCSnapshotAgentStore(0)
+	s := store.NewGRPCSnapshotAgentStore(0, 9001)
 
 	// 1. First call - calls server
 	_, err = s.GetStatus(context.Background(), addr)
@@ -226,7 +226,7 @@ func TestGRPCSnapshotAgentStore_CloseClient(t *testing.T) {
 	}()
 
 	// 1. Create store with 5s TTL
-	agentStore := store.NewGRPCSnapshotAgentStore(5 * time.Second)
+	agentStore := store.NewGRPCSnapshotAgentStore(5*time.Second, 9001)
 
 	// 2. First call - succeeds and caches
 	_, err = agentStore.GetStatus(context.Background(), addr)


### PR DESCRIPTION
## What does this PR do?

Adds the agent port to the routing logic

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed - it works in cluster in e2e (a different change)

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
