### PR TITLE
add work trigger for yield and acquire

### DIFF
--- a/pkg/accelerator-orchestrator/controller/controller.go
+++ b/pkg/accelerator-orchestrator/controller/controller.go
@@ -112,6 +112,11 @@ func NewController(
 	}
 }
 
+// EnqueueWork enqueues the group ID for reconciliation.
+func (c *Controller) EnqueueWork(groupID string) {
+	c.queue.Add(groupID)
+}
+
 // Run starts the controller's reconciliation loop.
 // It initializes the infrastructure orchestrator, then starts the specified number of worker goroutines.
 // It blocks until the provided context is cancelled.

--- a/pkg/accelerator-orchestrator/controller/controller_test.go
+++ b/pkg/accelerator-orchestrator/controller/controller_test.go
@@ -200,10 +200,12 @@ func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
 	lockStore := store.NewMemLockStore()
 	groupStore := store.NewGroupStore(lockStore)
 	jobStore := store.NewJobStore()
-	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.DefaultTypedControllerRateLimiter[string](),
-		workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-	)
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
 
 	groupID := "group-1"
 
@@ -216,7 +218,7 @@ func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
 	}
 
 	mockAgentStore := &controller.MockSnapshotAgentStore{}
-	c := controller.NewController(groupStore, jobStore, queue, mockOrch, mockAgentStore)
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
 
 	// Start the controller
 	go func() {
@@ -236,8 +238,9 @@ func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
 	}
 
 	// Reconcile Phase 1 (job-1 locked)
-	queue.Add(groupID)
-	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 2*time.Second)
+	initialDone := testQueue.getDoneCount()
+	testQueue.Add(groupID)
+	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > initialDone }, 2*time.Second)
 	if err != nil {
 		t.Fatalf("Timed out waiting for Phase 1 reconcile: %v", err)
 	}
@@ -250,8 +253,9 @@ func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
 	testGroup.Spec().RequestLock("job-2")
 
 	// Reconcile Phase 2 (job-2 enqueued, job-1 still locked)
-	queue.Add(groupID)
-	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 2*time.Second)
+	initialDone = testQueue.getDoneCount()
+	testQueue.Add(groupID)
+	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > initialDone }, 2*time.Second)
 	if err != nil {
 		t.Fatalf("Timed out waiting for Phase 2 reconcile: %v", err)
 	}
@@ -270,7 +274,7 @@ func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
 	}
 
 	// Reconcile Phase 3 (job-2 should be active/locking)
-	queue.Add(groupID)
+	testQueue.Add(groupID)
 	err = waitWithTimeout(func() bool {
 		return testGroup.Spec().LockingJob() == "job-2" && testGroup.Spec().ActiveJob() == "job-2"
 	}, 3*time.Second)
@@ -288,8 +292,9 @@ func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
 	testGroup.Spec().RequestLock("job-1")
 
 	// Reconcile Phase 4 (job-1 enqueued, job-2 still locked)
-	queue.Add(groupID)
-	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 2*time.Second)
+	initialDone = testQueue.getDoneCount()
+	testQueue.Add(groupID)
+	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > initialDone }, 2*time.Second)
 	if err != nil {
 		t.Fatalf("Timed out waiting for Phase 4 reconcile: %v", err)
 	}
@@ -308,7 +313,7 @@ func TestController_Reconcile_TwoJobsTakeLockTurns(t *testing.T) {
 	}
 
 	// Reconcile Phase 5 (job-1 should be active/locking again)
-	queue.Add(groupID)
+	testQueue.Add(groupID)
 	err = waitWithTimeout(func() bool {
 		return testGroup.Spec().LockingJob() == "job-1" && testGroup.Spec().ActiveJob() == "job-1"
 	}, 3*time.Second)
@@ -835,10 +840,12 @@ func TestController_Reconcile_DeduceLoadedJob_Success(t *testing.T) {
 	lockStore := store.NewMemLockStore()
 	groupStore := store.NewGroupStore(lockStore)
 	jobStore := store.NewJobStore()
-	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.DefaultTypedControllerRateLimiter[string](),
-		workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-	)
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
 
 	groupID := "group-1"
 	nodeNames := []string{"node-1", "node-2"}
@@ -872,7 +879,7 @@ func TestController_Reconcile_DeduceLoadedJob_Success(t *testing.T) {
 		},
 	}
 
-	c := controller.NewController(groupStore, jobStore, queue, mockOrch, &controller.MockSnapshotAgentStore{})
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, &controller.MockSnapshotAgentStore{})
 
 	go func() {
 		if err := c.Run(ctx, 1); err != nil {
@@ -880,9 +887,9 @@ func TestController_Reconcile_DeduceLoadedJob_Success(t *testing.T) {
 		}
 	}()
 
-	queue.Add(groupID)
+	testQueue.Add(groupID)
 
-	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 2*time.Second)
+	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
 	if err != nil {
 		t.Fatalf("Timed out waiting for reconcile: %v", err)
 	}
@@ -1015,10 +1022,12 @@ func TestController_Reconcile_DeduceLoadedJob_RunningAndUnspecified(t *testing.T
 	lockStore := store.NewMemLockStore()
 	groupStore := store.NewGroupStore(lockStore)
 	jobStore := store.NewJobStore()
-	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.DefaultTypedControllerRateLimiter[string](),
-		workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-	)
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
 
 	groupID := "group-1"
 	nodeNames := []string{"node-1", "node-2"}
@@ -1043,7 +1052,7 @@ func TestController_Reconcile_DeduceLoadedJob_RunningAndUnspecified(t *testing.T
 		},
 	}
 
-	c := controller.NewController(groupStore, jobStore, queue, mockOrch, &controller.MockSnapshotAgentStore{})
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, &controller.MockSnapshotAgentStore{})
 
 	go func() {
 		if err := c.Run(ctx, 1); err != nil {
@@ -1051,9 +1060,9 @@ func TestController_Reconcile_DeduceLoadedJob_RunningAndUnspecified(t *testing.T
 		}
 	}()
 
-	queue.Add(groupID)
+	testQueue.Add(groupID)
 
-	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 2*time.Second)
+	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
 	if err != nil {
 		t.Fatalf("Timed out waiting for reconcile: %v", err)
 	}
@@ -1261,10 +1270,12 @@ func TestController_Reconcile_DeduceLoadedJob_AllUnspecified(t *testing.T) {
 	lockStore := store.NewMemLockStore()
 	groupStore := store.NewGroupStore(lockStore)
 	jobStore := store.NewJobStore()
-	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.DefaultTypedControllerRateLimiter[string](),
-		workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-	)
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
 
 	groupID := "group-1"
 	nodeNames := []string{"node-1", "node-2"}
@@ -1297,7 +1308,7 @@ func TestController_Reconcile_DeduceLoadedJob_AllUnspecified(t *testing.T) {
 		},
 	}
 
-	c := controller.NewController(groupStore, jobStore, queue, mockOrch, &controller.MockSnapshotAgentStore{})
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, &controller.MockSnapshotAgentStore{})
 
 	go func() {
 		if err := c.Run(ctx, 1); err != nil {
@@ -1305,9 +1316,9 @@ func TestController_Reconcile_DeduceLoadedJob_AllUnspecified(t *testing.T) {
 		}
 	}()
 
-	queue.Add(groupID)
+	testQueue.Add(groupID)
 
-	err = waitWithTimeout(func() bool { return queue.Len() == 0 }, 2*time.Second)
+	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
 	if err != nil {
 		t.Fatalf("Timed out waiting for reconcile: %v", err)
 	}

--- a/pkg/accelerator-orchestrator/server/server.go
+++ b/pkg/accelerator-orchestrator/server/server.go
@@ -71,6 +71,9 @@ func (s *Server) Acquire(ctx context.Context, req *pb.AcquireRequest) (*pb.Acqui
 
 	// 2. Request Lock
 	group.Spec().RequestLock(jobID)
+	if s.ctrl != nil {
+		s.ctrl.EnqueueWork(groupID)
+	}
 
 	// 3. Wait Loop
 	ticker := time.NewTicker(acquirePollInterval)
@@ -148,6 +151,10 @@ func (s *Server) Yield(ctx context.Context, req *pb.YieldRequest) (*pb.YieldResp
 			return nil, status.Errorf(codes.PermissionDenied, "job %s does not hold lock for group %s", jobID, groupID)
 		}
 		return nil, status.Errorf(codes.Internal, "failed to yield: %v", err)
+	}
+
+	if s.ctrl != nil {
+		s.ctrl.EnqueueWork(groupID)
 	}
 
 	// 4. Construct Response from Snapshot

--- a/pkg/accelerator-orchestrator/server/server_test.go
+++ b/pkg/accelerator-orchestrator/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/api/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/controller"
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/server"
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/store"
 	"google.golang.org/grpc"
@@ -22,17 +23,20 @@ const bufSize = 1024 * 1024
 
 var lis *bufconn.Listener
 
-func initGRPCServer(groupStore server.GroupStore, jobStore server.JobStore) func() {
+//nolint:gocritic // Conflict with nonamedreturns linter
+func initGRPCServer(groupStore server.GroupStore, jobStore server.JobStore) (*mockWorkQueue, func()) {
 	lis = bufconn.Listen(bufSize)
 	s := grpc.NewServer()
-	pb.RegisterAcceleratorOrchestratorServiceServer(s, server.NewServer(nil, groupStore, jobStore))
+	mq := &mockWorkQueue{}
+	ctrl := controller.NewController(nil, nil, mq, nil, nil)
+	pb.RegisterAcceleratorOrchestratorServiceServer(s, server.NewServer(ctrl, groupStore, jobStore))
 	go func() {
 		if err := s.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
 			slog.Error("Server exited with error", "error", err)
 			panic(err)
 		}
 	}()
-	return func() {
+	return mq, func() {
 		s.GracefulStop()
 		lis.Close()
 	}
@@ -82,13 +86,14 @@ func bufDialer(context.Context, string) (net.Conn, error) {
 
 func TestServer_Acquire(t *testing.T) {
 	tests := []struct {
-		name         string
-		setupStores  func(t *testing.T, ctx context.Context) (server.GroupStore, server.JobStore)
-		groupID      string
-		jobID        string
-		timeout      time.Duration
-		expectedCode codes.Code
-		verify       func(t *testing.T, resp *pb.AcquireResponse, err error)
+		name          string
+		setupStores   func(t *testing.T, ctx context.Context) (server.GroupStore, server.JobStore)
+		groupID       string
+		jobID         string
+		timeout       time.Duration
+		expectedCode  codes.Code
+		verify        func(t *testing.T, resp *pb.AcquireResponse, err error)
+		expectEnqueue bool
 	}{
 		{
 			name: "group not found",
@@ -117,9 +122,10 @@ func TestServer_Acquire(t *testing.T) {
 				}
 				return gs, js
 			},
-			groupID:      "group-1",
-			jobID:        "job-1",
-			expectedCode: codes.Unavailable,
+			groupID:       "group-1",
+			jobID:         "job-1",
+			expectedCode:  codes.Unavailable,
+			expectEnqueue: true,
 		},
 		{
 			name: "timeout waiting for load",
@@ -132,10 +138,11 @@ func TestServer_Acquire(t *testing.T) {
 				}
 				return gs, store.NewJobStore()
 			},
-			groupID:      "group-1",
-			jobID:        "job-1",
-			timeout:      100 * time.Millisecond,
-			expectedCode: codes.DeadlineExceeded,
+			groupID:       "group-1",
+			jobID:         "job-1",
+			timeout:       100 * time.Millisecond,
+			expectedCode:  codes.DeadlineExceeded,
+			expectEnqueue: true,
 		},
 		{
 			name: "success after wait",
@@ -155,9 +162,10 @@ func TestServer_Acquire(t *testing.T) {
 
 				return gs, store.NewJobStore()
 			},
-			groupID:      "group-1",
-			jobID:        "job-1",
-			expectedCode: codes.OK,
+			groupID:       "group-1",
+			jobID:         "job-1",
+			expectedCode:  codes.OK,
+			expectEnqueue: true,
 			verify: func(t *testing.T, resp *pb.AcquireResponse, err error) {
 				t.Helper()
 				if err != nil {
@@ -184,7 +192,7 @@ func TestServer_Acquire(t *testing.T) {
 			}
 			gs, js := tc.setupStores(t, serverCtx)
 
-			cleanup := initGRPCServer(gs, js)
+			mq, cleanup := initGRPCServer(gs, js)
 			defer cleanup()
 			conn, err := grpc.NewClient(
 				"passthrough:///bufnet",
@@ -201,6 +209,16 @@ func TestServer_Acquire(t *testing.T) {
 				GroupId: tc.groupID,
 				JobId:   tc.jobID,
 			})
+
+			if tc.expectEnqueue {
+				if len(mq.added) != 1 || mq.added[0] != tc.groupID {
+					t.Errorf("expected group %s to be enqueued, got %v", tc.groupID, mq.added)
+				}
+			} else {
+				if len(mq.added) != 0 {
+					t.Errorf("expected no enqueue, got %v", mq.added)
+				}
+			}
 
 			if tc.expectedCode != codes.OK {
 				if err == nil {
@@ -225,12 +243,13 @@ func TestServer_Acquire(t *testing.T) {
 
 func TestServer_Yield(t *testing.T) {
 	tests := []struct {
-		name         string
-		setupStores  func(t *testing.T, ctx context.Context) (server.GroupStore, server.JobStore)
-		groupID      string
-		jobID        string
-		expectedCode codes.Code
-		verify       func(t *testing.T, resp *pb.YieldResponse, err error)
+		name          string
+		setupStores   func(t *testing.T, ctx context.Context) (server.GroupStore, server.JobStore)
+		groupID       string
+		jobID         string
+		expectedCode  codes.Code
+		verify        func(t *testing.T, resp *pb.YieldResponse, err error)
+		expectEnqueue bool
 	}{
 		{
 			name: "group not found",
@@ -277,9 +296,10 @@ func TestServer_Yield(t *testing.T) {
 				}
 				return gs, store.NewJobStore()
 			},
-			groupID:      "group-1",
-			jobID:        "job-1",
-			expectedCode: codes.OK,
+			groupID:       "group-1",
+			jobID:         "job-1",
+			expectedCode:  codes.OK,
+			expectEnqueue: true,
 			verify: func(t *testing.T, resp *pb.YieldResponse, err error) {
 				t.Helper()
 				if err != nil {
@@ -313,9 +333,10 @@ func TestServer_Yield(t *testing.T) {
 				g.Spec().RequestLock("job-2")
 				return gs, store.NewJobStore()
 			},
-			groupID:      "group-1",
-			jobID:        "job-1",
-			expectedCode: codes.OK,
+			groupID:       "group-1",
+			jobID:         "job-1",
+			expectedCode:  codes.OK,
+			expectEnqueue: true,
 			verify: func(t *testing.T, resp *pb.YieldResponse, err error) {
 				t.Helper()
 				if err != nil {
@@ -339,7 +360,7 @@ func TestServer_Yield(t *testing.T) {
 			ctx := context.Background()
 			gs, js := tc.setupStores(t, ctx)
 
-			cleanup := initGRPCServer(gs, js)
+			mq, cleanup := initGRPCServer(gs, js)
 			defer cleanup()
 			conn, err := grpc.NewClient(
 				"passthrough:///bufnet",
@@ -356,6 +377,16 @@ func TestServer_Yield(t *testing.T) {
 				GroupId: tc.groupID,
 				JobId:   tc.jobID,
 			})
+
+			if tc.expectEnqueue {
+				if len(mq.added) != 1 || mq.added[0] != tc.groupID {
+					t.Errorf("expected group %s to be enqueued, got %v", tc.groupID, mq.added)
+				}
+			} else {
+				if len(mq.added) != 0 {
+					t.Errorf("expected no enqueue, got %v", mq.added)
+				}
+			}
 
 			if tc.expectedCode != codes.OK {
 				if err == nil {
@@ -432,7 +463,7 @@ func TestServer_ListGroups(t *testing.T) {
 			ctx := context.Background()
 			gs := tc.setupStore(t, ctx)
 
-			cleanup := initGRPCServer(gs, nil)
+			_, cleanup := initGRPCServer(gs, nil)
 			defer cleanup()
 			conn, err := grpc.NewClient(
 				"passthrough:///bufnet",
@@ -668,7 +699,7 @@ func TestServer_GetGroupStatus(t *testing.T) {
 			ctx := context.Background()
 			gs, js := tc.setupStores(t, ctx)
 
-			cleanup := initGRPCServer(gs, js)
+			_, cleanup := initGRPCServer(gs, js)
 			defer cleanup()
 			conn, err := grpc.NewClient(
 				"passthrough:///bufnet",
@@ -707,3 +738,17 @@ func TestServer_GetGroupStatus(t *testing.T) {
 		})
 	}
 }
+
+type mockWorkQueue struct {
+	controller.WorkQueue
+	added []string
+}
+
+func (m *mockWorkQueue) Add(groupID string) {
+	m.added = append(m.added, groupID)
+}
+func (m *mockWorkQueue) AddRateLimited(groupID string) {}
+func (m *mockWorkQueue) Forget(groupID string)         {}
+func (m *mockWorkQueue) Done(groupID string)           {}
+func (m *mockWorkQueue) Get() (string, bool)           { return "", false }
+func (m *mockWorkQueue) ShutDown()                     {}

--- a/pkg/accelerator-orchestrator/server/server_test.go
+++ b/pkg/accelerator-orchestrator/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"net"
+	"sync"
 	"testing"
 	"time"
 
@@ -210,13 +211,14 @@ func TestServer_Acquire(t *testing.T) {
 				JobId:   tc.jobID,
 			})
 
+			added := mq.GetAdded()
 			if tc.expectEnqueue {
-				if len(mq.added) != 1 || mq.added[0] != tc.groupID {
-					t.Errorf("expected group %s to be enqueued, got %v", tc.groupID, mq.added)
+				if len(added) != 1 || added[0] != tc.groupID {
+					t.Errorf("expected group %s to be enqueued, got %v", tc.groupID, added)
 				}
 			} else {
-				if len(mq.added) != 0 {
-					t.Errorf("expected no enqueue, got %v", mq.added)
+				if len(added) != 0 {
+					t.Errorf("expected no enqueue, got %v", added)
 				}
 			}
 
@@ -378,13 +380,14 @@ func TestServer_Yield(t *testing.T) {
 				JobId:   tc.jobID,
 			})
 
+			added := mq.GetAdded()
 			if tc.expectEnqueue {
-				if len(mq.added) != 1 || mq.added[0] != tc.groupID {
-					t.Errorf("expected group %s to be enqueued, got %v", tc.groupID, mq.added)
+				if len(added) != 1 || added[0] != tc.groupID {
+					t.Errorf("expected group %s to be enqueued, got %v", tc.groupID, added)
 				}
 			} else {
-				if len(mq.added) != 0 {
-					t.Errorf("expected no enqueue, got %v", mq.added)
+				if len(added) != 0 {
+					t.Errorf("expected no enqueue, got %v", added)
 				}
 			}
 
@@ -741,12 +744,24 @@ func TestServer_GetGroupStatus(t *testing.T) {
 
 type mockWorkQueue struct {
 	controller.WorkQueue
+	mu    sync.Mutex
 	added []string
 }
 
 func (m *mockWorkQueue) Add(groupID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
 	m.added = append(m.added, groupID)
 }
+
+func (m *mockWorkQueue) GetAdded() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]string, len(m.added))
+	copy(cp, m.added)
+	return cp
+}
+
 func (m *mockWorkQueue) AddRateLimited(groupID string) {}
 func (m *mockWorkQueue) Forget(groupID string)         {}
 func (m *mockWorkQueue) Done(groupID string)           {}


### PR DESCRIPTION
## What does this PR do?

Add work trigger for yield and acquire. This is needed for the init phase so lock can be processed even though there are no node updates or pod updates yet.

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed - found and fixed in e2e testing (a different PR)

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
