### PR TITLE
Fix project sync workflow: use vars context and add reopened trigger

### DIFF
--- a/.github/workflows/project-sync.yaml
+++ b/.github/workflows/project-sync.yaml
@@ -9,14 +9,11 @@ on:
   pull_request:
     types: [opened, ready_for_review, review_requested]
   issues:
-    types: [opened]
-
-env:
-  ENABLED: ${{ vars.ENABLE_PROJECT_SYNC != 'false' }}
+    types: [opened, reopened]
 
 jobs:
   sync-pr-review-status:
-    if: env.ENABLED == 'true' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_review')
+    if: vars.ENABLE_PROJECT_SYNC != 'false' && (github.event_name == 'pull_request' || github.event_name == 'pull_request_review')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7
@@ -124,7 +121,7 @@ jobs:
             core.info(`Updated PR #${pr.number} to "${status}"`);
 
   add-issue-to-project:
-    if: env.ENABLED == 'true' && github.event_name == 'issues'
+    if: vars.ENABLE_PROJECT_SYNC != 'false' && github.event_name == 'issues'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/github-script@v7


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and their purpose -->

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
