### PR TITLE
consider IDLE a context loaded state for init

### DIFF
--- a/pkg/accelerator-orchestrator/controller/controller.go
+++ b/pkg/accelerator-orchestrator/controller/controller.go
@@ -268,7 +268,8 @@ func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activ
 
 	// 3. Ensure no other jobs have their context loaded
 	for jobID, state := range agentJobStates {
-		if jobID == activeJobID || state != pb.SnapshotAgentJobState_STATE_RUNNING {
+		isLoaded := state == pb.SnapshotAgentJobState_STATE_RUNNING || state == pb.SnapshotAgentJobState_STATE_IDLE
+		if jobID == activeJobID || !isLoaded {
 			continue
 		}
 
@@ -366,7 +367,7 @@ func (c *Controller) isJobLoaded(ctx context.Context, group *store.Group, jobID 
 		}
 
 		switch state {
-		case pb.SnapshotAgentJobState_STATE_RUNNING:
+		case pb.SnapshotAgentJobState_STATE_RUNNING, pb.SnapshotAgentJobState_STATE_IDLE:
 			// Safe, checked for conflicts already
 		case pb.SnapshotAgentJobState_STATE_UNSPECIFIED:
 			if nodeRunningJob[node] != "" {

--- a/pkg/accelerator-orchestrator/controller/controller_test.go
+++ b/pkg/accelerator-orchestrator/controller/controller_test.go
@@ -3,7 +3,6 @@ package controller_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"testing"
 	"time"
@@ -407,188 +406,6 @@ func TestController_Reconcile_OneJobLoopRemainsActive(t *testing.T) {
 	}
 }
 
-func TestController_Reconcile_TriggersSnapshot(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.DefaultTypedControllerRateLimiter[string](),
-		workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-	)
-
-	groupID := "group-1"
-	nodeName := "node-1"
-
-	// 1. Setup group and nodes
-	testGroup, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to create group: %v", err)
-	}
-	testGroup.Status().SetNodes([]string{nodeName})
-	// Set active job to job-1
-	testGroup.Spec().SetActiveJob("job-1")
-
-	// 2. Setup jobs in store
-	job1 := store.NewJob(groupID, "job-1")
-	job2 := store.NewJob(groupID, "job-2")
-	// job-2 is RUNNING on node-1, which is NOT the active job (job-1)
-	job2.UpdateContextState(nodeName, pb.SnapshotAgentJobState_STATE_RUNNING)
-
-	if err := jobStore.Put(ctx, job1); err != nil {
-		t.Fatalf("failed to put job1: %v", err)
-	}
-	if err := jobStore.Put(ctx, job2); err != nil {
-		t.Fatalf("failed to put job2: %v", err)
-	}
-
-	// 3. Mock SnapshotAgentStore to track calls
-	snapshotCalled := make(chan string, 1)
-	getStatusCalls := 0
-	mockAgentStore := &controller.MockSnapshotAgentStore{
-		GetStatusFunc: func(ctx context.Context, node string) (*agentpb.StatusResponse, error) {
-			if node == nodeName {
-				getStatusCalls++
-				state := agentpb.JobState_JOB_STATE_RUNNING
-				if getStatusCalls > 1 {
-					state = agentpb.JobState_JOB_STATE_SAVED
-				}
-				return &agentpb.StatusResponse{
-					JobStatuses: []*agentpb.JobStatus{
-						{JobId: "job-2", State: state},
-						{JobId: "job-1", State: agentpb.JobState_JOB_STATE_IDLE},
-					},
-				}, nil
-			}
-			return &agentpb.StatusResponse{}, nil
-		},
-		SnapshotFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.SnapshotResponse, error) {
-			if node == nodeName && jobID == "job-2" && gID == groupID {
-				snapshotCalled <- jobID
-			}
-			return &agentpb.SnapshotResponse{OperationId: "op-123"}, nil
-		},
-		OperationFunc: func(ctx context.Context, node, operationID string) (*agentpb.GetOperationResponse, error) {
-			if node == nodeName && operationID == "op-123" {
-				return &agentpb.GetOperationResponse{
-					Status: agentpb.OperationStatus_OPERATION_STATUS_COMPLETE,
-				}, nil
-			}
-			return &agentpb.GetOperationResponse{}, nil
-		},
-	}
-
-	mockOrch := &mockInfrastructureOrchestrator{
-		observeFunc: func(ctx context.Context, gID string) error {
-			// Do nothing, we already set up the state
-			return nil
-		},
-	}
-
-	c := controller.NewController(groupStore, jobStore, queue, mockOrch, mockAgentStore)
-
-	// Start the controller
-	go func() {
-		if err := c.Run(ctx, 1); err != nil {
-			t.Errorf("Controller Run failed: %v", err)
-		}
-	}()
-
-	// Trigger reconcile
-	queue.Add(groupID)
-
-	// Verify Snapshot was called
-	select {
-	case jobID := <-snapshotCalled:
-		if jobID != "job-2" {
-			t.Errorf("Expected snapshot to be called for job-2, got %s", jobID)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Timed out waiting for Snapshot to be called")
-	}
-
-	// Verify that the job state in store was refreshed to SAVED
-	err = waitWithTimeout(func() bool {
-		j, err := jobStore.Get(ctx, groupID, "job-2")
-		if err != nil {
-			return false
-		}
-		state, ok := j.ContextState()[nodeName]
-		return ok && state == pb.SnapshotAgentJobState_STATE_SAVED
-	}, 2*time.Second)
-	if err != nil {
-		t.Errorf("Timed out waiting for job-2 state to be refreshed to SAVED in store")
-	}
-}
-
-func TestController_Reconcile_ActiveJobFaultedFails(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	testQueue := &trackQueue{
-		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-		),
-	}
-
-	groupID := "group-1"
-	nodeName := "node-1"
-
-	// 1. Setup group and nodes
-	testGroup, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to create group: %v", err)
-	}
-	testGroup.Status().SetNodes([]string{nodeName})
-	testGroup.Spec().SetActiveJob("job-1")
-
-	// 2. Setup jobs in store
-	job1 := store.NewJob(groupID, "job-1")
-	// job-1 (active) is FAULTED on node-1
-	job1.UpdateContextState(nodeName, pb.SnapshotAgentJobState_STATE_FAULTED)
-
-	if err := jobStore.Put(ctx, job1); err != nil {
-		t.Fatalf("failed to put job1: %v", err)
-	}
-
-	mockAgentStore := &controller.MockSnapshotAgentStore{}
-	mockOrch := &mockInfrastructureOrchestrator{
-		observeFunc: func(ctx context.Context, gID string) error {
-			return nil
-		},
-	}
-
-	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
-
-	// Start the controller
-	go func() {
-		if err := c.Run(ctx, 1); err != nil {
-			t.Errorf("Controller Run failed: %v", err)
-		}
-	}()
-
-	// Trigger reconcile
-	testQueue.Add(groupID)
-
-	// Verify that it failed and was re-queued (AddRateLimited called)
-	err = waitWithTimeout(func() bool {
-		return testQueue.getAddRateLimitedCount() > 0
-	}, 2*time.Second)
-	if err != nil {
-		t.Fatal("Timed out waiting for item to be re-queued (reconciliation should have failed)")
-	}
-
-	if testQueue.getAddRateLimitedCount() < 1 {
-		t.Errorf("Expected AddRateLimited to be called at least once, got %d", testQueue.getAddRateLimitedCount())
-	}
-}
-
 func TestController_ObserveJobContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -649,851 +466,419 @@ func TestController_ObserveJobContext(t *testing.T) {
 	}
 }
 
-func TestController_Reconcile_TriggersRestore(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+type reconcileTestCase struct {
+	name         string
+	activeJobID  string
+	lockingJobID string
+	initialJobs  []*store.Job
+	nodes        []string
 
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	queue := workqueue.NewTypedRateLimitingQueueWithConfig(
-		workqueue.DefaultTypedControllerRateLimiter[string](),
-		workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-	)
+	// Mock Agent Behavior
+	initialAgentStatuses map[string][]*agentpb.JobStatus
+	postOpAgentStatuses  map[string][]*agentpb.JobStatus
 
-	groupID := "group-1"
-	nodeName := "node-1"
+	// Expected Actions
+	expectedSnapshotJob  string
+	expectedSnapshotNode string
+	expectedRestoreJob   string
+	expectedRestoreNode  string
 
-	// 1. Setup group and nodes
-	testGroup, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to create group: %v", err)
+	// Expected Outcomes
+	expectedLoadedJob  string
+	expectedGroupState pb.GroupStatus_State
+	expectFailure      bool
+}
+
+func TestController_Reconcile(t *testing.T) {
+	// Helper to make jobs easily in table definition
+	makeJob := func(groupID, jobID string, nodeStates map[string]pb.SnapshotAgentJobState_State) *store.Job {
+		j := store.NewJob(groupID, jobID)
+		for node, state := range nodeStates {
+			j.UpdateContextState(node, state)
+		}
+		return j
 	}
-	testGroup.Status().SetNodes([]string{nodeName})
-	testGroup.Spec().SetActiveJob("job-1")
 
-	// 2. Setup jobs in store
-	job1 := store.NewJob(groupID, "job-1")
-	job1.UpdateContextState(nodeName, pb.SnapshotAgentJobState_STATE_SAVED)
-
-	if err := jobStore.Put(ctx, job1); err != nil {
-		t.Fatalf("failed to put job1: %v", err)
+	testCases := []reconcileTestCase{
+		{
+			name:        "Snapshot_EvictRunningJob_1Node",
+			activeJobID: "job-1",
+			nodes:       []string{"node-1"},
+			initialJobs: []*store.Job{
+				makeJob("group-1", "job-1", nil),
+				makeJob("group-1", "job-2", map[string]pb.SnapshotAgentJobState_State{"node-1": pb.SnapshotAgentJobState_STATE_RUNNING}),
+			},
+			initialAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-1": {
+					{JobId: "job-2", State: agentpb.JobState_JOB_STATE_RUNNING},
+					{JobId: "job-1", State: agentpb.JobState_JOB_STATE_IDLE},
+				},
+			},
+			postOpAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-1": {
+					{JobId: "job-2", State: agentpb.JobState_JOB_STATE_SAVED},
+					{JobId: "job-1", State: agentpb.JobState_JOB_STATE_IDLE},
+				},
+			},
+			expectedSnapshotJob:  "job-2",
+			expectedSnapshotNode: "node-1",
+			expectedLoadedJob:    "job-1",
+			expectedGroupState:   pb.GroupStatus_STATE_IDLE_YIELDED,
+		},
+		{
+			name:        "Error_ActiveJobFaulted",
+			activeJobID: "job-1",
+			nodes:       []string{"node-1"},
+			initialJobs: []*store.Job{
+				makeJob("group-1", "job-1", map[string]pb.SnapshotAgentJobState_State{"node-1": pb.SnapshotAgentJobState_STATE_FAULTED}),
+			},
+			expectFailure: true,
+		},
+		{
+			name:        "Restore_SavedActiveJob_1Node",
+			activeJobID: "job-1",
+			nodes:       []string{"node-1"},
+			initialJobs: []*store.Job{
+				makeJob("group-1", "job-1", map[string]pb.SnapshotAgentJobState_State{"node-1": pb.SnapshotAgentJobState_STATE_SAVED}),
+			},
+			initialAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-1": {
+					{JobId: "job-1", State: agentpb.JobState_JOB_STATE_SAVED},
+				},
+			},
+			postOpAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-1": {
+					{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING},
+				},
+			},
+			expectedRestoreJob:  "job-1",
+			expectedRestoreNode: "node-1",
+			expectedLoadedJob:   "job-1",
+			expectedGroupState:  pb.GroupStatus_STATE_IDLE_YIELDED,
+		},
+		{
+			name:        "NoOp_ActiveJobAlreadyRunning_1Node",
+			activeJobID: "job-1",
+			nodes:       []string{"node-1"},
+			initialJobs: []*store.Job{
+				makeJob("group-1", "job-1", map[string]pb.SnapshotAgentJobState_State{"node-1": pb.SnapshotAgentJobState_STATE_RUNNING}),
+			},
+			initialAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-1": {
+					{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING},
+				},
+			},
+			expectedLoadedJob:  "job-1",
+			expectedGroupState: pb.GroupStatus_STATE_IDLE_YIELDED,
+		},
+		{
+			name:        "NoOp_ActiveJobAlreadyRunning_2Nodes",
+			activeJobID: "job-1",
+			initialJobs: []*store.Job{
+				makeJob("group-1", "job-1", map[string]pb.SnapshotAgentJobState_State{
+					"node-1": pb.SnapshotAgentJobState_STATE_RUNNING,
+					"node-2": pb.SnapshotAgentJobState_STATE_RUNNING,
+				}),
+			},
+			initialAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-1": {{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING}},
+				"node-2": {{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING}},
+			},
+			expectedLoadedJob:  "job-1",
+			expectedGroupState: pb.GroupStatus_STATE_IDLE_YIELDED,
+		},
+		{
+			name:        "Restore_PartiallySavedActiveJob",
+			activeJobID: "job-1",
+			initialJobs: []*store.Job{
+				makeJob("group-1", "job-1", map[string]pb.SnapshotAgentJobState_State{
+					"node-1": pb.SnapshotAgentJobState_STATE_RUNNING,
+					"node-2": pb.SnapshotAgentJobState_STATE_SAVED,
+				}),
+			},
+			initialAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-1": {{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING}},
+				"node-2": {{JobId: "job-1", State: agentpb.JobState_JOB_STATE_SAVED}},
+			},
+			postOpAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-2": {{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING}},
+			},
+			expectedRestoreJob:  "job-1",
+			expectedRestoreNode: "node-2",
+			expectedLoadedJob:   "job-1",
+			expectedGroupState:  pb.GroupStatus_STATE_IDLE_YIELDED,
+		},
+		{
+			name:        "NoOp_NewActiveJobNoRestore",
+			activeJobID: "job-1",
+			initialJobs: []*store.Job{
+				makeJob("group-1", "job-1", map[string]pb.SnapshotAgentJobState_State{
+					"node-1": pb.SnapshotAgentJobState_STATE_RUNNING,
+				}),
+			},
+			initialAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-1": {{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING}},
+				"node-2": {},
+			},
+			expectedLoadedJob:  "job-1",
+			expectedGroupState: pb.GroupStatus_STATE_IDLE_YIELDED,
+		},
+		{
+			name:        "Snapshot_EvictRunningForActiveJob",
+			activeJobID: "job-1",
+			initialJobs: []*store.Job{
+				makeJob("group-1", "job-1", map[string]pb.SnapshotAgentJobState_State{
+					"node-1": pb.SnapshotAgentJobState_STATE_RUNNING,
+				}),
+				makeJob("group-1", "job-2", map[string]pb.SnapshotAgentJobState_State{
+					"node-2": pb.SnapshotAgentJobState_STATE_RUNNING,
+				}),
+			},
+			initialAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-1": {{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING}},
+				"node-2": {{JobId: "job-2", State: agentpb.JobState_JOB_STATE_RUNNING}},
+			},
+			postOpAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-2": {{JobId: "job-2", State: agentpb.JobState_JOB_STATE_SAVED}},
+			},
+			expectedSnapshotJob:  "job-2",
+			expectedSnapshotNode: "node-2",
+			expectedLoadedJob:    "job-1",
+			expectedGroupState:   pb.GroupStatus_STATE_IDLE_YIELDED,
+		},
+		{
+			name:        "Snapshot_EvictIdleForActiveJob",
+			activeJobID: "job-1",
+			initialJobs: []*store.Job{
+				makeJob("group-1", "job-1", map[string]pb.SnapshotAgentJobState_State{
+					"node-1": pb.SnapshotAgentJobState_STATE_RUNNING,
+				}),
+				makeJob("group-1", "job-2", map[string]pb.SnapshotAgentJobState_State{
+					"node-2": pb.SnapshotAgentJobState_STATE_IDLE,
+				}),
+			},
+			initialAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-1": {{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING}},
+				"node-2": {{JobId: "job-2", State: agentpb.JobState_JOB_STATE_IDLE}},
+			},
+			postOpAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-2": {{JobId: "job-2", State: agentpb.JobState_JOB_STATE_SAVED}},
+			},
+			expectedSnapshotJob:  "job-2",
+			expectedSnapshotNode: "node-2",
+			expectedLoadedJob:    "job-1",
+			expectedGroupState:   pb.GroupStatus_STATE_IDLE_YIELDED,
+		},
+		{
+			name:        "Error_MultipleRunningJobsOnNode",
+			activeJobID: "job-1",
+			initialJobs: []*store.Job{
+				makeJob("group-1", "job-1", map[string]pb.SnapshotAgentJobState_State{
+					"node-1": pb.SnapshotAgentJobState_STATE_RUNNING,
+					"node-2": pb.SnapshotAgentJobState_STATE_SAVED,
+				}),
+				makeJob("group-1", "job-2", map[string]pb.SnapshotAgentJobState_State{
+					"node-2": pb.SnapshotAgentJobState_STATE_RUNNING,
+				}),
+			},
+			initialAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-1": {{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING}},
+				"node-2": {
+					{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING},
+					{JobId: "job-2", State: agentpb.JobState_JOB_STATE_RUNNING},
+				},
+			},
+			expectFailure: true,
+		},
+		{
+			name:               "NoOp_AllJobsUnspecified",
+			activeJobID:        "job-1",
+			expectedLoadedJob:  "job-1",
+			expectedGroupState: pb.GroupStatus_STATE_IDLE_YIELDED,
+		},
+		{
+			name:               "NoOp_NonExistentActiveJob",
+			activeJobID:        "job-1",
+			expectedLoadedJob:  "job-1",
+			expectedGroupState: pb.GroupStatus_STATE_IDLE_YIELDED,
+		},
+		{
+			name:        "Snapshot_EvictRunningForNewActiveJob",
+			activeJobID: "job-1",
+			initialJobs: []*store.Job{
+				makeJob("group-1", "job-2", map[string]pb.SnapshotAgentJobState_State{
+					"node-2": pb.SnapshotAgentJobState_STATE_RUNNING,
+				}),
+			},
+			initialAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-2": {{JobId: "job-2", State: agentpb.JobState_JOB_STATE_RUNNING}},
+			},
+			postOpAgentStatuses: map[string][]*agentpb.JobStatus{
+				"node-2": {{JobId: "job-2", State: agentpb.JobState_JOB_STATE_SAVED}},
+			},
+			expectedSnapshotJob:  "job-2",
+			expectedSnapshotNode: "node-2",
+			expectedLoadedJob:    "job-1",
+			expectedGroupState:   pb.GroupStatus_STATE_IDLE_YIELDED,
+		},
 	}
 
-	// 3. Mock SnapshotAgentStore to track calls
-	restoreCalled := make(chan string, 1)
-	getStatusCalls := 0
-	mockAgentStore := &controller.MockSnapshotAgentStore{
-		GetStatusFunc: func(ctx context.Context, node string) (*agentpb.StatusResponse, error) {
-			if node == nodeName {
-				getStatusCalls++
-				state := agentpb.JobState_JOB_STATE_SAVED
-				if getStatusCalls > 1 {
-					state = agentpb.JobState_JOB_STATE_RUNNING
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			lockStore := store.NewMemLockStore()
+			groupStore := store.NewGroupStore(lockStore)
+			jobStore := store.NewJobStore()
+			testQueue := &trackQueue{
+				TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+					workqueue.DefaultTypedControllerRateLimiter[string](),
+					workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+				),
+			}
+
+			groupID := "group-1"
+			nodes := tc.nodes
+			if len(nodes) == 0 {
+				nodes = []string{"node-1", "node-2"}
+			}
+
+			// 1. Setup group and nodes
+			group, _, err := groupStore.GetOrCreate(ctx, groupID)
+			if err != nil {
+				t.Fatalf("failed to create group: %v", err)
+			}
+			group.Status().SetNodes(nodes)
+			if tc.activeJobID != "" {
+				group.Spec().SetActiveJob(tc.activeJobID)
+			}
+			if tc.lockingJobID != "" {
+				if err := lockStore.Lock(ctx, groupID, tc.lockingJobID); err != nil {
+					t.Fatalf("failed to lock: %v", err)
 				}
-				return &agentpb.StatusResponse{
-					JobStatuses: []*agentpb.JobStatus{
-						{JobId: "job-1", State: state},
-					},
-				}, nil
+				group.Spec().RequestLock(tc.lockingJobID)
 			}
-			return &agentpb.StatusResponse{}, nil
-		},
-		RestoreFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.RestoreResponse, error) {
-			if node == nodeName && jobID == "job-1" && gID == groupID {
-				restoreCalled <- jobID
-			}
-			return &agentpb.RestoreResponse{OperationId: "op-123"}, nil
-		},
-		OperationFunc: func(ctx context.Context, node, operationID string) (*agentpb.GetOperationResponse, error) {
-			if node == nodeName && operationID == "op-123" {
-				return &agentpb.GetOperationResponse{
-					Status: agentpb.OperationStatus_OPERATION_STATUS_COMPLETE,
-				}, nil
-			}
-			return &agentpb.GetOperationResponse{}, nil
-		},
-	}
 
-	mockOrch := &mockInfrastructureOrchestrator{
-		observeFunc: func(ctx context.Context, gID string) error {
-			return nil
-		},
-	}
-
-	c := controller.NewController(groupStore, jobStore, queue, mockOrch, mockAgentStore)
-
-	// Start the controller
-	go func() {
-		if err := c.Run(ctx, 1); err != nil {
-			t.Errorf("Controller Run failed: %v", err)
-		}
-	}()
-
-	// Trigger reconcile
-	queue.Add(groupID)
-
-	// Verify Restore was called
-	select {
-	case jobID := <-restoreCalled:
-		if jobID != "job-1" {
-			t.Errorf("Expected restore to be called for job-1, got %s", jobID)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Timed out waiting for Restore to be called")
-	}
-
-	// Verify that the job state in store was refreshed to RUNNING
-	err = waitWithTimeout(func() bool {
-		j, err := jobStore.Get(ctx, groupID, "job-1")
-		if err != nil {
-			return false
-		}
-		state, ok := j.ContextState()[nodeName]
-		return ok && state == pb.SnapshotAgentJobState_STATE_RUNNING
-	}, 2*time.Second)
-	if err != nil {
-		t.Errorf("Timed out waiting for job-1 state to be refreshed to RUNNING in store")
-	}
-}
-
-func TestController_Reconcile_ActiveJobAlreadyRunningExitsEarly(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	testQueue := &trackQueue{
-		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-		),
-	}
-
-	groupID := "group-1"
-	nodeName := "node-1"
-
-	// 1. Setup group and nodes
-	testGroup, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to create group: %v", err)
-	}
-	testGroup.Status().SetNodes([]string{nodeName})
-	testGroup.Spec().SetActiveJob("job-1")
-
-	// 2. Setup jobs in store
-	job1 := store.NewJob(groupID, "job-1")
-	job1.UpdateContextState(nodeName, pb.SnapshotAgentJobState_STATE_RUNNING)
-
-	if err := jobStore.Put(ctx, job1); err != nil {
-		t.Fatalf("failed to put job1: %v", err)
-	}
-
-	// 3. Mock SnapshotAgentStore to fail if any disruptive action is taken.
-	mockAgentStore := &controller.MockSnapshotAgentStore{
-		SnapshotFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.SnapshotResponse, error) {
-			t.Errorf("Unexpected call to Snapshot")
-			return nil, fmt.Errorf("unexpected call")
-		},
-		RestoreFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.RestoreResponse, error) {
-			t.Errorf("Unexpected call to Restore")
-			return nil, fmt.Errorf("unexpected call")
-		},
-	}
-
-	mockOrch := &mockInfrastructureOrchestrator{
-		observeFunc: func(ctx context.Context, gID string) error {
-			return nil
-		},
-	}
-
-	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
-
-	// Start the controller
-	go func() {
-		if err := c.Run(ctx, 1); err != nil {
-			t.Errorf("Controller Run failed: %v", err)
-		}
-	}()
-
-	// Trigger reconcile
-	testQueue.Add(groupID)
-
-	// Verify that it finished successfully (Done called)
-	err = waitWithTimeout(func() bool {
-		return testQueue.getDoneCount() > 0
-	}, 2*time.Second)
-	if err != nil {
-		t.Fatal("Timed out waiting for item to be processed (Done should have been called)")
-	}
-
-	if testQueue.getDoneCount() != 1 {
-		t.Errorf("Expected Done to be called exactly once, got %d", testQueue.getDoneCount())
-	}
-}
-
-func TestController_Reconcile_DeduceLoadedJob_Success(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	testQueue := &trackQueue{
-		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-		),
-	}
-
-	groupID := "group-1"
-	nodeNames := []string{"node-1", "node-2"}
-
-	group, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to create group: %v", err)
-	}
-	group.Status().SetNodes(nodeNames)
-	group.Spec().SetActiveJob("job-1")
-
-	// job-1 is running on all nodes
-	job1 := store.NewJob(groupID, "job-1")
-	job1.UpdateContextState("node-1", pb.SnapshotAgentJobState_STATE_RUNNING)
-	job1.UpdateContextState("node-2", pb.SnapshotAgentJobState_STATE_RUNNING)
-	if err := jobStore.Put(ctx, job1); err != nil {
-		t.Fatalf("failed to put job1: %v", err)
-	}
-
-	// job-2 is saved on all nodes
-	job2 := store.NewJob(groupID, "job-2")
-	job2.UpdateContextState("node-1", pb.SnapshotAgentJobState_STATE_SAVED)
-	job2.UpdateContextState("node-2", pb.SnapshotAgentJobState_STATE_SAVED)
-	if err := jobStore.Put(ctx, job2); err != nil {
-		t.Fatalf("failed to put job2: %v", err)
-	}
-
-	mockOrch := &mockInfrastructureOrchestrator{
-		observeFunc: func(ctx context.Context, gID string) error {
-			return nil
-		},
-	}
-
-	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, &controller.MockSnapshotAgentStore{})
-
-	go func() {
-		if err := c.Run(ctx, 1); err != nil {
-			t.Errorf("Controller Run failed: %v", err)
-		}
-	}()
-
-	testQueue.Add(groupID)
-
-	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
-	if err != nil {
-		t.Fatalf("Timed out waiting for reconcile: %v", err)
-	}
-
-	if group.Status().LoadedJob() != "job-1" {
-		t.Errorf("Expected loadedJob to be 'job-1', got %q", group.Status().LoadedJob())
-	}
-	state, _ := group.Status().State()
-	if state != pb.GroupStatus_STATE_IDLE_YIELDED {
-		t.Errorf("Expected state to be STATE_IDLE_YIELDED, got %v", state)
-	}
-}
-
-func TestController_Reconcile_DeduceLoadedJob_PartiallyLoaded(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	testQueue := &trackQueue{
-		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-		),
-	}
-
-	groupID := "group-1"
-	nodeNames := []string{"node-1", "node-2"}
-
-	group, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to create group: %v", err)
-	}
-	group.Status().SetNodes(nodeNames)
-	group.Spec().SetActiveJob("job-1")
-
-	// job-1 is running on node-1, but saved on node-2
-	job1 := store.NewJob(groupID, "job-1")
-	job1.UpdateContextState("node-1", pb.SnapshotAgentJobState_STATE_RUNNING)
-	job1.UpdateContextState("node-2", pb.SnapshotAgentJobState_STATE_SAVED)
-	if err := jobStore.Put(ctx, job1); err != nil {
-		t.Fatalf("failed to put job1: %v", err)
-	}
-
-	restoreCalled := make(chan string, 1)
-	getStatusCallsNode2 := 0
-	mockAgentStore := &controller.MockSnapshotAgentStore{
-		GetStatusFunc: func(ctx context.Context, node string) (*agentpb.StatusResponse, error) {
-			if node == "node-1" {
-				return &agentpb.StatusResponse{
-					JobStatuses: []*agentpb.JobStatus{
-						{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING},
-					},
-				}, nil
-			}
-			if node == "node-2" {
-				getStatusCallsNode2++
-				state := agentpb.JobState_JOB_STATE_SAVED
-				if getStatusCallsNode2 > 1 {
-					state = agentpb.JobState_JOB_STATE_RUNNING
+			// 2. Setup jobs in store
+			for _, job := range tc.initialJobs {
+				if err := jobStore.Put(ctx, job); err != nil {
+					t.Fatalf("failed to put job: %v", err)
 				}
-				return &agentpb.StatusResponse{
-					JobStatuses: []*agentpb.JobStatus{
-						{JobId: "job-1", State: state},
-					},
-				}, nil
 			}
-			return &agentpb.StatusResponse{}, nil
-		},
-		RestoreFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.RestoreResponse, error) {
-			if node == "node-2" && jobID == "job-1" && gID == groupID {
-				restoreCalled <- jobID
+
+			// 3. Mock SnapshotAgentStore
+			snapshotCalled := make(chan string, 1)
+			restoreCalled := make(chan string, 1)
+
+			callsPerNode := make(map[string]int)
+			var mu sync.Mutex
+
+			mockAgentStore := &controller.MockSnapshotAgentStore{
+				GetStatusFunc: func(ctx context.Context, node string) (*agentpb.StatusResponse, error) {
+					mu.Lock()
+					callsPerNode[node]++
+					count := callsPerNode[node]
+					mu.Unlock()
+
+					if count > 1 && tc.postOpAgentStatuses != nil {
+						if statuses, ok := tc.postOpAgentStatuses[node]; ok {
+							return &agentpb.StatusResponse{JobStatuses: statuses}, nil
+						}
+					}
+
+					if tc.initialAgentStatuses != nil {
+						if statuses, ok := tc.initialAgentStatuses[node]; ok {
+							return &agentpb.StatusResponse{JobStatuses: statuses}, nil
+						}
+					}
+					return &agentpb.StatusResponse{}, nil
+				},
+				SnapshotFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.SnapshotResponse, error) {
+					if node == tc.expectedSnapshotNode && jobID == tc.expectedSnapshotJob && gID == groupID {
+						snapshotCalled <- jobID
+					}
+					return &agentpb.SnapshotResponse{OperationId: "op-123"}, nil
+				},
+				RestoreFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.RestoreResponse, error) {
+					if node == tc.expectedRestoreNode && jobID == tc.expectedRestoreJob && gID == groupID {
+						restoreCalled <- jobID
+					}
+					return &agentpb.RestoreResponse{OperationId: "op-123"}, nil
+				},
+				OperationFunc: func(ctx context.Context, node, operationID string) (*agentpb.GetOperationResponse, error) {
+					if operationID == "op-123" {
+						return &agentpb.GetOperationResponse{
+							Status: agentpb.OperationStatus_OPERATION_STATUS_COMPLETE,
+						}, nil
+					}
+					return &agentpb.GetOperationResponse{}, nil
+				},
 			}
-			return &agentpb.RestoreResponse{OperationId: "op-123"}, nil
-		},
-		OperationFunc: func(ctx context.Context, node, operationID string) (*agentpb.GetOperationResponse, error) {
-			if node == "node-2" && operationID == "op-123" {
-				return &agentpb.GetOperationResponse{
-					Status: agentpb.OperationStatus_OPERATION_STATUS_COMPLETE,
-				}, nil
+
+			mockOrch := &mockInfrastructureOrchestrator{
+				observeFunc: func(ctx context.Context, gID string) error {
+					return nil
+				},
 			}
-			return &agentpb.GetOperationResponse{}, nil
-		},
-	}
 
-	mockOrch := &mockInfrastructureOrchestrator{
-		observeFunc: func(ctx context.Context, gID string) error {
-			return nil
-		},
-	}
+			c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
 
-	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
-
-	go func() {
-		if err := c.Run(ctx, 1); err != nil {
-			t.Errorf("Controller Run failed: %v", err)
-		}
-	}()
-
-	testQueue.Add(groupID)
-
-	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
-	if err != nil {
-		t.Fatalf("Timed out waiting for reconcile: %v", err)
-	}
-
-	select {
-	case jobID := <-restoreCalled:
-		if jobID != "job-1" {
-			t.Errorf("Expected restore to be called for job-1 on node-2, got %s", jobID)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Timed out waiting for Restore to be called")
-	}
-
-	if group.Status().LoadedJob() != "job-1" {
-		t.Errorf("Expected loadedJob to be 'job-1', got %q", group.Status().LoadedJob())
-	}
-	state, _ := group.Status().State()
-	if state != pb.GroupStatus_STATE_IDLE_YIELDED {
-		t.Errorf("Expected state to be STATE_IDLE_YIELDED, got %v", state)
-	}
-}
-
-func TestController_Reconcile_DeduceLoadedJob_RunningAndUnspecified(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	testQueue := &trackQueue{
-		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-		),
-	}
-
-	groupID := "group-1"
-	nodeNames := []string{"node-1", "node-2"}
-
-	group, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to create group: %v", err)
-	}
-	group.Status().SetNodes(nodeNames)
-	group.Spec().SetActiveJob("job-1")
-
-	// job-1 is running on node-1, but UNSPECIFIED on node-2
-	job1 := store.NewJob(groupID, "job-1")
-	job1.UpdateContextState("node-1", pb.SnapshotAgentJobState_STATE_RUNNING)
-	if err := jobStore.Put(ctx, job1); err != nil {
-		t.Fatalf("failed to put job1: %v", err)
-	}
-
-	mockOrch := &mockInfrastructureOrchestrator{
-		observeFunc: func(ctx context.Context, gID string) error {
-			return nil
-		},
-	}
-
-	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, &controller.MockSnapshotAgentStore{})
-
-	go func() {
-		if err := c.Run(ctx, 1); err != nil {
-			t.Errorf("Controller Run failed: %v", err)
-		}
-	}()
-
-	testQueue.Add(groupID)
-
-	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
-	if err != nil {
-		t.Fatalf("Timed out waiting for reconcile: %v", err)
-	}
-
-	if group.Status().LoadedJob() != "job-1" {
-		t.Errorf("Expected loadedJob to be 'job-1', got %q", group.Status().LoadedJob())
-	}
-	state, _ := group.Status().State()
-	if state != pb.GroupStatus_STATE_IDLE_YIELDED {
-		t.Errorf("Expected state to be STATE_IDLE_YIELDED, got %v", state)
-	}
-}
-
-func TestController_Reconcile_DeduceLoadedJob_RunningAndUnspecifiedButOtherRunning(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	testQueue := &trackQueue{
-		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-		),
-	}
-
-	groupID := "group-1"
-	nodeNames := []string{"node-1", "node-2"}
-
-	group, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to create group: %v", err)
-	}
-	group.Status().SetNodes(nodeNames)
-	group.Spec().SetActiveJob("job-1")
-
-	// job-1 is running on node-1, but UNSPECIFIED on node-2
-	job1 := store.NewJob(groupID, "job-1")
-	job1.UpdateContextState("node-1", pb.SnapshotAgentJobState_STATE_RUNNING)
-	if err := jobStore.Put(ctx, job1); err != nil {
-		t.Fatalf("failed to put job1: %v", err)
-	}
-
-	// job-2 is UNSPECIFIED on node-1, but RUNNING on node-2
-	job2 := store.NewJob(groupID, "job-2")
-	job2.UpdateContextState("node-2", pb.SnapshotAgentJobState_STATE_RUNNING)
-	if err := jobStore.Put(ctx, job2); err != nil {
-		t.Fatalf("failed to put job2: %v", err)
-	}
-
-	snapshotCalled := make(chan string, 1)
-	getStatusCallsNode2 := 0
-	mockAgentStore := &controller.MockSnapshotAgentStore{
-		GetStatusFunc: func(ctx context.Context, node string) (*agentpb.StatusResponse, error) {
-			if node == "node-1" {
-				return &agentpb.StatusResponse{
-					JobStatuses: []*agentpb.JobStatus{
-						{JobId: "job-1", State: agentpb.JobState_JOB_STATE_RUNNING},
-					},
-				}, nil
-			}
-			if node == "node-2" {
-				getStatusCallsNode2++
-				state := agentpb.JobState_JOB_STATE_RUNNING
-				if getStatusCallsNode2 > 1 {
-					state = agentpb.JobState_JOB_STATE_SAVED
+			// Start the controller
+			go func() {
+				if err := c.Run(ctx, 1); err != nil {
+					t.Errorf("Controller Run failed: %v", err)
 				}
-				return &agentpb.StatusResponse{
-					JobStatuses: []*agentpb.JobStatus{
-						{JobId: "job-2", State: state},
-					},
-				}, nil
-			}
-			return &agentpb.StatusResponse{}, nil
-		},
-		SnapshotFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.SnapshotResponse, error) {
-			if node == "node-2" && jobID == "job-2" && gID == groupID {
-				snapshotCalled <- jobID
-			}
-			return &agentpb.SnapshotResponse{OperationId: "op-123"}, nil
-		},
-		OperationFunc: func(ctx context.Context, node, operationID string) (*agentpb.GetOperationResponse, error) {
-			if node == "node-2" && operationID == "op-123" {
-				return &agentpb.GetOperationResponse{
-					Status: agentpb.OperationStatus_OPERATION_STATUS_COMPLETE,
-				}, nil
-			}
-			return &agentpb.GetOperationResponse{}, nil
-		},
-	}
+			}()
 
-	mockOrch := &mockInfrastructureOrchestrator{
-		observeFunc: func(ctx context.Context, gID string) error {
-			return nil
-		},
-	}
+			// Trigger reconcile
+			testQueue.Add(groupID)
 
-	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
-
-	go func() {
-		if err := c.Run(ctx, 1); err != nil {
-			t.Errorf("Controller Run failed: %v", err)
-		}
-	}()
-
-	testQueue.Add(groupID)
-
-	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
-	if err != nil {
-		t.Fatalf("Timed out waiting for reconcile: %v", err)
-	}
-
-	select {
-	case jobID := <-snapshotCalled:
-		if jobID != "job-2" {
-			t.Errorf("Expected snapshot to be called for job-2 on node-2, got %s", jobID)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Timed out waiting for Snapshot to be called")
-	}
-
-	if group.Status().LoadedJob() != "job-1" {
-		t.Errorf("Expected loadedJob to be 'job-1', got %q", group.Status().LoadedJob())
-	}
-	state, _ := group.Status().State()
-	if state != pb.GroupStatus_STATE_IDLE_YIELDED {
-		t.Errorf("Expected state to be STATE_IDLE_YIELDED, got %v", state)
-	}
-}
-
-func TestController_Reconcile_DeduceLoadedJob_Conflict(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	testQueue := &trackQueue{
-		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-		),
-	}
-
-	groupID := "group-1"
-	nodeNames := []string{"node-1", "node-2"}
-
-	group, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to create group: %v", err)
-	}
-	group.Status().SetNodes(nodeNames)
-	group.Spec().SetActiveJob("job-1")
-
-	// job-1 is running on node-1, and running on node-2
-	job1 := store.NewJob(groupID, "job-1")
-	job1.UpdateContextState("node-1", pb.SnapshotAgentJobState_STATE_RUNNING)
-	job1.UpdateContextState("node-2", pb.SnapshotAgentJobState_STATE_RUNNING)
-	if err := jobStore.Put(ctx, job1); err != nil {
-		t.Fatalf("failed to put job1: %v", err)
-	}
-
-	// job-2 is also running on node-1 (CONFLICT), but saved on node-2
-	job2 := store.NewJob(groupID, "job-2")
-	job2.UpdateContextState("node-1", pb.SnapshotAgentJobState_STATE_RUNNING)
-	job2.UpdateContextState("node-2", pb.SnapshotAgentJobState_STATE_SAVED)
-	if err := jobStore.Put(ctx, job2); err != nil {
-		t.Fatalf("failed to put job2: %v", err)
-	}
-
-	mockOrch := &mockInfrastructureOrchestrator{
-		observeFunc: func(ctx context.Context, gID string) error {
-			return nil
-		},
-	}
-
-	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, &controller.MockSnapshotAgentStore{})
-
-	go func() {
-		if err := c.Run(ctx, 1); err != nil {
-			t.Errorf("Controller Run failed: %v", err)
-		}
-	}()
-
-	testQueue.Add(groupID)
-
-	// Wait for the item to be re-added due to failure
-	err = waitWithTimeout(func() bool {
-		return testQueue.getAddRateLimitedCount() > 0
-	}, 2*time.Second)
-	if err != nil {
-		t.Fatal("Timed out waiting for item to be re-queued (expected failure)")
-	}
-
-	if testQueue.getAddRateLimitedCount() == 0 {
-		t.Errorf("Expected AddRateLimited to be called at least once")
-	}
-}
-
-func TestController_Reconcile_DeduceLoadedJob_AllUnspecified(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	testQueue := &trackQueue{
-		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-		),
-	}
-
-	groupID := "group-1"
-	nodeNames := []string{"node-1", "node-2"}
-
-	group, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to create group: %v", err)
-	}
-	group.Status().SetNodes(nodeNames)
-	group.Spec().SetActiveJob("job-1")
-
-	// job-1 is UNSPECIFIED on all nodes
-	job1 := store.NewJob(groupID, "job-1")
-	// leave node-1 and node-2 as UNSPECIFIED
-	if err := jobStore.Put(ctx, job1); err != nil {
-		t.Fatalf("failed to put job1: %v", err)
-	}
-
-	// job-2 is SAVED on all nodes
-	job2 := store.NewJob(groupID, "job-2")
-	job2.UpdateContextState("node-1", pb.SnapshotAgentJobState_STATE_SAVED)
-	job2.UpdateContextState("node-2", pb.SnapshotAgentJobState_STATE_SAVED)
-	if err := jobStore.Put(ctx, job2); err != nil {
-		t.Fatalf("failed to put job2: %v", err)
-	}
-
-	mockOrch := &mockInfrastructureOrchestrator{
-		observeFunc: func(ctx context.Context, gID string) error {
-			return nil
-		},
-	}
-
-	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, &controller.MockSnapshotAgentStore{})
-
-	go func() {
-		if err := c.Run(ctx, 1); err != nil {
-			t.Errorf("Controller Run failed: %v", err)
-		}
-	}()
-
-	testQueue.Add(groupID)
-
-	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
-	if err != nil {
-		t.Fatalf("Timed out waiting for reconcile: %v", err)
-	}
-
-	// job-1 should be considered loaded because it is UNSPECIFIED and no other job is RUNNING.
-	if group.Status().LoadedJob() != "job-1" {
-		t.Errorf("Expected loadedJob to be 'job-1', got %q", group.Status().LoadedJob())
-	}
-	state, _ := group.Status().State()
-	if state != pb.GroupStatus_STATE_IDLE_YIELDED {
-		t.Errorf("Expected state to be STATE_IDLE_YIELDED, got %v", state)
-	}
-}
-
-func TestController_Reconcile_DeduceLoadedJob_NonExistent(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	testQueue := &trackQueue{
-		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-		),
-	}
-
-	groupID := "group-1"
-	nodeNames := []string{"node-1", "node-2"}
-
-	group, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to create group: %v", err)
-	}
-	group.Status().SetNodes(nodeNames)
-	group.Spec().SetActiveJob("job-1")
-
-	// job-1 does NOT exist in jobStore (no pods)
-	// no other jobs exist either
-
-	mockOrch := &mockInfrastructureOrchestrator{
-		observeFunc: func(ctx context.Context, gID string) error {
-			return nil
-		},
-	}
-
-	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, &controller.MockSnapshotAgentStore{})
-
-	go func() {
-		if err := c.Run(ctx, 1); err != nil {
-			t.Errorf("Controller Run failed: %v", err)
-		}
-	}()
-
-	testQueue.Add(groupID)
-
-	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
-	if err != nil {
-		t.Fatalf("Timed out waiting for reconcile: %v", err)
-	}
-
-	// job-1 should be assumed loaded because it doesn't exist and no other job is running.
-	if group.Status().LoadedJob() != "job-1" {
-		t.Errorf("Expected loadedJob to be 'job-1', got %q", group.Status().LoadedJob())
-	}
-	state, _ := group.Status().State()
-	if state != pb.GroupStatus_STATE_IDLE_YIELDED {
-		t.Errorf("Expected state to be STATE_IDLE_YIELDED, got %v", state)
-	}
-}
-
-func TestController_Reconcile_DeduceLoadedJob_NonExistentButOtherRunning(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	testQueue := &trackQueue{
-		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[string](),
-			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
-		),
-	}
-
-	groupID := "group-1"
-	nodeNames := []string{"node-1", "node-2"}
-
-	group, _, err := groupStore.GetOrCreate(ctx, groupID)
-	if err != nil {
-		t.Fatalf("failed to create group: %v", err)
-	}
-	group.Status().SetNodes(nodeNames)
-	group.Spec().SetActiveJob("job-1")
-
-	// job-1 does NOT exist in jobStore (no pods)
-
-	// job-2 IS running on node-1
-	job2 := store.NewJob(groupID, "job-2")
-	job2.UpdateContextState("node-1", pb.SnapshotAgentJobState_STATE_RUNNING)
-	if err := jobStore.Put(ctx, job2); err != nil {
-		t.Fatalf("failed to put job2: %v", err)
-	}
-
-	snapshotCalled := make(chan string, 1)
-	getStatusCallsNode1 := 0
-	mockAgentStore := &controller.MockSnapshotAgentStore{
-		GetStatusFunc: func(ctx context.Context, node string) (*agentpb.StatusResponse, error) {
-			if node == "node-1" {
-				getStatusCallsNode1++
-				state := agentpb.JobState_JOB_STATE_RUNNING
-				if getStatusCallsNode1 > 1 {
-					state = agentpb.JobState_JOB_STATE_SAVED
+			if tc.expectFailure {
+				err = waitWithTimeout(func() bool {
+					return testQueue.getAddRateLimitedCount() > 0
+				}, 2*time.Second)
+				if err != nil {
+					t.Fatal("Timed out waiting for item to be re-queued (reconciliation should have failed)")
 				}
-				return &agentpb.StatusResponse{
-					JobStatuses: []*agentpb.JobStatus{
-						{JobId: "job-2", State: state},
-					},
-				}, nil
+				return
 			}
-			return &agentpb.StatusResponse{}, nil
-		},
-		SnapshotFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.SnapshotResponse, error) {
-			if node == "node-1" && jobID == "job-2" && gID == groupID {
-				snapshotCalled <- jobID
+
+			err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
+			if err != nil {
+				t.Fatalf("Timed out waiting for reconcile to complete: %v", err)
 			}
-			return &agentpb.SnapshotResponse{OperationId: "op-123"}, nil
-		},
-		OperationFunc: func(ctx context.Context, node, operationID string) (*agentpb.GetOperationResponse, error) {
-			if node == "node-1" && operationID == "op-123" {
-				return &agentpb.GetOperationResponse{
-					Status: agentpb.OperationStatus_OPERATION_STATUS_COMPLETE,
-				}, nil
+
+			if tc.expectedSnapshotJob != "" {
+				select {
+				case jobID := <-snapshotCalled:
+					if jobID != tc.expectedSnapshotJob {
+						t.Errorf("Expected snapshot for %s, got %s", tc.expectedSnapshotJob, jobID)
+					}
+				case <-time.After(2 * time.Second):
+					t.Fatalf("Timed out waiting for expected Snapshot of %s on %s", tc.expectedSnapshotJob, tc.expectedSnapshotNode)
+				}
 			}
-			return &agentpb.GetOperationResponse{}, nil
-		},
-	}
 
-	mockOrch := &mockInfrastructureOrchestrator{
-		observeFunc: func(ctx context.Context, gID string) error {
-			return nil
-		},
-	}
+			if tc.expectedRestoreJob != "" {
+				select {
+				case jobID := <-restoreCalled:
+					if jobID != tc.expectedRestoreJob {
+						t.Errorf("Expected restore for %s, got %s", tc.expectedRestoreJob, jobID)
+					}
+				case <-time.After(2 * time.Second):
+					t.Fatalf("Timed out waiting for expected Restore of %s on %s", tc.expectedRestoreJob, tc.expectedRestoreNode)
+				}
+			}
 
-	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
+			if group.Status().LoadedJob() != tc.expectedLoadedJob {
+				t.Errorf("Expected loadedJob to be %q, got %q", tc.expectedLoadedJob, group.Status().LoadedJob())
+			}
 
-	go func() {
-		if err := c.Run(ctx, 1); err != nil {
-			t.Errorf("Controller Run failed: %v", err)
-		}
-	}()
-
-	testQueue.Add(groupID)
-
-	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
-	if err != nil {
-		t.Fatalf("Timed out waiting for reconcile: %v", err)
-	}
-
-	select {
-	case jobID := <-snapshotCalled:
-		if jobID != "job-2" {
-			t.Errorf("Expected snapshot to be called for job-2 on node-1, got %s", jobID)
-		}
-	case <-time.After(2 * time.Second):
-		t.Fatal("Timed out waiting for Snapshot to be called")
-	}
-
-	// job-1 should be assumed loaded because we snapshotted job-2 and nothing else is running.
-	if group.Status().LoadedJob() != "job-1" {
-		t.Errorf("Expected loadedJob to be 'job-1', got %q", group.Status().LoadedJob())
-	}
-	state, _ := group.Status().State()
-	if state != pb.GroupStatus_STATE_IDLE_YIELDED {
-		t.Errorf("Expected state to be STATE_IDLE_YIELDED, got %v", state)
+			state, _ := group.Status().State()
+			if state != tc.expectedGroupState {
+				t.Errorf("Expected group state to be %v, got %v", tc.expectedGroupState, state)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What does this PR do?

For the agent, when the pod first arrives and is running on the GPU (but has no snaphots yet) it is considered IDLE by the agent. This means the orchestrator needs to consider IDLE a context-loaded state so it will restore and snapshot properly.

Also consolidated the unit tests to test case form to keep it easier to read and keep track of what was tested and what was expected.

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
