### PR TITLE
Fix project sync for fork PRs, suppress failures in PR checks

### DIFF
--- a/.github/workflows/project-sync.yaml
+++ b/.github/workflows/project-sync.yaml
@@ -4,7 +4,7 @@ name: Sync Project Board
 # in repo Settings > Secrets and variables > Actions > Variables
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
   issues:
     types: [opened]
@@ -13,6 +13,7 @@ jobs:
   add-to-project:
     if: vars.ENABLE_PROJECT_SYNC != 'false'
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - uses: actions/github-script@v7
         with:


### PR DESCRIPTION
Use pull_request_target so secrets are available for fork PRs. Add continue-on-error so failures show as neutral, not red.

## What does this PR do?

<!-- Describe the changes and their purpose -->

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
