### PR TITLE
Acquire - Refresh state & check current locker

### DIFF
--- a/pkg/accelerator-orchestrator/server/server.go
+++ b/pkg/accelerator-orchestrator/server/server.go
@@ -30,23 +30,29 @@ type JobStore interface {
 	ListByGroup(ctx context.Context, groupID string) ([]*store.Job, error)
 }
 
-const acquirePollInterval = 1 * time.Second
+// checkAcquireFunc defines the signature for the Acquire check hook.
+type checkAcquireFunc func(ctx context.Context, groupID, jobID string, startTime time.Time) (*pb.AcquireResponse, error, bool)
 
 // Server implements the AcceleratorOrchestratorService gRPC server.
 type Server struct {
 	pb.UnimplementedAcceleratorOrchestratorServiceServer
-	ctrl       *controller.Controller
-	groupStore GroupStore
-	jobStore   JobStore
+	ctrl                *controller.Controller
+	groupStore          GroupStore
+	jobStore            JobStore
+	acquirePollInterval time.Duration
+	checkAcquire        checkAcquireFunc
 }
 
 // NewServer creates a new Server instance.
 func NewServer(ctrl *controller.Controller, groupStore GroupStore, jobStore JobStore) *Server {
-	return &Server{
-		ctrl:       ctrl,
-		groupStore: groupStore,
-		jobStore:   jobStore,
+	s := &Server{
+		ctrl:                ctrl,
+		groupStore:          groupStore,
+		jobStore:            jobStore,
+		acquirePollInterval: 1 * time.Second,
 	}
+	s.checkAcquire = s.defaultCheckAcquire
+	return s
 }
 
 // Acquire implements AcceleratorOrchestratorService.Acquire.
@@ -76,7 +82,7 @@ func (s *Server) Acquire(ctx context.Context, req *pb.AcquireRequest) (*pb.Acqui
 	}
 
 	// 3. Wait Loop
-	ticker := time.NewTicker(acquirePollInterval)
+	ticker := time.NewTicker(s.acquirePollInterval)
 	defer ticker.Stop()
 
 	for {
@@ -85,26 +91,46 @@ func (s *Server) Acquire(ctx context.Context, req *pb.AcquireRequest) (*pb.Acqui
 			slog.InfoContext(ctx, "Acquire context cancelled", "error", ctx.Err())
 			return nil, status.FromContextError(ctx.Err()).Err()
 		case <-ticker.C:
-			// Check if group is faulted
-			faulted, err := s.isGroupFaulted(ctx, groupID)
-			if err != nil {
-				return nil, status.Errorf(codes.Internal, "failed to check if group is faulted: %v", err)
-			}
-			if faulted {
-				return nil, status.Errorf(codes.Unavailable, "group %s is faulted", groupID)
-			}
-
-			// Check if loaded job is ours
-			if group.Status().LoadedJob() == jobID {
-				slog.InfoContext(ctx, "Acquire succeeded, job loaded")
-				return &pb.AcquireResponse{
-					Success:         true,
-					ContextRestored: true, // Default to true, as we don't have enough info to determine if it was zero-overhead
-					WaitedMs:        time.Since(startTime).Milliseconds(),
-				}, nil
+			resp, err, done := s.checkAcquire(ctx, groupID, jobID, startTime)
+			if done {
+				return resp, err
 			}
 		}
 	}
+}
+
+func (s *Server) defaultCheckAcquire(
+	ctx context.Context,
+	groupID, jobID string,
+	startTime time.Time,
+) (*pb.AcquireResponse, error, bool) {
+	// Re-read group to get the latest status and spec from the store (fixes stale group bug)
+	group, err := s.groupStore.Get(ctx, groupID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to get group: %v", err), true
+	}
+
+	// Check if group is faulted
+	faulted, err := s.isGroupFaulted(ctx, groupID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to check if group is faulted: %v", err), true
+	}
+	if faulted {
+		return nil, status.Errorf(codes.Unavailable, "group %s is faulted", groupID), true
+	}
+
+	// Check if we are the lock holder AND the context is loaded
+	// (fixes premature success bug)
+	if group.Spec().LockingJob() == jobID && group.Status().LoadedJob() == jobID {
+		slog.InfoContext(ctx, "Acquire succeeded, job loaded and lock held")
+		return &pb.AcquireResponse{
+			Success:         true,
+			ContextRestored: true, // Default to true, as we don't have enough info to determine if it was zero-overhead
+			WaitedMs:        time.Since(startTime).Milliseconds(),
+		}, nil, true
+	}
+
+	return nil, nil, false //nolint:nilnil // returning nil, nil is intended when done is false
 }
 
 func (s *Server) isGroupFaulted(ctx context.Context, groupID string) (bool, error) {

--- a/pkg/accelerator-orchestrator/server/server_internal_test.go
+++ b/pkg/accelerator-orchestrator/server/server_internal_test.go
@@ -1,0 +1,330 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/api/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/controller"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/store"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+const bufSize = 1024 * 1024
+
+var lis *bufconn.Listener
+
+// BufDialer is exported for external tests.
+func BufDialer(context.Context, string) (net.Conn, error) {
+	return lis.Dial()
+}
+
+// InitGRPCServer is exported for external tests.
+// It sets the acquirePollInterval to 1ms for fast testing.
+func InitGRPCServer(groupStore GroupStore, jobStore JobStore) (*Server, *MockWorkQueue, func()) {
+	lis = bufconn.Listen(bufSize)
+	s := grpc.NewServer()
+	mq := &MockWorkQueue{}
+	ctrl := controller.NewController(nil, nil, mq, nil, nil)
+	srv := NewServer(ctrl, groupStore, jobStore)
+	srv.acquirePollInterval = 1 * time.Millisecond // Set to 1ms for testing
+	pb.RegisterAcceleratorOrchestratorServiceServer(s, srv)
+	go func() {
+		if err := s.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
+			slog.Error("Server exited with error", "error", err)
+			panic(err)
+		}
+	}()
+	return srv, mq, func() {
+		s.GracefulStop()
+		lis.Close()
+	}
+}
+
+// MockWorkQueue is exported for external tests.
+type MockWorkQueue struct {
+	controller.WorkQueue
+	mu    sync.Mutex
+	added []string
+}
+
+func (m *MockWorkQueue) Add(groupID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.added = append(m.added, groupID)
+}
+
+func (m *MockWorkQueue) GetAdded() []string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]string, len(m.added))
+	copy(cp, m.added)
+	return cp
+}
+
+func (m *MockWorkQueue) AddRateLimited(groupID string) {}
+func (m *MockWorkQueue) Forget(groupID string)         {}
+func (m *MockWorkQueue) Done(groupID string)           {}
+func (m *MockWorkQueue) Get() (string, bool)           { return "", false }
+func (m *MockWorkQueue) ShutDown()                     {}
+
+// MockGroupStore is exported for external tests.
+type MockGroupStore struct {
+	GetFunc  func(ctx context.Context, id string) (*store.Group, error)
+	ListFunc func(ctx context.Context) ([]*store.Group, error)
+	SetGroup func(g *store.Group)
+}
+
+func (m *MockGroupStore) Get(ctx context.Context, id string) (*store.Group, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(ctx, id)
+	}
+	return nil, store.ErrNotFound
+}
+
+func (m *MockGroupStore) List(ctx context.Context) ([]*store.Group, error) {
+	if m.ListFunc != nil {
+		return m.ListFunc(ctx)
+	}
+	return nil, nil
+}
+
+// MockJobStore is exported for external tests.
+type MockJobStore struct {
+	GetFunc         func(ctx context.Context, groupID, jobID string) (*store.Job, error)
+	ListByGroupFunc func(ctx context.Context, groupID string) ([]*store.Job, error)
+}
+
+func (m *MockJobStore) Get(ctx context.Context, groupID, jobID string) (*store.Job, error) {
+	if m.GetFunc != nil {
+		return m.GetFunc(ctx, groupID, jobID)
+	}
+	return nil, store.ErrNotFound
+}
+
+func (m *MockJobStore) ListByGroup(ctx context.Context, groupID string) ([]*store.Job, error) {
+	if m.ListByGroupFunc != nil {
+		return m.ListByGroupFunc(ctx, groupID)
+	}
+	return nil, nil
+}
+
+// MockGroupLockStore is exported for external tests.
+type MockGroupLockStore struct {
+	lock string
+}
+
+func (m *MockGroupLockStore) GetLock(ctx context.Context) (string, error) {
+	return m.lock, nil
+}
+
+func (m *MockGroupLockStore) Lock(ctx context.Context, jobID string) error {
+	m.lock = jobID
+	return nil
+}
+
+func (m *MockGroupLockStore) Unlock(ctx context.Context, jobID string) error {
+	m.lock = ""
+	return nil
+}
+
+func TestServer_Acquire_Whitebox(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupStores   func(t *testing.T, ctx context.Context) (GroupStore, JobStore)
+		groupID       string
+		jobID         string
+		expectedCode  codes.Code
+		verify        func(t *testing.T, resp *pb.AcquireResponse, err error)
+		expectEnqueue bool
+		hook          func(t *testing.T, srv *Server, gs GroupStore, js JobStore, cancel context.CancelFunc)
+	}{
+		{
+			name: "block when it has not yet reconciled but another job requesting lock",
+			setupStores: func(t *testing.T, ctx context.Context) (GroupStore, JobStore) {
+				t.Helper()
+				lockStore := store.NewMemLockStore()
+				// Imagine job-1 got the lock then yielded.
+				// Then job-2 asks for the lock. That acquire is now in waiting while job-1 unloads.
+				// Lock it for job-2 (LockingJob = job-2)
+				if err := lockStore.Lock(ctx, "group-1", "job-2"); err != nil {
+					t.Fatalf("failed to lock: %v", err)
+				}
+				gs := store.NewGroupStore(lockStore)
+				g, _, err := gs.GetOrCreate(ctx, "group-1")
+				if err != nil {
+					t.Fatalf("failed to create group: %v", err)
+				}
+				// Simulate job-1 has not yet unloaded (LoadedJob = job-1)
+				g.Status().SetLoadedJob("job-1")
+				return gs, store.NewJobStore()
+			},
+			groupID:       "group-1",
+			jobID:         "job-1",        // job-1 tries to acquire, should block because lock is for job-2
+			expectedCode:  codes.Canceled, // We expect Canceled because we will cancel it manually
+			expectEnqueue: true,
+			hook: func(t *testing.T, srv *Server, gs GroupStore, js JobStore, cancel context.CancelFunc) {
+				t.Helper()
+				tickCalled := make(chan struct{}, 1)
+				origCheck := srv.checkAcquire
+				srv.checkAcquire = func(ctx context.Context, groupID, jobID string, startTime time.Time) (*pb.AcquireResponse, error, bool) {
+					resp, err, done := origCheck(ctx, groupID, jobID, startTime)
+					select {
+					case tickCalled <- struct{}{}:
+					default:
+					}
+					return resp, err, done
+				}
+				// Wait for 5 ticks to be sure it is blocked, then cancel
+				go func() {
+					for i := 0; i < 5; i++ {
+						<-tickCalled
+					}
+					cancel()
+				}()
+			},
+		},
+		{
+			name: "succeed when job loads later",
+			setupStores: func(t *testing.T, ctx context.Context) (GroupStore, JobStore) {
+				t.Helper()
+				// Create group 1: locked for job-2, but job-1 is loaded
+				m1 := &MockGroupLockStore{lock: "job-2"}
+				g1, err := store.NewGroup(ctx, "group-1", m1)
+				if err != nil {
+					t.Fatalf("failed to create group1: %v", err)
+				}
+				g1.Status().SetLoadedJob("job-1")
+
+				var mu sync.Mutex
+				currentGroup := g1
+
+				gs := &MockGroupStore{
+					GetFunc: func(ctx context.Context, id string) (*store.Group, error) {
+						mu.Lock()
+						defer mu.Unlock()
+						return currentGroup, nil
+					},
+					SetGroup: func(g *store.Group) {
+						mu.Lock()
+						currentGroup = g
+						mu.Unlock()
+					},
+				}
+				return gs, store.NewJobStore()
+			},
+			groupID:       "group-1",
+			jobID:         "job-2", // job-2 tries to acquire, should succeed after job-2 is loaded
+			expectedCode:  codes.OK,
+			expectEnqueue: true,
+			hook: func(t *testing.T, srv *Server, gs GroupStore, js JobStore, cancel context.CancelFunc) {
+				t.Helper()
+				mGS, ok := gs.(*MockGroupStore)
+				if !ok {
+					t.Fatalf("expected *MockGroupStore, got %T", gs)
+				}
+				tickCalled := make(chan struct{}, 1)
+				origCheck := srv.checkAcquire
+				srv.checkAcquire = func(ctx context.Context, groupID, jobID string, startTime time.Time) (*pb.AcquireResponse, error, bool) {
+					resp, err, done := origCheck(ctx, groupID, jobID, startTime)
+					select {
+					case tickCalled <- struct{}{}:
+					default:
+					}
+					return resp, err, done
+				}
+				// Wait for first tick, then update group to g2
+				go func() {
+					<-tickCalled
+					m2 := &MockGroupLockStore{lock: "job-2"}
+					g2, err := store.NewGroup(context.Background(), "group-1", m2)
+					if err != nil {
+						t.Errorf("failed to create group2: %v", err)
+						return
+					}
+					g2.Status().SetLoadedJob("job-2")
+					mGS.SetGroup(g2)
+				}()
+			},
+			verify: func(t *testing.T, resp *pb.AcquireResponse, err error) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("Unexpected error: %v", err)
+				}
+				if !resp.Success {
+					t.Errorf("Expected success to be true")
+				}
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			serverCtx := context.Background()
+			clientCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			gs, js := tc.setupStores(t, serverCtx)
+
+			srv, mq, cleanup := InitGRPCServer(gs, js)
+			defer cleanup()
+
+			if tc.hook != nil {
+				tc.hook(t, srv, gs, js, cancel)
+			}
+
+			conn, err := grpc.NewClient(
+				"passthrough:///bufnet",
+				grpc.WithContextDialer(BufDialer),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			if err != nil {
+				t.Fatalf("Failed to dial bufnet: %v", err)
+			}
+			defer conn.Close()
+			client := pb.NewAcceleratorOrchestratorServiceClient(conn)
+
+			resp, err := client.Acquire(clientCtx, &pb.AcquireRequest{
+				GroupId: tc.groupID,
+				JobId:   tc.jobID,
+			})
+
+			added := mq.GetAdded()
+			if tc.expectEnqueue {
+				if len(added) != 1 || added[0] != tc.groupID {
+					t.Errorf("expected group %s to be enqueued, got %v", tc.groupID, added)
+				}
+			} else {
+				if len(added) != 0 {
+					t.Errorf("expected no enqueue, got %v", added)
+				}
+			}
+
+			if tc.expectedCode != codes.OK {
+				if err == nil {
+					t.Fatalf("Expected error, got nil")
+				}
+				st, ok := status.FromError(err)
+				if !ok {
+					t.Fatalf("Expected gRPC status error, got: %v", err)
+				}
+				if st.Code() != tc.expectedCode {
+					t.Errorf("Expected code %v, got %v", tc.expectedCode, st.Code())
+				}
+				return
+			}
+
+			if tc.verify != nil {
+				tc.verify(t, resp, err)
+			}
+		})
+	}
+}

--- a/pkg/accelerator-orchestrator/server/server_test.go
+++ b/pkg/accelerator-orchestrator/server/server_test.go
@@ -3,87 +3,17 @@ package server_test
 import (
 	"context"
 	"errors"
-	"log/slog"
-	"net"
-	"sync"
 	"testing"
 	"time"
 
 	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/api/v1alpha1"
-	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/controller"
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/server"
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/store"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
-	"google.golang.org/grpc/test/bufconn"
 )
-
-const bufSize = 1024 * 1024
-
-var lis *bufconn.Listener
-
-//nolint:gocritic // Conflict with nonamedreturns linter
-func initGRPCServer(groupStore server.GroupStore, jobStore server.JobStore) (*mockWorkQueue, func()) {
-	lis = bufconn.Listen(bufSize)
-	s := grpc.NewServer()
-	mq := &mockWorkQueue{}
-	ctrl := controller.NewController(nil, nil, mq, nil, nil)
-	pb.RegisterAcceleratorOrchestratorServiceServer(s, server.NewServer(ctrl, groupStore, jobStore))
-	go func() {
-		if err := s.Serve(lis); err != nil && !errors.Is(err, grpc.ErrServerStopped) {
-			slog.Error("Server exited with error", "error", err)
-			panic(err)
-		}
-	}()
-	return mq, func() {
-		s.GracefulStop()
-		lis.Close()
-	}
-}
-
-type mockGroupStore struct {
-	getFunc  func(ctx context.Context, id string) (*store.Group, error)
-	listFunc func(ctx context.Context) ([]*store.Group, error)
-}
-
-func (m *mockGroupStore) Get(ctx context.Context, id string) (*store.Group, error) {
-	if m.getFunc != nil {
-		return m.getFunc(ctx, id)
-	}
-	return nil, store.ErrNotFound
-}
-
-func (m *mockGroupStore) List(ctx context.Context) ([]*store.Group, error) {
-	if m.listFunc != nil {
-		return m.listFunc(ctx)
-	}
-	return nil, nil
-}
-
-type mockJobStore struct {
-	getFunc         func(ctx context.Context, groupID, jobID string) (*store.Job, error)
-	listByGroupFunc func(ctx context.Context, groupID string) ([]*store.Job, error)
-}
-
-func (m *mockJobStore) Get(ctx context.Context, groupID, jobID string) (*store.Job, error) {
-	if m.getFunc != nil {
-		return m.getFunc(ctx, groupID, jobID)
-	}
-	return nil, store.ErrNotFound
-}
-
-func (m *mockJobStore) ListByGroup(ctx context.Context, groupID string) ([]*store.Job, error) {
-	if m.listByGroupFunc != nil {
-		return m.listByGroupFunc(ctx, groupID)
-	}
-	return nil, nil
-}
-
-func bufDialer(context.Context, string) (net.Conn, error) {
-	return lis.Dial()
-}
 
 func TestServer_Acquire(t *testing.T) {
 	tests := []struct {
@@ -93,7 +23,6 @@ func TestServer_Acquire(t *testing.T) {
 		jobID         string
 		timeout       time.Duration
 		expectedCode  codes.Code
-		verify        func(t *testing.T, resp *pb.AcquireResponse, err error)
 		expectEnqueue bool
 	}{
 		{
@@ -145,41 +74,6 @@ func TestServer_Acquire(t *testing.T) {
 			expectedCode:  codes.DeadlineExceeded,
 			expectEnqueue: true,
 		},
-		{
-			name: "success after wait",
-			setupStores: func(t *testing.T, ctx context.Context) (server.GroupStore, server.JobStore) {
-				t.Helper()
-				gs := store.NewGroupStore(store.NewMemLockStore())
-				g, _, err := gs.GetOrCreate(ctx, "group-1")
-				if err != nil {
-					t.Fatalf("failed to create group: %v", err)
-				}
-
-				// Simulate controller loading the job after a short delay
-				go func() {
-					time.Sleep(50 * time.Millisecond)
-					g.Status().SetLoadedJob("job-1")
-				}()
-
-				return gs, store.NewJobStore()
-			},
-			groupID:       "group-1",
-			jobID:         "job-1",
-			expectedCode:  codes.OK,
-			expectEnqueue: true,
-			verify: func(t *testing.T, resp *pb.AcquireResponse, err error) {
-				t.Helper()
-				if err != nil {
-					t.Fatalf("Unexpected error: %v", err)
-				}
-				if !resp.Success {
-					t.Errorf("Expected success to be true")
-				}
-				if resp.WaitedMs < 50 {
-					t.Errorf("Expected WaitedMs to be at least 50ms, got %d", resp.WaitedMs)
-				}
-			},
-		},
 	}
 
 	for _, tc := range tests {
@@ -193,11 +87,11 @@ func TestServer_Acquire(t *testing.T) {
 			}
 			gs, js := tc.setupStores(t, serverCtx)
 
-			mq, cleanup := initGRPCServer(gs, js)
+			_, mq, cleanup := server.InitGRPCServer(gs, js)
 			defer cleanup()
 			conn, err := grpc.NewClient(
 				"passthrough:///bufnet",
-				grpc.WithContextDialer(bufDialer),
+				grpc.WithContextDialer(server.BufDialer),
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			)
 			if err != nil {
@@ -206,7 +100,7 @@ func TestServer_Acquire(t *testing.T) {
 			defer conn.Close()
 			client := pb.NewAcceleratorOrchestratorServiceClient(conn)
 
-			resp, err := client.Acquire(clientCtx, &pb.AcquireRequest{
+			_, err = client.Acquire(clientCtx, &pb.AcquireRequest{
 				GroupId: tc.groupID,
 				JobId:   tc.jobID,
 			})
@@ -234,10 +128,6 @@ func TestServer_Acquire(t *testing.T) {
 					t.Errorf("Expected code %v, got %v", tc.expectedCode, st.Code())
 				}
 				return
-			}
-
-			if tc.verify != nil {
-				tc.verify(t, resp, err)
 			}
 		})
 	}
@@ -362,11 +252,11 @@ func TestServer_Yield(t *testing.T) {
 			ctx := context.Background()
 			gs, js := tc.setupStores(t, ctx)
 
-			mq, cleanup := initGRPCServer(gs, js)
+			_, mq, cleanup := server.InitGRPCServer(gs, js)
 			defer cleanup()
 			conn, err := grpc.NewClient(
 				"passthrough:///bufnet",
-				grpc.WithContextDialer(bufDialer),
+				grpc.WithContextDialer(server.BufDialer),
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			)
 			if err != nil {
@@ -450,8 +340,8 @@ func TestServer_ListGroups(t *testing.T) {
 			name: "error path",
 			setupStore: func(t *testing.T, ctx context.Context) server.GroupStore {
 				t.Helper()
-				return &mockGroupStore{
-					listFunc: func(ctx context.Context) ([]*store.Group, error) {
+				return &server.MockGroupStore{
+					ListFunc: func(ctx context.Context) ([]*store.Group, error) {
 						return nil, errors.New("database error")
 					},
 				}
@@ -466,11 +356,11 @@ func TestServer_ListGroups(t *testing.T) {
 			ctx := context.Background()
 			gs := tc.setupStore(t, ctx)
 
-			_, cleanup := initGRPCServer(gs, nil)
+			_, _, cleanup := server.InitGRPCServer(gs, nil)
 			defer cleanup()
 			conn, err := grpc.NewClient(
 				"passthrough:///bufnet",
-				grpc.WithContextDialer(bufDialer),
+				grpc.WithContextDialer(server.BufDialer),
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			)
 			if err != nil {
@@ -538,8 +428,8 @@ func TestServer_GetGroupStatus(t *testing.T) {
 			name: "failed to get group (internal)",
 			setupStores: func(t *testing.T, ctx context.Context) (server.GroupStore, server.JobStore) {
 				t.Helper()
-				gs := &mockGroupStore{
-					getFunc: func(ctx context.Context, id string) (*store.Group, error) {
+				gs := &server.MockGroupStore{
+					GetFunc: func(ctx context.Context, id string) (*store.Group, error) {
 						return nil, errors.New("database error")
 					},
 				}
@@ -572,8 +462,8 @@ func TestServer_GetGroupStatus(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to create group: %v", err)
 				}
-				js := &mockJobStore{
-					listByGroupFunc: func(ctx context.Context, groupID string) ([]*store.Job, error) {
+				js := &server.MockJobStore{
+					ListByGroupFunc: func(ctx context.Context, groupID string) ([]*store.Job, error) {
 						return nil, errors.New("database error")
 					},
 				}
@@ -702,11 +592,11 @@ func TestServer_GetGroupStatus(t *testing.T) {
 			ctx := context.Background()
 			gs, js := tc.setupStores(t, ctx)
 
-			_, cleanup := initGRPCServer(gs, js)
+			_, _, cleanup := server.InitGRPCServer(gs, js)
 			defer cleanup()
 			conn, err := grpc.NewClient(
 				"passthrough:///bufnet",
-				grpc.WithContextDialer(bufDialer),
+				grpc.WithContextDialer(server.BufDialer),
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			)
 			if err != nil {
@@ -741,29 +631,3 @@ func TestServer_GetGroupStatus(t *testing.T) {
 		})
 	}
 }
-
-type mockWorkQueue struct {
-	controller.WorkQueue
-	mu    sync.Mutex
-	added []string
-}
-
-func (m *mockWorkQueue) Add(groupID string) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	m.added = append(m.added, groupID)
-}
-
-func (m *mockWorkQueue) GetAdded() []string {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	cp := make([]string, len(m.added))
-	copy(cp, m.added)
-	return cp
-}
-
-func (m *mockWorkQueue) AddRateLimited(groupID string) {}
-func (m *mockWorkQueue) Forget(groupID string)         {}
-func (m *mockWorkQueue) Done(groupID string)           {}
-func (m *mockWorkQueue) Get() (string, bool)           { return "", false }
-func (m *mockWorkQueue) ShutDown()                     {}


### PR DESCRIPTION
## What does this PR do?

Fix some bugs found in integration testing with real vllm. Specifically, longer vllm snapshot meant that Acquire needed to loop longer before it got the lock. It also showed a condition where locked but not loaded state let a different lock slip through.

Did need to create whitebox internal test suite (and move all the shared mocks/fakes over) so I could use a func var to get at internal logic timing with channels instead of time.sleeps (a future source of flakes).

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
