### PR TITLE
orchestrator handle idle to active transition

### DIFF
--- a/cmd/acceleratororchestrator/main.go
+++ b/cmd/acceleratororchestrator/main.go
@@ -40,6 +40,7 @@ func run() error {
 	kubeconfig := flag.String("kubeconfig", "", "Path to a kubeconfig. Only required if out-of-cluster.")
 	controllerWorkers := flag.Int("controller-workers", 1, "The number of workers for the controller")
 	snapshotAgentPort := flag.Int("snapshot-agent-port", 9001, "The default port for snapshot agents")
+	resyncPeriod := flag.Duration("resync-period", 30*time.Second, "The period for periodic resync of agent states")
 	flag.Parse()
 
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
@@ -91,6 +92,7 @@ func run() error {
 		infraOrch,
 		snapshotAgentStore,
 	)
+	ctrl.ResyncPeriod = *resyncPeriod
 
 	// Start informers
 	nodeInformerFactory.Start(ctx.Done())

--- a/pkg/accelerator-orchestrator/controller/controller.go
+++ b/pkg/accelerator-orchestrator/controller/controller.go
@@ -93,6 +93,7 @@ type Controller struct {
 	jobStore          *store.JobStore
 	infraOrchestrator InfrastructureOrchestrator
 	agentStore        store.SnapshotAgentStore
+	ResyncPeriod      time.Duration
 }
 
 // NewController creates a new Controller with the provided stores, queue, and infrastructure orchestrator.
@@ -109,6 +110,7 @@ func NewController(
 		jobStore:          jobStore,
 		infraOrchestrator: infraOrchestrator,
 		agentStore:        agentStore,
+		ResyncPeriod:      30 * time.Second,
 	}
 }
 
@@ -138,6 +140,25 @@ func (c *Controller) Run(ctx context.Context, workers int) error {
 			c.runWorker(ctx, workerID)
 		}, time.Second)
 	}
+
+	// Periodic resync loop to poll agent states and trigger reconciliation
+	go func() {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(c.ResyncPeriod):
+		}
+		until(ctx, func(ctx context.Context) {
+			groups, err := c.groupStore.List(ctx)
+			if err != nil {
+				slog.ErrorContext(ctx, "Failed to list groups for periodic resync", "error", err)
+				return
+			}
+			for _, g := range groups {
+				c.EnqueueWork(g.ID())
+			}
+		}, c.ResyncPeriod)
+	}()
 
 	slog.InfoContext(ctx, "Started workers")
 	<-ctx.Done()
@@ -268,21 +289,30 @@ func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activ
 
 	// 3. Ensure no other jobs have their context loaded
 	for jobID, state := range agentJobStates {
-		if jobID == activeJobID || state != pb.SnapshotAgentJobState_STATE_RUNNING {
+		if jobID == activeJobID {
 			continue
 		}
 
-		slog.InfoContext(ctx, "Triggering snapshot for job", "jobID", jobID, "state", state)
-		resp, err := c.agentStore.Snapshot(ctx, nodeName, jobID, groupID)
-		if err != nil {
-			return fmt.Errorf("failed to trigger snapshot for job %s on node %s: %w", jobID, nodeName, err)
-		}
-		if err := c.waitForOperation(ctx, nodeName, resp.OperationId); err != nil {
-			return fmt.Errorf("failed while waiting for snapshot operation %s for job %s on node %s: %w",
-				resp.OperationId, jobID, nodeName, err)
-		}
-		if err := c.observeNodeJobContext(ctx, groupID, nodeName); err != nil {
-			return fmt.Errorf("failed to refresh agent state after snapshot: %w", err)
+		switch state {
+		case pb.SnapshotAgentJobState_STATE_RUNNING:
+			slog.InfoContext(ctx, "Triggering snapshot for job", "jobID", jobID, "state", state)
+			resp, err := c.agentStore.Snapshot(ctx, nodeName, jobID, groupID)
+			if err != nil {
+				return fmt.Errorf("failed to trigger snapshot for job %s on node %s: %w", jobID, nodeName, err)
+			}
+			if err := c.waitForOperation(ctx, nodeName, resp.OperationId); err != nil {
+				return fmt.Errorf("failed while waiting for snapshot operation %s for job %s on node %s: %w",
+					resp.OperationId, jobID, nodeName, err)
+			}
+			if err := c.observeNodeJobContext(ctx, groupID, nodeName); err != nil {
+				return fmt.Errorf("failed to refresh agent state after snapshot: %w", err)
+			}
+		case pb.SnapshotAgentJobState_STATE_IDLE:
+			slog.InfoContext(ctx, "Other job is IDLE, waiting for it to become ACTIVE before preemption", "jobID", jobID)
+			return fmt.Errorf("preemption pending: waiting for job %s to transition from IDLE to RUNNING", jobID)
+		case pb.SnapshotAgentJobState_STATE_TRANSITIONING:
+			slog.InfoContext(ctx, "Other job is TRANSITIONING, waiting for it to finish", "jobID", jobID)
+			return fmt.Errorf("preemption pending: job %s is currently transitioning", jobID)
 		}
 	}
 

--- a/pkg/accelerator-orchestrator/controller/controller_test.go
+++ b/pkg/accelerator-orchestrator/controller/controller_test.go
@@ -1497,3 +1497,280 @@ func TestController_Reconcile_DeduceLoadedJob_NonExistentButOtherRunning(t *test
 		t.Errorf("Expected state to be STATE_IDLE_YIELDED, got %v", state)
 	}
 }
+
+func TestController_PeriodicResync(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
+
+	groupID := "group-1"
+
+	// 1. Setup group in store
+	_, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+
+	mockOrch := &mockInfrastructureOrchestrator{
+		observeFunc: func(ctx context.Context, gID string) error {
+			return nil
+		},
+	}
+
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, &controller.MockSnapshotAgentStore{})
+	c.ResyncPeriod = 100 * time.Millisecond
+
+	// Start the controller
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+
+	// Verify that it was processed (Done called)
+	err = waitWithTimeout(func() bool {
+		return testQueue.getDoneCount() > 0
+	}, 1*time.Second)
+	if err != nil {
+		t.Fatal("Timed out waiting for periodic resync to trigger reconciliation")
+	}
+
+	if testQueue.getDoneCount() < 1 {
+		t.Errorf("Expected Done to be called at least once, got %d", testQueue.getDoneCount())
+	}
+}
+
+func TestController_Reconcile_DeduceLoadedJob_IdleNotLoaded(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
+
+	groupID := "group-1"
+	nodeName := "node-1"
+
+	group, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	group.Status().SetNodes([]string{nodeName})
+	group.Spec().SetActiveJob("job-1")
+
+	// job-1 is IDLE on node-1
+	job1 := store.NewJob(groupID, "job-1")
+	job1.UpdateContextState(nodeName, pb.SnapshotAgentJobState_STATE_IDLE)
+	if err := jobStore.Put(ctx, job1); err != nil {
+		t.Fatalf("failed to put job1: %v", err)
+	}
+
+	mockOrch := &mockInfrastructureOrchestrator{
+		observeFunc: func(ctx context.Context, gID string) error {
+			return nil
+		},
+	}
+
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, &controller.MockSnapshotAgentStore{})
+
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+
+	testQueue.Add(groupID)
+
+	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
+	if err != nil {
+		t.Fatalf("Timed out waiting for reconcile: %v", err)
+	}
+
+	// job-1 should NOT be considered loaded because it is IDLE.
+	if group.Status().LoadedJob() != "" {
+		t.Errorf("Expected loadedJob to be empty, got %q", group.Status().LoadedJob())
+	}
+	state, _ := group.Status().State()
+	if state != pb.GroupStatus_STATE_IDLE_YIELDED {
+		t.Errorf("Expected state to be STATE_IDLE_YIELDED, got %v", state)
+	}
+}
+
+func TestController_Reconcile_PreemptionSafetyGates_IdleJob(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
+
+	groupID := "group-1"
+	nodeName := "node-1"
+
+	// 1. Setup group and nodes
+	testGroup, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	testGroup.Status().SetNodes([]string{nodeName})
+	testGroup.Spec().SetActiveJob("job-1")
+
+	// 2. Setup jobs in store
+	job1 := store.NewJob(groupID, "job-1")
+	job1.UpdateContextState(nodeName, pb.SnapshotAgentJobState_STATE_SAVED) // Needs restore
+
+	job2 := store.NewJob(groupID, "job-2")
+	job2.UpdateContextState(nodeName, pb.SnapshotAgentJobState_STATE_IDLE) // Other job is IDLE
+
+	if err := jobStore.Put(ctx, job1); err != nil {
+		t.Fatalf("failed to put job1: %v", err)
+	}
+	if err := jobStore.Put(ctx, job2); err != nil {
+		t.Fatalf("failed to put job2: %v", err)
+	}
+
+	// 3. Mock SnapshotAgentStore to fail if Snapshot/Restore is called
+	mockAgentStore := &controller.MockSnapshotAgentStore{
+		SnapshotFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.SnapshotResponse, error) {
+			t.Errorf("Unexpected call to Snapshot")
+			return nil, fmt.Errorf("unexpected call")
+		},
+		RestoreFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.RestoreResponse, error) {
+			t.Errorf("Unexpected call to Restore")
+			return nil, fmt.Errorf("unexpected call")
+		},
+	}
+
+	mockOrch := &mockInfrastructureOrchestrator{
+		observeFunc: func(ctx context.Context, gID string) error {
+			return nil
+		},
+	}
+
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
+
+	// Start the controller
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+
+	// Trigger reconcile
+	testQueue.Add(groupID)
+
+	// Verify that it failed and was re-queued (AddRateLimited called)
+	err = waitWithTimeout(func() bool {
+		return testQueue.getAddRateLimitedCount() > 0
+	}, 2*time.Second)
+	if err != nil {
+		t.Fatal("Timed out waiting for item to be re-queued (reconciliation should have failed)")
+	}
+
+	if testQueue.getAddRateLimitedCount() < 1 {
+		t.Errorf("Expected AddRateLimited to be called at least once, got %d", testQueue.getAddRateLimitedCount())
+	}
+}
+
+func TestController_Reconcile_PreemptionSafetyGates_TransitioningJob(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
+
+	groupID := "group-1"
+	nodeName := "node-1"
+
+	// 1. Setup group and nodes
+	testGroup, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	testGroup.Status().SetNodes([]string{nodeName})
+	testGroup.Spec().SetActiveJob("job-1")
+
+	// 2. Setup jobs in store
+	job1 := store.NewJob(groupID, "job-1")
+	job1.UpdateContextState(nodeName, pb.SnapshotAgentJobState_STATE_SAVED) // Needs restore
+
+	job2 := store.NewJob(groupID, "job-2")
+	job2.UpdateContextState(nodeName, pb.SnapshotAgentJobState_STATE_TRANSITIONING) // Other job is TRANSITIONING
+
+	if err := jobStore.Put(ctx, job1); err != nil {
+		t.Fatalf("failed to put job1: %v", err)
+	}
+	if err := jobStore.Put(ctx, job2); err != nil {
+		t.Fatalf("failed to put job2: %v", err)
+	}
+
+	// 3. Mock SnapshotAgentStore to fail if Snapshot/Restore is called
+	mockAgentStore := &controller.MockSnapshotAgentStore{
+		SnapshotFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.SnapshotResponse, error) {
+			t.Errorf("Unexpected call to Snapshot")
+			return nil, fmt.Errorf("unexpected call")
+		},
+		RestoreFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.RestoreResponse, error) {
+			t.Errorf("Unexpected call to Restore")
+			return nil, fmt.Errorf("unexpected call")
+		},
+	}
+
+	mockOrch := &mockInfrastructureOrchestrator{
+		observeFunc: func(ctx context.Context, gID string) error {
+			return nil
+		},
+	}
+
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
+
+	// Start the controller
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+
+	// Trigger reconcile
+	testQueue.Add(groupID)
+
+	// Verify that it failed and was re-queued (AddRateLimited called)
+	err = waitWithTimeout(func() bool {
+		return testQueue.getAddRateLimitedCount() > 0
+	}, 2*time.Second)
+	if err != nil {
+		t.Fatal("Timed out waiting for item to be re-queued (reconciliation should have failed)")
+	}
+
+	if testQueue.getAddRateLimitedCount() < 1 {
+		t.Errorf("Expected AddRateLimited to be called at least once, got %d", testQueue.getAddRateLimitedCount())
+	}
+}


### PR DESCRIPTION
## What does this PR do?

After https://github.com/llm-d-incubation/llm-d-rl-time-slicing/pull/77, IDLE is now a state that can transition to ACTIVE at any time without any pod modifcations etc. For the orchestrator to handle this, this PR adds:
* A resync loop to catch any off band transitions (not super fast since there is not pending work but still needed for methods on getting info on groups to be eventually accurate)
* Logic that assumes IDLE is a precursor to ACTIVE. This means we will not say a job is fully loaded if there is IDLE, we wait for it to become active. This also means for snapshooting, we will wait for an IDLE job to become ACTIVE before snaphotting it. This wait is very important because if we yield the lock to another job and THEN the IDLE job becomes active we end up with two active jobs on the same machines.

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
