### PR TITLE
Clean up backend enum in snapshot agent client

### DIFF
--- a/pkg/accelerator-orchestrator/store/snapshot_agent_store.go
+++ b/pkg/accelerator-orchestrator/store/snapshot_agent_store.go
@@ -164,9 +164,8 @@ func (s *GRPCSnapshotAgentStore) Restore(
 	}
 
 	resp, err := client.Restore(ctx, &agentpb.RestoreRequest{
-		JobId:   jobID,
-		Group:   groupID,
-		Backend: agentpb.Backend_BACKEND_CUDA, // Default to CUDA
+		JobId: jobID,
+		Group: groupID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to trigger restore for job %s on agent at %s: %w", jobID, address, err)

--- a/pkg/client/python/README.md
+++ b/pkg/client/python/README.md
@@ -29,10 +29,13 @@ from timeslice.snapshot_agent import SnapshotAgentClient
 
 with SnapshotAgentClient(endpoint="localhost:9001") as client:
     # Trigger a snapshot and wait for it to complete
+    from timeslice.snapshot_agent import snapshot_agent_pb2
     result = client.snapshot_and_wait(
         job_id="my-job", 
         group="default", 
-        backend="CUDA"
+        backend_config=snapshot_agent_pb2.BackendConfig(
+            cuda=snapshot_agent_pb2.CudaBackendConfig()
+        )
     )
     print(f"Snapshot finished with status: {result.status}")
 ```

--- a/pkg/client/python/timeslice/snapshot_agent/client.py
+++ b/pkg/client/python/timeslice/snapshot_agent/client.py
@@ -1,7 +1,7 @@
 import logging
 import time
 from abc import ABC, abstractmethod
-from typing import Optional, Union
+from typing import Optional
 
 import grpc
 
@@ -41,8 +41,6 @@ class SnapshotAgentInterface(ABC):
         self,
         job_id: str,
         group: str = "",
-        backend: Union[str, int] = 0,
-        pids: Optional[list[int]] = None,
         backend_config: Optional[snapshot_agent_pb2.BackendConfig] = None,
     ) -> SnapshotResponse:
         """Triggers an asynchronous snapshot."""
@@ -50,7 +48,10 @@ class SnapshotAgentInterface(ABC):
 
     @abstractmethod
     def restore(
-        self, job_id: str, group: str = "", backend: Union[str, int] = 0
+        self,
+        job_id: str,
+        group: str = "",
+        backend_config: Optional[snapshot_agent_pb2.BackendConfig] = None,
     ) -> RestoreResponse:
         """Triggers an asynchronous restoration."""
         pass
@@ -117,28 +118,10 @@ class SnapshotAgentClient(SnapshotAgentInterface):
         logger.error(message)
         raise SnapshotAgentError(message, code=e.code(), details=e.details()) from e
 
-    def _get_backend_enum(self, backend: Union[str, int]) -> int:
-        """Maps backend string or int to the Backend enum value."""
-        if isinstance(backend, int):
-            return backend
-        try:
-            # Try exact match first
-            return snapshot_agent_pb2.Backend.Value(backend)
-        except ValueError:
-            # Try with prefix
-            try:
-                return snapshot_agent_pb2.Backend.Value(f"BACKEND_{backend.upper()}")
-            except ValueError:
-                logger.warning(
-                    f"Unknown backend '{backend}', using BACKEND_UNSPECIFIED"
-                )
-                return snapshot_agent_pb2.BACKEND_UNSPECIFIED
-
     def snapshot(
         self,
         job_id: str,
         group: str = "",
-        backend: Union[str, int] = 0,
         backend_config: Optional[snapshot_agent_pb2.BackendConfig] = None,
     ) -> SnapshotResponse:
         """
@@ -146,32 +129,20 @@ class SnapshotAgentClient(SnapshotAgentInterface):
         Args:
             job_id: ID of the job to snapshot.
             group: Group for the snapshot.
-            backend: Backend to use (e.g., 'CUDA' or snapshot_agent_pb2.BACKEND_CUDA).
-            backend_config: Optional BackendConfig proto. If provided, 'backend' is ignored.
+            backend_config: Optional BackendConfig proto.
         Returns:
             SnapshotResponse containing the operation_id.
         Raises:
             SnapshotAgentError on gRPC or unexpected errors.
         """
         try:
-            if backend_config is not None:
-                # Extract backend_enum from backend_config for backward compatibility with old servers
-                if backend_config.HasField("cuda"):
-                    backend_enum = snapshot_agent_pb2.BACKEND_CUDA
-                else:
-                    backend_enum = snapshot_agent_pb2.BACKEND_UNSPECIFIED
-            else:
-                backend_enum = self._get_backend_enum(backend)
-
-            # Send both backend and backend_config for backward compatibility
             request = snapshot_agent_pb2.SnapshotRequest(
                 job_id=job_id,
                 group=group,
-                backend=backend_enum,
                 backend_config=backend_config,
             )
             logger.info(
-                f"Calling Snapshot with job_id={job_id}, group={group}, backend={backend_enum}, backend_config={backend_config}..."
+                f"Calling Snapshot with job_id={job_id}, group={group}, backend_config={backend_config}..."
             )
             response = self.stub.Snapshot(request)
             return SnapshotResponse(operation_id=response.operation_id)
@@ -182,26 +153,30 @@ class SnapshotAgentClient(SnapshotAgentInterface):
             raise SnapshotAgentError(f"Unexpected error: {e}") from e
 
     def restore(
-        self, job_id: str, group: str = "", backend: Union[str, int] = 0
+        self,
+        job_id: str,
+        group: str = "",
+        backend_config: Optional[snapshot_agent_pb2.BackendConfig] = None,
     ) -> RestoreResponse:
         """
         Triggers an asynchronous restoration.
         Args:
             job_id: ID of the job to restore.
             group: Group for the restoration.
-            backend: Backend to use.
+            backend_config: Optional BackendConfig proto.
         Returns:
             RestoreResponse containing the operation_id.
         Raises:
             SnapshotAgentError on gRPC or unexpected errors.
         """
         try:
-            backend_enum = self._get_backend_enum(backend)
             request = snapshot_agent_pb2.RestoreRequest(
-                job_id=job_id, group=group, backend=backend_enum
+                job_id=job_id,
+                group=group,
+                backend_config=backend_config,
             )
             logger.info(
-                f"Calling Restore with job_id={job_id}, group={group}, backend={backend_enum}..."
+                f"Calling Restore with job_id={job_id}, group={group}, backend_config={backend_config}..."
             )
             response = self.stub.Restore(request)
             return RestoreResponse(operation_id=response.operation_id)
@@ -324,21 +299,20 @@ class SnapshotAgentClient(SnapshotAgentInterface):
         self,
         job_id: str,
         group: str = "",
-        backend: Union[str, int] = 0,
         poll_interval_sec: float = 1.0,
         backend_config: Optional[snapshot_agent_pb2.BackendConfig] = None,
     ) -> GetOperationResponse:
         """Calls snapshot and waits for completion."""
-        response = self.snapshot(job_id, group, backend, backend_config=backend_config)
+        response = self.snapshot(job_id, group, backend_config=backend_config)
         return self.wait_for_operation(response.operation_id, poll_interval_sec)
 
     def restore_and_wait(
         self,
         job_id: str,
         group: str = "",
-        backend: Union[str, int] = 0,
         poll_interval_sec: float = 1.0,
+        backend_config: Optional[snapshot_agent_pb2.BackendConfig] = None,
     ) -> GetOperationResponse:
         """Calls restore and waits for completion."""
-        response = self.restore(job_id, group, backend)
+        response = self.restore(job_id, group, backend_config=backend_config)
         return self.wait_for_operation(response.operation_id, poll_interval_sec)

--- a/pkg/client/python/timeslice/snapshot_agent/snapshot_agent_pb2.py
+++ b/pkg/client/python/timeslice/snapshot_agent/snapshot_agent_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n-timeslice/snapshot_agent/snapshot_agent.proto\x12\x17snapshot_agent.v1alpha1\"\x1d\n\rProcessTarget\x12\x0c\n\x04pids\x18\x01 \x03(\x05\"T\n\x11\x43udaBackendConfig\x12?\n\x0f\x65xplicit_target\x18\x01 \x01(\x0b\x32&.snapshot_agent.v1alpha1.ProcessTarget\"V\n\rBackendConfig\x12:\n\x04\x63uda\x18\x01 \x01(\x0b\x32*.snapshot_agent.v1alpha1.CudaBackendConfigH\x00\x42\t\n\x07\x62\x61\x63kend\"\xa7\x01\n\x0fSnapshotRequest\x12\x0e\n\x06job_id\x18\x01 \x01(\t\x12\r\n\x05group\x18\x02 \x01(\t\x12\x35\n\x07\x62\x61\x63kend\x18\x03 \x01(\x0e\x32 .snapshot_agent.v1alpha1.BackendB\x02\x18\x01\x12>\n\x0e\x62\x61\x63kend_config\x18\x04 \x01(\x0b\x32&.snapshot_agent.v1alpha1.BackendConfig\"(\n\x10SnapshotResponse\x12\x14\n\x0coperation_id\x18\x01 \x01(\t\"b\n\x0eRestoreRequest\x12\x0e\n\x06job_id\x18\x01 \x01(\t\x12\r\n\x05group\x18\x02 \x01(\t\x12\x31\n\x07\x62\x61\x63kend\x18\x03 \x01(\x0e\x32 .snapshot_agent.v1alpha1.Backend\"\'\n\x0fRestoreResponse\x12\x14\n\x0coperation_id\x18\x01 \x01(\t\"+\n\x13GetOperationRequest\x12\x14\n\x0coperation_id\x18\x01 \x01(\t\"\xee\x01\n\x14GetOperationResponse\x12\x38\n\x06status\x18\x01 \x01(\x0e\x32(.snapshot_agent.v1alpha1.OperationStatus\x12\x1a\n\rstorage_bytes\x18\x02 \x01(\x03H\x00\x88\x01\x01\x12\"\n\x15snapshot_device_bytes\x18\x03 \x01(\x03H\x01\x88\x01\x01\x12\x12\n\nelapsed_ms\x18\x04 \x01(\x03\x12\x12\n\x05\x65rror\x18\x05 \x01(\tH\x02\x88\x01\x01\x42\x10\n\x0e_storage_bytesB\x18\n\x16_snapshot_device_bytesB\x08\n\x06_error\"\x0f\n\rStatusRequest\"M\n\tJobStatus\x12\x0e\n\x06job_id\x18\x01 \x01(\t\x12\x30\n\x05state\x18\x02 \x01(\x0e\x32!.snapshot_agent.v1alpha1.JobState\"V\n\x11\x41\x63\x63\x65leratorStatus\x12\n\n\x02id\x18\x01 \x01(\t\x12\x19\n\x11memory_used_bytes\x18\x02 \x01(\x03\x12\x1a\n\x12memory_total_bytes\x18\x03 \x01(\x03\"\x94\x01\n\x0eStatusResponse\x12\x38\n\x0cjob_statuses\x18\x01 \x03(\x0b\x32\".snapshot_agent.v1alpha1.JobStatus\x12H\n\x14\x61\x63\x63\x65lerator_statuses\x18\x02 \x03(\x0b\x32*.snapshot_agent.v1alpha1.AcceleratorStatus*4\n\x07\x42\x61\x63kend\x12\x17\n\x13\x42\x41\x43KEND_UNSPECIFIED\x10\x00\x12\x10\n\x0c\x42\x41\x43KEND_CUDA\x10\x01*\x8d\x01\n\x0fOperationStatus\x12 \n\x1cOPERATION_STATUS_UNSPECIFIED\x10\x00\x12\x1c\n\x18OPERATION_STATUS_PENDING\x10\x01\x12\x1d\n\x19OPERATION_STATUS_COMPLETE\x10\x02\x12\x1b\n\x17OPERATION_STATUS_FAILED\x10\x03*\x99\x01\n\x08JobState\x12\x19\n\x15JOB_STATE_UNSPECIFIED\x10\x00\x12\x12\n\x0eJOB_STATE_IDLE\x10\x01\x12\x15\n\x11JOB_STATE_RUNNING\x10\x02\x12\x1b\n\x17JOB_STATE_TRANSITIONING\x10\x03\x12\x13\n\x0fJOB_STATE_SAVED\x10\x04\x12\x15\n\x11JOB_STATE_FAULTED\x10\x05\x32\x9d\x03\n\x14SnapshotAgentService\x12_\n\x08Snapshot\x12(.snapshot_agent.v1alpha1.SnapshotRequest\x1a).snapshot_agent.v1alpha1.SnapshotResponse\x12\\\n\x07Restore\x12\'.snapshot_agent.v1alpha1.RestoreRequest\x1a(.snapshot_agent.v1alpha1.RestoreResponse\x12k\n\x0cGetOperation\x12,.snapshot_agent.v1alpha1.GetOperationRequest\x1a-.snapshot_agent.v1alpha1.GetOperationResponse\x12Y\n\x06Status\x12&.snapshot_agent.v1alpha1.StatusRequest\x1a\'.snapshot_agent.v1alpha1.StatusResponseB\\ZZgithub.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1;v1alpha1b\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n-timeslice/snapshot_agent/snapshot_agent.proto\x12\x17snapshot_agent.v1alpha1\"\x1d\n\rProcessTarget\x12\x0c\n\x04pids\x18\x01 \x03(\x05\"T\n\x11\x43udaBackendConfig\x12?\n\x0f\x65xplicit_target\x18\x01 \x01(\x0b\x32&.snapshot_agent.v1alpha1.ProcessTarget\"V\n\rBackendConfig\x12:\n\x04\x63uda\x18\x01 \x01(\x0b\x32*.snapshot_agent.v1alpha1.CudaBackendConfigH\x00\x42\t\n\x07\x62\x61\x63kend\"\xa7\x01\n\x0fSnapshotRequest\x12\x0e\n\x06job_id\x18\x01 \x01(\t\x12\r\n\x05group\x18\x02 \x01(\t\x12\x35\n\x07\x62\x61\x63kend\x18\x03 \x01(\x0e\x32 .snapshot_agent.v1alpha1.BackendB\x02\x18\x01\x12>\n\x0e\x62\x61\x63kend_config\x18\x04 \x01(\x0b\x32&.snapshot_agent.v1alpha1.BackendConfig\"(\n\x10SnapshotResponse\x12\x14\n\x0coperation_id\x18\x01 \x01(\t\"\xa6\x01\n\x0eRestoreRequest\x12\x0e\n\x06job_id\x18\x01 \x01(\t\x12\r\n\x05group\x18\x02 \x01(\t\x12\x35\n\x07\x62\x61\x63kend\x18\x03 \x01(\x0e\x32 .snapshot_agent.v1alpha1.BackendB\x02\x18\x01\x12>\n\x0e\x62\x61\x63kend_config\x18\x04 \x01(\x0b\x32&.snapshot_agent.v1alpha1.BackendConfig\"\'\n\x0fRestoreResponse\x12\x14\n\x0coperation_id\x18\x01 \x01(\t\"+\n\x13GetOperationRequest\x12\x14\n\x0coperation_id\x18\x01 \x01(\t\"\xee\x01\n\x14GetOperationResponse\x12\x38\n\x06status\x18\x01 \x01(\x0e\x32(.snapshot_agent.v1alpha1.OperationStatus\x12\x1a\n\rstorage_bytes\x18\x02 \x01(\x03H\x00\x88\x01\x01\x12\"\n\x15snapshot_device_bytes\x18\x03 \x01(\x03H\x01\x88\x01\x01\x12\x12\n\nelapsed_ms\x18\x04 \x01(\x03\x12\x12\n\x05\x65rror\x18\x05 \x01(\tH\x02\x88\x01\x01\x42\x10\n\x0e_storage_bytesB\x18\n\x16_snapshot_device_bytesB\x08\n\x06_error\"\x0f\n\rStatusRequest\"M\n\tJobStatus\x12\x0e\n\x06job_id\x18\x01 \x01(\t\x12\x30\n\x05state\x18\x02 \x01(\x0e\x32!.snapshot_agent.v1alpha1.JobState\"V\n\x11\x41\x63\x63\x65leratorStatus\x12\n\n\x02id\x18\x01 \x01(\t\x12\x19\n\x11memory_used_bytes\x18\x02 \x01(\x03\x12\x1a\n\x12memory_total_bytes\x18\x03 \x01(\x03\"\x94\x01\n\x0eStatusResponse\x12\x38\n\x0cjob_statuses\x18\x01 \x03(\x0b\x32\".snapshot_agent.v1alpha1.JobStatus\x12H\n\x14\x61\x63\x63\x65lerator_statuses\x18\x02 \x03(\x0b\x32*.snapshot_agent.v1alpha1.AcceleratorStatus*8\n\x07\x42\x61\x63kend\x12\x17\n\x13\x42\x41\x43KEND_UNSPECIFIED\x10\x00\x12\x10\n\x0c\x42\x41\x43KEND_CUDA\x10\x01\x1a\x02\x18\x01*\x8d\x01\n\x0fOperationStatus\x12 \n\x1cOPERATION_STATUS_UNSPECIFIED\x10\x00\x12\x1c\n\x18OPERATION_STATUS_PENDING\x10\x01\x12\x1d\n\x19OPERATION_STATUS_COMPLETE\x10\x02\x12\x1b\n\x17OPERATION_STATUS_FAILED\x10\x03*\x99\x01\n\x08JobState\x12\x19\n\x15JOB_STATE_UNSPECIFIED\x10\x00\x12\x12\n\x0eJOB_STATE_IDLE\x10\x01\x12\x15\n\x11JOB_STATE_RUNNING\x10\x02\x12\x1b\n\x17JOB_STATE_TRANSITIONING\x10\x03\x12\x13\n\x0fJOB_STATE_SAVED\x10\x04\x12\x15\n\x11JOB_STATE_FAULTED\x10\x05\x32\x9d\x03\n\x14SnapshotAgentService\x12_\n\x08Snapshot\x12(.snapshot_agent.v1alpha1.SnapshotRequest\x1a).snapshot_agent.v1alpha1.SnapshotResponse\x12\\\n\x07Restore\x12\'.snapshot_agent.v1alpha1.RestoreRequest\x1a(.snapshot_agent.v1alpha1.RestoreResponse\x12k\n\x0cGetOperation\x12,.snapshot_agent.v1alpha1.GetOperationRequest\x1a-.snapshot_agent.v1alpha1.GetOperationResponse\x12Y\n\x06Status\x12&.snapshot_agent.v1alpha1.StatusRequest\x1a\'.snapshot_agent.v1alpha1.StatusResponseB\\ZZgithub.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1;v1alpha1b\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,14 +32,18 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'timeslice.snapshot_agent.sn
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'ZZgithub.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1;v1alpha1'
+  _globals['_BACKEND']._loaded_options = None
+  _globals['_BACKEND']._serialized_options = b'\030\001'
   _globals['_SNAPSHOTREQUEST'].fields_by_name['backend']._loaded_options = None
   _globals['_SNAPSHOTREQUEST'].fields_by_name['backend']._serialized_options = b'\030\001'
-  _globals['_BACKEND']._serialized_start=1253
-  _globals['_BACKEND']._serialized_end=1305
-  _globals['_OPERATIONSTATUS']._serialized_start=1308
-  _globals['_OPERATIONSTATUS']._serialized_end=1449
-  _globals['_JOBSTATE']._serialized_start=1452
-  _globals['_JOBSTATE']._serialized_end=1605
+  _globals['_RESTOREREQUEST'].fields_by_name['backend']._loaded_options = None
+  _globals['_RESTOREREQUEST'].fields_by_name['backend']._serialized_options = b'\030\001'
+  _globals['_BACKEND']._serialized_start=1322
+  _globals['_BACKEND']._serialized_end=1378
+  _globals['_OPERATIONSTATUS']._serialized_start=1381
+  _globals['_OPERATIONSTATUS']._serialized_end=1522
+  _globals['_JOBSTATE']._serialized_start=1525
+  _globals['_JOBSTATE']._serialized_end=1678
   _globals['_PROCESSTARGET']._serialized_start=74
   _globals['_PROCESSTARGET']._serialized_end=103
   _globals['_CUDABACKENDCONFIG']._serialized_start=105
@@ -50,22 +54,22 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_SNAPSHOTREQUEST']._serialized_end=447
   _globals['_SNAPSHOTRESPONSE']._serialized_start=449
   _globals['_SNAPSHOTRESPONSE']._serialized_end=489
-  _globals['_RESTOREREQUEST']._serialized_start=491
-  _globals['_RESTOREREQUEST']._serialized_end=589
-  _globals['_RESTORERESPONSE']._serialized_start=591
-  _globals['_RESTORERESPONSE']._serialized_end=630
-  _globals['_GETOPERATIONREQUEST']._serialized_start=632
-  _globals['_GETOPERATIONREQUEST']._serialized_end=675
-  _globals['_GETOPERATIONRESPONSE']._serialized_start=678
-  _globals['_GETOPERATIONRESPONSE']._serialized_end=916
-  _globals['_STATUSREQUEST']._serialized_start=918
-  _globals['_STATUSREQUEST']._serialized_end=933
-  _globals['_JOBSTATUS']._serialized_start=935
-  _globals['_JOBSTATUS']._serialized_end=1012
-  _globals['_ACCELERATORSTATUS']._serialized_start=1014
-  _globals['_ACCELERATORSTATUS']._serialized_end=1100
-  _globals['_STATUSRESPONSE']._serialized_start=1103
-  _globals['_STATUSRESPONSE']._serialized_end=1251
-  _globals['_SNAPSHOTAGENTSERVICE']._serialized_start=1608
-  _globals['_SNAPSHOTAGENTSERVICE']._serialized_end=2021
+  _globals['_RESTOREREQUEST']._serialized_start=492
+  _globals['_RESTOREREQUEST']._serialized_end=658
+  _globals['_RESTORERESPONSE']._serialized_start=660
+  _globals['_RESTORERESPONSE']._serialized_end=699
+  _globals['_GETOPERATIONREQUEST']._serialized_start=701
+  _globals['_GETOPERATIONREQUEST']._serialized_end=744
+  _globals['_GETOPERATIONRESPONSE']._serialized_start=747
+  _globals['_GETOPERATIONRESPONSE']._serialized_end=985
+  _globals['_STATUSREQUEST']._serialized_start=987
+  _globals['_STATUSREQUEST']._serialized_end=1002
+  _globals['_JOBSTATUS']._serialized_start=1004
+  _globals['_JOBSTATUS']._serialized_end=1081
+  _globals['_ACCELERATORSTATUS']._serialized_start=1083
+  _globals['_ACCELERATORSTATUS']._serialized_end=1169
+  _globals['_STATUSRESPONSE']._serialized_start=1172
+  _globals['_STATUSRESPONSE']._serialized_end=1320
+  _globals['_SNAPSHOTAGENTSERVICE']._serialized_start=1681
+  _globals['_SNAPSHOTAGENTSERVICE']._serialized_end=2094
 # @@protoc_insertion_point(module_scope)

--- a/pkg/snapshot-agent/api/v1alpha1/snapshot_agent.pb.go
+++ b/pkg/snapshot-agent/api/v1alpha1/snapshot_agent.pb.go
@@ -7,12 +7,11 @@
 package v1alpha1
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -22,6 +21,7 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+// Deprecated: Marked as deprecated in snapshot_agent.proto.
 type Backend int32
 
 const (
@@ -465,8 +465,13 @@ type RestoreRequest struct {
 	// job_id should be unique within that group.
 	JobId string `protobuf:"bytes,1,opt,name=job_id,json=jobId,proto3" json:"job_id,omitempty"`
 	// group is an optional identifier for a set of related jobs.
-	Group         string  `protobuf:"bytes,2,opt,name=group,proto3" json:"group,omitempty"`
-	Backend       Backend `protobuf:"varint,3,opt,name=backend,proto3,enum=snapshot_agent.v1alpha1.Backend" json:"backend,omitempty"`
+	Group string `protobuf:"bytes,2,opt,name=group,proto3" json:"group,omitempty"`
+	// Deprecated: Use backend_config instead.
+	//
+	// Deprecated: Marked as deprecated in snapshot_agent.proto.
+	Backend Backend `protobuf:"varint,3,opt,name=backend,proto3,enum=snapshot_agent.v1alpha1.Backend" json:"backend,omitempty"`
+	// backend_config specifies the backend-specific configuration for the restoration.
+	BackendConfig *BackendConfig `protobuf:"bytes,4,opt,name=backend_config,json=backendConfig,proto3" json:"backend_config,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -515,11 +520,19 @@ func (x *RestoreRequest) GetGroup() string {
 	return ""
 }
 
+// Deprecated: Marked as deprecated in snapshot_agent.proto.
 func (x *RestoreRequest) GetBackend() Backend {
 	if x != nil {
 		return x.Backend
 	}
 	return Backend_BACKEND_UNSPECIFIED
+}
+
+func (x *RestoreRequest) GetBackendConfig() *BackendConfig {
+	if x != nil {
+		return x.BackendConfig
+	}
+	return nil
 }
 
 type RestoreResponse struct {
@@ -907,11 +920,12 @@ const file_snapshot_agent_proto_rawDesc = "" +
 	"\abackend\x18\x03 \x01(\x0e2 .snapshot_agent.v1alpha1.BackendB\x02\x18\x01R\abackend\x12M\n" +
 	"\x0ebackend_config\x18\x04 \x01(\v2&.snapshot_agent.v1alpha1.BackendConfigR\rbackendConfig\"5\n" +
 	"\x10SnapshotResponse\x12!\n" +
-	"\foperation_id\x18\x01 \x01(\tR\voperationId\"y\n" +
+	"\foperation_id\x18\x01 \x01(\tR\voperationId\"\xcc\x01\n" +
 	"\x0eRestoreRequest\x12\x15\n" +
 	"\x06job_id\x18\x01 \x01(\tR\x05jobId\x12\x14\n" +
-	"\x05group\x18\x02 \x01(\tR\x05group\x12:\n" +
-	"\abackend\x18\x03 \x01(\x0e2 .snapshot_agent.v1alpha1.BackendR\abackend\"4\n" +
+	"\x05group\x18\x02 \x01(\tR\x05group\x12>\n" +
+	"\abackend\x18\x03 \x01(\x0e2 .snapshot_agent.v1alpha1.BackendB\x02\x18\x01R\abackend\x12M\n" +
+	"\x0ebackend_config\x18\x04 \x01(\v2&.snapshot_agent.v1alpha1.BackendConfigR\rbackendConfig\"4\n" +
 	"\x0fRestoreResponse\x12!\n" +
 	"\foperation_id\x18\x01 \x01(\tR\voperationId\"8\n" +
 	"\x13GetOperationRequest\x12!\n" +
@@ -936,10 +950,10 @@ const file_snapshot_agent_proto_rawDesc = "" +
 	"\x12memory_total_bytes\x18\x03 \x01(\x03R\x10memoryTotalBytes\"\xb6\x01\n" +
 	"\x0eStatusResponse\x12E\n" +
 	"\fjob_statuses\x18\x01 \x03(\v2\".snapshot_agent.v1alpha1.JobStatusR\vjobStatuses\x12]\n" +
-	"\x14accelerator_statuses\x18\x02 \x03(\v2*.snapshot_agent.v1alpha1.AcceleratorStatusR\x13acceleratorStatuses*4\n" +
+	"\x14accelerator_statuses\x18\x02 \x03(\v2*.snapshot_agent.v1alpha1.AcceleratorStatusR\x13acceleratorStatuses*8\n" +
 	"\aBackend\x12\x17\n" +
 	"\x13BACKEND_UNSPECIFIED\x10\x00\x12\x10\n" +
-	"\fBACKEND_CUDA\x10\x01*\x8d\x01\n" +
+	"\fBACKEND_CUDA\x10\x01\x1a\x02\x18\x01*\x8d\x01\n" +
 	"\x0fOperationStatus\x12 \n" +
 	"\x1cOPERATION_STATUS_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18OPERATION_STATUS_PENDING\x10\x01\x12\x1d\n" +
@@ -996,23 +1010,24 @@ var file_snapshot_agent_proto_depIdxs = []int32{
 	0,  // 2: snapshot_agent.v1alpha1.SnapshotRequest.backend:type_name -> snapshot_agent.v1alpha1.Backend
 	5,  // 3: snapshot_agent.v1alpha1.SnapshotRequest.backend_config:type_name -> snapshot_agent.v1alpha1.BackendConfig
 	0,  // 4: snapshot_agent.v1alpha1.RestoreRequest.backend:type_name -> snapshot_agent.v1alpha1.Backend
-	1,  // 5: snapshot_agent.v1alpha1.GetOperationResponse.status:type_name -> snapshot_agent.v1alpha1.OperationStatus
-	2,  // 6: snapshot_agent.v1alpha1.JobStatus.state:type_name -> snapshot_agent.v1alpha1.JobState
-	13, // 7: snapshot_agent.v1alpha1.StatusResponse.job_statuses:type_name -> snapshot_agent.v1alpha1.JobStatus
-	14, // 8: snapshot_agent.v1alpha1.StatusResponse.accelerator_statuses:type_name -> snapshot_agent.v1alpha1.AcceleratorStatus
-	6,  // 9: snapshot_agent.v1alpha1.SnapshotAgentService.Snapshot:input_type -> snapshot_agent.v1alpha1.SnapshotRequest
-	8,  // 10: snapshot_agent.v1alpha1.SnapshotAgentService.Restore:input_type -> snapshot_agent.v1alpha1.RestoreRequest
-	10, // 11: snapshot_agent.v1alpha1.SnapshotAgentService.GetOperation:input_type -> snapshot_agent.v1alpha1.GetOperationRequest
-	12, // 12: snapshot_agent.v1alpha1.SnapshotAgentService.Status:input_type -> snapshot_agent.v1alpha1.StatusRequest
-	7,  // 13: snapshot_agent.v1alpha1.SnapshotAgentService.Snapshot:output_type -> snapshot_agent.v1alpha1.SnapshotResponse
-	9,  // 14: snapshot_agent.v1alpha1.SnapshotAgentService.Restore:output_type -> snapshot_agent.v1alpha1.RestoreResponse
-	11, // 15: snapshot_agent.v1alpha1.SnapshotAgentService.GetOperation:output_type -> snapshot_agent.v1alpha1.GetOperationResponse
-	15, // 16: snapshot_agent.v1alpha1.SnapshotAgentService.Status:output_type -> snapshot_agent.v1alpha1.StatusResponse
-	13, // [13:17] is the sub-list for method output_type
-	9,  // [9:13] is the sub-list for method input_type
-	9,  // [9:9] is the sub-list for extension type_name
-	9,  // [9:9] is the sub-list for extension extendee
-	0,  // [0:9] is the sub-list for field type_name
+	5,  // 5: snapshot_agent.v1alpha1.RestoreRequest.backend_config:type_name -> snapshot_agent.v1alpha1.BackendConfig
+	1,  // 6: snapshot_agent.v1alpha1.GetOperationResponse.status:type_name -> snapshot_agent.v1alpha1.OperationStatus
+	2,  // 7: snapshot_agent.v1alpha1.JobStatus.state:type_name -> snapshot_agent.v1alpha1.JobState
+	13, // 8: snapshot_agent.v1alpha1.StatusResponse.job_statuses:type_name -> snapshot_agent.v1alpha1.JobStatus
+	14, // 9: snapshot_agent.v1alpha1.StatusResponse.accelerator_statuses:type_name -> snapshot_agent.v1alpha1.AcceleratorStatus
+	6,  // 10: snapshot_agent.v1alpha1.SnapshotAgentService.Snapshot:input_type -> snapshot_agent.v1alpha1.SnapshotRequest
+	8,  // 11: snapshot_agent.v1alpha1.SnapshotAgentService.Restore:input_type -> snapshot_agent.v1alpha1.RestoreRequest
+	10, // 12: snapshot_agent.v1alpha1.SnapshotAgentService.GetOperation:input_type -> snapshot_agent.v1alpha1.GetOperationRequest
+	12, // 13: snapshot_agent.v1alpha1.SnapshotAgentService.Status:input_type -> snapshot_agent.v1alpha1.StatusRequest
+	7,  // 14: snapshot_agent.v1alpha1.SnapshotAgentService.Snapshot:output_type -> snapshot_agent.v1alpha1.SnapshotResponse
+	9,  // 15: snapshot_agent.v1alpha1.SnapshotAgentService.Restore:output_type -> snapshot_agent.v1alpha1.RestoreResponse
+	11, // 16: snapshot_agent.v1alpha1.SnapshotAgentService.GetOperation:output_type -> snapshot_agent.v1alpha1.GetOperationResponse
+	15, // 17: snapshot_agent.v1alpha1.SnapshotAgentService.Status:output_type -> snapshot_agent.v1alpha1.StatusResponse
+	14, // [14:18] is the sub-list for method output_type
+	10, // [10:14] is the sub-list for method input_type
+	10, // [10:10] is the sub-list for extension type_name
+	10, // [10:10] is the sub-list for extension extendee
+	0,  // [0:10] is the sub-list for field type_name
 }
 
 func init() { file_snapshot_agent_proto_init() }

--- a/pkg/snapshot-agent/api/v1alpha1/snapshot_agent.proto
+++ b/pkg/snapshot-agent/api/v1alpha1/snapshot_agent.proto
@@ -20,6 +20,7 @@ service SnapshotAgentService {
 }
 
 enum Backend {
+  option deprecated = true;
   BACKEND_UNSPECIFIED = 0;
   BACKEND_CUDA = 1;
 }
@@ -67,7 +68,10 @@ message RestoreRequest {
   string job_id = 1;
   // group is an optional identifier for a set of related jobs.
   string group = 2;
-  Backend backend = 3;
+  // Deprecated: Use backend_config instead.
+  Backend backend = 3 [deprecated = true];
+  // backend_config specifies the backend-specific configuration for the restoration.
+  BackendConfig backend_config = 4;
 }
 
 message RestoreResponse {

--- a/pkg/snapshot-agent/api/v1alpha1/snapshot_agent_grpc.pb.go
+++ b/pkg/snapshot-agent/api/v1alpha1/snapshot_agent_grpc.pb.go
@@ -8,7 +8,6 @@ package v1alpha1
 
 import (
 	context "context"
-
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/pkg/snapshot-agent/server/server.go
+++ b/pkg/snapshot-agent/server/server.go
@@ -43,28 +43,13 @@ func NewServer(
 	}
 }
 
-func (s *Server) getBackendType(backend pb.Backend) backends.BackendType {
-	switch backend {
-	case pb.Backend_BACKEND_CUDA:
-		return backends.BackendCuda
-	default:
-		return s.defaultBackend
-	}
-}
-
 // Snapshot triggers an asynchronous snapshot of the accelerator context for a job.
 func (s *Server) Snapshot(ctx context.Context, req *pb.SnapshotRequest) (*pb.SnapshotResponse, error) {
 	ctx = logging.WithServerMethod(ctx, "Snapshot")
 	ctx = logging.WithJobID(ctx, req.GetJobId())
 	ctx = logging.WithGroupID(ctx, req.GetGroup())
 
-	var backendType backends.BackendType
-	if req.GetBackendConfig() != nil {
-		backendType = s.getSnapshotBackendType(req.GetBackendConfig())
-	} else {
-		//nolint:staticcheck // SA1019: Keep supporting deprecated backend field for backward compatibility
-		backendType = s.getBackendType(req.GetBackend())
-	}
+	backendType := s.getSnapshotBackendType(req.GetBackendConfig())
 	slog.InfoContext(ctx, "Snapshot called", "backend", backendType)
 
 	var explicitPIDs []int32
@@ -126,9 +111,8 @@ func (s *Server) Restore(ctx context.Context, req *pb.RestoreRequest) (*pb.Resto
 	ctx = logging.WithJobID(ctx, req.GetJobId())
 	ctx = logging.WithGroupID(ctx, req.GetGroup())
 
-	slog.InfoContext(ctx, "Restore called", "backend", req.GetBackend())
-
-	backendType := s.getBackendType(req.GetBackend())
+	backendType := s.getSnapshotBackendType(req.GetBackendConfig())
+	slog.InfoContext(ctx, "Restore called", "backend", backendType)
 
 	backend, ok := s.backendMap[backendType]
 	if !ok {

--- a/pkg/snapshot-agent/server/server_internal_test.go
+++ b/pkg/snapshot-agent/server/server_internal_test.go
@@ -55,6 +55,7 @@ func initGRPCServer() {
 	failingBackend := &FailingBackend{}
 	backendsMap := map[backends.BackendType]backends.Backend{
 		backends.BackendNoop: noopBackend,
+		backends.BackendCuda: noopBackend,
 		"failing":            failingBackend,
 	}
 
@@ -132,9 +133,8 @@ func prepareSavedJob(
 	}
 
 	_, err := client.Snapshot(ctx, &pb.SnapshotRequest{
-		JobId:   jobID,
-		Group:   group,
-		Backend: pb.Backend_BACKEND_UNSPECIFIED,
+		JobId: jobID,
+		Group: group,
 	})
 	if err != nil {
 		t.Fatalf("Failed to snapshot: %v", err)
@@ -174,11 +174,12 @@ func TestServer_Snapshot(t *testing.T) {
 	client := pb.NewSnapshotAgentServiceClient(conn)
 
 	tests := []struct {
-		name    string
-		jobID   string
-		group   string
-		podName string
-		pids    []int
+		name          string
+		jobID         string
+		group         string
+		podName       string
+		pids          []int
+		backendConfig *pb.BackendConfig
 	}{
 		{
 			name:    "With Group",
@@ -193,6 +194,18 @@ func TestServer_Snapshot(t *testing.T) {
 			group:   "",
 			podName: "pod-snapshot-nogroup",
 			pids:    []int{456},
+		},
+		{
+			name:    "With BackendConfig",
+			jobID:   "test-job-snapshot-backendconfig",
+			group:   "",
+			podName: "pod-snapshot-backendconfig",
+			pids:    []int{789},
+			backendConfig: &pb.BackendConfig{
+				Backend: &pb.BackendConfig_Cuda{
+					Cuda: &pb.CudaBackendConfig{},
+				},
+			},
 		},
 	}
 
@@ -210,9 +223,9 @@ func TestServer_Snapshot(t *testing.T) {
 			}
 
 			_, err = client.Snapshot(ctx, &pb.SnapshotRequest{
-				JobId:   tc.jobID,
-				Group:   tc.group,
-				Backend: pb.Backend_BACKEND_UNSPECIFIED,
+				JobId:         tc.jobID,
+				Group:         tc.group,
+				BackendConfig: tc.backendConfig,
 			})
 			if err != nil {
 				t.Errorf("Expected success (using default noop backend), got error: %v", err)
@@ -234,11 +247,12 @@ func TestServer_Restore(t *testing.T) {
 	client := pb.NewSnapshotAgentServiceClient(conn)
 
 	tests := []struct {
-		name    string
-		jobID   string
-		group   string
-		podName string
-		pids    []int
+		name          string
+		jobID         string
+		group         string
+		podName       string
+		pids          []int
+		backendConfig *pb.BackendConfig
 	}{
 		{
 			name:    "With Group",
@@ -254,6 +268,18 @@ func TestServer_Restore(t *testing.T) {
 			podName: "pod-restore-nogroup",
 			pids:    []int{456},
 		},
+		{
+			name:    "With BackendConfig",
+			jobID:   "test-job-restore-backendconfig",
+			group:   "",
+			podName: "pod-restore-backendconfig",
+			pids:    []int{789},
+			backendConfig: &pb.BackendConfig{
+				Backend: &pb.BackendConfig_Cuda{
+					Cuda: &pb.CudaBackendConfig{},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {
@@ -261,9 +287,9 @@ func TestServer_Restore(t *testing.T) {
 			prepareSavedJob(t, client, ctx, tc.jobID, tc.group, tc.podName, tc.pids)
 
 			_, err = client.Restore(ctx, &pb.RestoreRequest{
-				JobId:   tc.jobID,
-				Group:   tc.group,
-				Backend: pb.Backend_BACKEND_UNSPECIFIED,
+				JobId:         tc.jobID,
+				Group:         tc.group,
+				BackendConfig: tc.backendConfig,
 			})
 			if err != nil {
 				t.Errorf("Expected success (using default noop backend), got error: %v", err)
@@ -405,10 +431,10 @@ func TestServer_Health(t *testing.T) {
 		t.Errorf("Expected status=SERVING for noop backend, got %v", resp.Status)
 	}
 
-	// Test missing backend (Cuda is not in backendsMap in initGRPCServer)
-	_, err = client.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: string(backends.BackendCuda)})
+	// Test missing backend (Cuda is now in backendsMap in initGRPCServer, use a non-existent one)
+	_, err = client.Check(ctx, &grpc_health_v1.HealthCheckRequest{Service: "missing-backend"})
 	if status.Code(err) != codes.NotFound {
-		t.Errorf("Expected NotFound error for missing CUDA backend, got: %v", err)
+		t.Errorf("Expected NotFound error for missing backend, got: %v", err)
 	}
 
 	// Test failing backend


### PR DESCRIPTION
## What does this PR do?

This PR finalizes the migration from the legacy `Backend` enum to the new `BackendConfig` structure in the Snapshot Agent API.

The server now completely ignores the legacy `backend` enum field. All internal routing and logic have been updated to strictly depend on `BackendConfig`.

Action Required for Users: If you are calling the Snapshot Agent directly (e.g., via grpcurl or older client versions), you must update your requests to specify `backend_config` instead of `backend`.

## Why is this change needed?

https://github.com/llm-d-incubation/llm-d-rl-time-slicing/issues/51

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

https://github.com/llm-d-incubation/llm-d-rl-time-slicing/issues/51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshot and restore now support backend-specific configuration via `backend_config` (including CUDA), in addition to legacy backend selection.
* **Bug Fixes**
  * Restore backend selection now follows the same `backend_config`-first behavior as snapshot.
  * Legacy backend selection remains supported for backward compatibility (now deprecated).
* **Documentation**
  * Updated the Python client README and usage examples to use `backend_config`.
* **Tests**
  * Expanded server-side tests to validate `backend_config`-based snapshot and restore requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->