### PR TITLE
Crash Recovery For Mid Transitioning

### DIFF
--- a/pkg/accelerator-orchestrator/controller/controller.go
+++ b/pkg/accelerator-orchestrator/controller/controller.go
@@ -283,11 +283,9 @@ func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activ
 		if state, ok := agentJobStates[activeJobID]; ok && state == pb.SnapshotAgentJobState_STATE_FAULTED {
 			return fmt.Errorf("active job %s is in FAULTED state on node %s, requires human intervention", activeJobID, nodeName)
 		}
-	}
 
-	// Wait out any existing transitioning. We lack the operation ID to track so wait via error
-	// to retry later via rate-limited requeue.
-	if activeJobID != "" {
+		// Wait out any existing transitioning. We lack the operation ID to track so wait via error
+		// to retry later via rate-limited requeue.
 		if state, ok := agentJobStates[activeJobID]; ok && state == pb.SnapshotAgentJobState_STATE_TRANSITIONING {
 			slog.InfoContext(ctx, "Active job is TRANSITIONING, waiting for it to finish", "activeJobID", activeJobID)
 			return fmt.Errorf("reconciliation pending: active job %s is currently transitioning", activeJobID)

--- a/pkg/accelerator-orchestrator/controller/controller.go
+++ b/pkg/accelerator-orchestrator/controller/controller.go
@@ -285,9 +285,14 @@ func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activ
 		}
 	}
 
-	// 2. Wait out any existing transitions
-	// TODO: crash recovery detect that an agent is still in the middle of transitioning. We will not have the operation
-	// number but we can still wait till it leaves that state.
+	// Wait out any existing transitioning. We lack the operation ID to track so wait via error
+	// to retry later via rate-limited requeue.
+	if activeJobID != "" {
+		if state, ok := agentJobStates[activeJobID]; ok && state == pb.SnapshotAgentJobState_STATE_TRANSITIONING {
+			slog.InfoContext(ctx, "Active job is TRANSITIONING, waiting for it to finish", "activeJobID", activeJobID)
+			return fmt.Errorf("reconciliation pending: active job %s is currently transitioning", activeJobID)
+		}
+	}
 
 	// 3. Ensure no other jobs have their context loaded
 	for jobID, state := range agentJobStates {

--- a/pkg/accelerator-orchestrator/controller/controller_test.go
+++ b/pkg/accelerator-orchestrator/controller/controller_test.go
@@ -1882,3 +1882,79 @@ func TestController_Reconcile_DeduceActiveJob_RestartCase(t *testing.T) {
 		})
 	}
 }
+
+func TestController_Reconcile_PreemptionSafetyGates_ActiveJobTransitioning(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
+
+	groupID := "group-1"
+	nodeName := "node-1"
+
+	// 1. Setup group and nodes
+	testGroup, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	testGroup.Status().SetNodes([]string{nodeName})
+	testGroup.Spec().SetActiveJob("job-1")
+
+	// 2. Setup active job in store with TRANSITIONING state
+	job1 := store.NewJob(groupID, "job-1")
+	job1.UpdateContextState(nodeName, pb.SnapshotAgentJobState_STATE_TRANSITIONING)
+
+	if err := jobStore.Put(ctx, job1); err != nil {
+		t.Fatalf("failed to put job1: %v", err)
+	}
+
+	// 3. Mock SnapshotAgentStore to fail if Snapshot/Restore is called
+	mockAgentStore := &controller.MockSnapshotAgentStore{
+		SnapshotFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.SnapshotResponse, error) {
+			t.Errorf("Unexpected call to Snapshot")
+			return nil, fmt.Errorf("unexpected call")
+		},
+		RestoreFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.RestoreResponse, error) {
+			t.Errorf("Unexpected call to Restore")
+			return nil, fmt.Errorf("unexpected call")
+		},
+	}
+
+	mockOrch := &mockInfrastructureOrchestrator{
+		observeFunc: func(ctx context.Context, gID string) error {
+			return nil
+		},
+	}
+
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
+
+	// Start the controller
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+
+	// Trigger reconcile
+	testQueue.Add(groupID)
+
+	// Verify that it failed and was re-queued (AddRateLimited called)
+	err = waitWithTimeout(func() bool {
+		return testQueue.getAddRateLimitedCount() > 0
+	}, 2*time.Second)
+	if err != nil {
+		t.Fatal("Timed out waiting for item to be re-queued (reconciliation should have failed)")
+	}
+
+	if testQueue.getAddRateLimitedCount() < 1 {
+		t.Errorf("Expected AddRateLimited to be called at least once, got %d", testQueue.getAddRateLimitedCount())
+	}
+}


### PR DESCRIPTION
Logic to resume work when the orchestrator gets restarted while active jobs is in a transitioning action.

## What does this PR do?

<!-- Describe the changes and their purpose -->

## Why is this change needed?

We want the orchestrator to be able to resume work if it is ever rebooted during normal operations.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved controller behavior when the active job is marked as transitioning, preventing premature reconciliation and retrying the work item later.
  * Added an active-job-specific safety gate so restore/preemption actions are skipped until the transition completes.

* **Tests**
  * Added a new test covering the transitioning active-job scenario, verifying reconciliation fails and the item is re-queued without triggering unexpected snapshot/restore calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->