### PR TITLE
Crash recovery for STATE_IDLE_YIELDED

### DIFF
--- a/pkg/accelerator-orchestrator/controller/controller.go
+++ b/pkg/accelerator-orchestrator/controller/controller.go
@@ -220,30 +220,32 @@ func (c *Controller) reconcileGroup(ctx context.Context, groupID string) error {
 		return fmt.Errorf("failed to observe job context: %w", err)
 	}
 
-	// TODO: deduce activejob for restart case when group is in STATE_IDLE_YIELDED
-
 	// 2. Determine Desired State
-	g, err := c.groupStore.Get(ctx, groupID)
+	group, err := c.groupStore.Get(ctx, groupID)
 	if err != nil {
 		return fmt.Errorf("failed to get group %s from store: %w", groupID, err)
 	}
 
-	if _, err := g.Spec().TryPromote(ctx); err != nil {
+	if err := c.tryDeduceActiveJob(ctx, group); err != nil {
+		return fmt.Errorf("failed to try deducing active job: %w", err)
+	}
+
+	if _, err := group.Spec().TryPromote(ctx); err != nil {
 		return fmt.Errorf("failed to promote next job: %w", err)
 	}
 
-	activeJob := g.Spec().ActiveJob()
+	activeJob := group.Spec().ActiveJob()
 
 	// 3. Act
 	// TODO: add optional fan out parallelism for node reconciliation
-	for _, node := range g.Status().Nodes() {
-		if err := c.reconcileNode(ctx, g.ID(), node, activeJob); err != nil {
+	for _, node := range group.Status().Nodes() {
+		if err := c.reconcileNode(ctx, group.ID(), node, activeJob); err != nil {
 			return fmt.Errorf("failed to reconcile node %s: %w", node, err)
 		}
 	}
 
 	// 4. Update Status
-	if err := c.updateGroupStatus(ctx, g); err != nil {
+	if err := c.updateGroupStatus(ctx, group); err != nil {
 		return fmt.Errorf("failed to update group status: %w", err)
 	}
 
@@ -338,6 +340,44 @@ func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activ
 	}
 	if err := c.observeNodeJobContext(ctx, groupID, nodeName); err != nil {
 		return fmt.Errorf("failed to refresh agent state after restore: %w", err)
+	}
+
+	return nil
+}
+
+// tryDeduceActiveJob is a best-effort helper that deduces and sets the active job after a controller
+// restart when no job is currently locking the group and exactly one job is loaded on all nodes.
+// If multiple jobs appear loaded or none are loaded, it cannot deduce what was going on and leaves activeJob unchanged.
+func (c *Controller) tryDeduceActiveJob(ctx context.Context, group *store.Group) error {
+	if group.Spec().LockingJob() != "" || group.Spec().ActiveJob() != "" {
+		return nil
+	}
+
+	jobs, err := c.jobStore.ListByGroup(ctx, group.ID())
+	if err != nil {
+		return fmt.Errorf("failed to list jobs for group %s: %w", group.ID(), err)
+	}
+
+	var loadedJob string
+	for _, job := range jobs {
+		loaded, err := c.isJobLoaded(ctx, group, job.JobID())
+		if err != nil {
+			return fmt.Errorf("failed to check if job %s is loaded: %w", job.JobID(), err)
+		}
+		if loaded {
+			if loadedJob != "" {
+				// Multiple jobs appear loaded; cannot unambiguously deduce the active job
+				slog.WarnContext(ctx, "Cannot deduce active job during restart: at least two jobs appear loaded",
+					"candidate1", loadedJob, "candidate2", job.JobID())
+				return nil
+			}
+			loadedJob = job.JobID()
+		}
+	}
+
+	if loadedJob != "" {
+		slog.InfoContext(ctx, "Deduced active job for restart case", "activeJobID", loadedJob)
+		group.Spec().SetActiveJob(loadedJob)
 	}
 
 	return nil

--- a/pkg/accelerator-orchestrator/controller/controller_test.go
+++ b/pkg/accelerator-orchestrator/controller/controller_test.go
@@ -1774,3 +1774,111 @@ func TestController_Reconcile_PreemptionSafetyGates_TransitioningJob(t *testing.
 		t.Errorf("Expected AddRateLimited to be called at least once, got %d", testQueue.getAddRateLimitedCount())
 	}
 }
+
+func TestController_Reconcile_DeduceActiveJob_RestartCase(t *testing.T) {
+	tests := []struct {
+		name              string
+		job1State         pb.SnapshotAgentJobState_State
+		job2State         pb.SnapshotAgentJobState_State
+		expectedActiveJob string
+		expectedLoadedJob string
+		expectedState     pb.GroupStatus_State
+	}{
+		{
+			name:              "Success: exactly one job running (loaded)",
+			job1State:         pb.SnapshotAgentJobState_STATE_RUNNING,
+			job2State:         pb.SnapshotAgentJobState_STATE_SAVED,
+			expectedActiveJob: "job-1",
+			expectedLoadedJob: "job-1",
+			expectedState:     pb.GroupStatus_STATE_IDLE_YIELDED,
+		},
+		{
+			name:              "NoneLoaded: both jobs in saved state",
+			job1State:         pb.SnapshotAgentJobState_STATE_SAVED,
+			job2State:         pb.SnapshotAgentJobState_STATE_SAVED,
+			expectedActiveJob: "",
+			expectedLoadedJob: "",
+			expectedState:     pb.GroupStatus_STATE_IDLE,
+		},
+		{
+			name:              "Ambiguous: both jobs in unspecified state (both loaded in init)",
+			job1State:         pb.SnapshotAgentJobState_STATE_UNSPECIFIED,
+			job2State:         pb.SnapshotAgentJobState_STATE_UNSPECIFIED,
+			expectedActiveJob: "",
+			expectedLoadedJob: "",
+			expectedState:     pb.GroupStatus_STATE_IDLE,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			lockStore := store.NewMemLockStore()
+			groupStore := store.NewGroupStore(lockStore)
+			jobStore := store.NewJobStore()
+			testQueue := &trackQueue{
+				TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+					workqueue.DefaultTypedControllerRateLimiter[string](),
+					workqueue.TypedRateLimitingQueueConfig[string]{Name: "test-" + tc.name},
+				),
+			}
+
+			groupID := "group-1"
+			nodeNames := []string{"node-1", "node-2"}
+
+			group, _, err := groupStore.GetOrCreate(ctx, groupID)
+			if err != nil {
+				t.Fatalf("failed to create group: %v", err)
+			}
+			group.Status().SetNodes(nodeNames)
+
+			job1 := store.NewJob(groupID, "job-1")
+			job1.UpdateContextState("node-1", tc.job1State)
+			job1.UpdateContextState("node-2", tc.job1State)
+			if err := jobStore.Put(ctx, job1); err != nil {
+				t.Fatalf("failed to put job1: %v", err)
+			}
+
+			job2 := store.NewJob(groupID, "job-2")
+			job2.UpdateContextState("node-1", tc.job2State)
+			job2.UpdateContextState("node-2", tc.job2State)
+			if err := jobStore.Put(ctx, job2); err != nil {
+				t.Fatalf("failed to put job2: %v", err)
+			}
+
+			mockOrch := &mockInfrastructureOrchestrator{
+				observeFunc: func(ctx context.Context, gID string) error {
+					return nil
+				},
+			}
+
+			c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, &controller.MockSnapshotAgentStore{})
+
+			go func() {
+				if err := c.Run(ctx, 1); err != nil {
+					t.Errorf("Controller Run failed: %v", err)
+				}
+			}()
+
+			testQueue.Add(groupID)
+
+			err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 2*time.Second)
+			if err != nil {
+				t.Fatalf("Timed out waiting for reconcile: %v", err)
+			}
+
+			if group.Spec().ActiveJob() != tc.expectedActiveJob {
+				t.Errorf("Expected ActiveJob %q, got %q", tc.expectedActiveJob, group.Spec().ActiveJob())
+			}
+			if group.Status().LoadedJob() != tc.expectedLoadedJob {
+				t.Errorf("Expected loadedJob %q, got %q", tc.expectedLoadedJob, group.Status().LoadedJob())
+			}
+			state, _ := group.Status().State()
+			if state != tc.expectedState {
+				t.Errorf("Expected state %v, got %v", tc.expectedState, state)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds the best effort ability to recover after a reboot when the state is having a job in STATE_IDLE_YIELDED. In other words, no one is holding the lock & the last yielder remains active till a new and different job asks for the lock.

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restart handling so the controller can recover the active job more reliably when state is missing or incomplete.
  * Reconciliation now uses a consistent active job selection when updating node and group status, reducing chances of inconsistent state after a restart.

* **Tests**
  * Added coverage for restart scenarios to verify active job detection and the resulting group status across multiple cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->