### PR TITLE
snapshot-agent: bootstrap job state on first snapshot in standalone mode

### DIFF
--- a/pkg/snapshot-agent/server/server.go
+++ b/pkg/snapshot-agent/server/server.go
@@ -70,6 +70,8 @@ func (s *Server) Snapshot(ctx context.Context, req *pb.SnapshotRequest) (*pb.Sna
 		return nil, status.Errorf(codes.NotFound, "backend %s not found", backendType)
 	}
 
+	s.ensureJobRunningIfGPUOccupied(ctx, req.GetJobId(), req.GetGroup())
+
 	bgCtx := context.WithoutCancel(ctx)
 	opID, err := s.state.StartSnapshot(req.GetJobId(), req.GetGroup(), func() error {
 		slog.InfoContext(bgCtx, "Background: Starting snapshot", "backend", backendType)
@@ -103,6 +105,37 @@ func (s *Server) getSnapshotBackendType(config *pb.BackendConfig) backends.Backe
 		return backends.BackendCuda
 	}
 	return s.defaultBackend
+}
+
+// ensureJobRunningIfGPUOccupied registers the job and, if it is IDLE while
+// the GPU has running compute processes, transitions it to RUNNING.
+//
+// Standalone mode only: in k8s mode the watcher is the single source of
+// state-machine transitions (and additionally binds jobs to their targets,
+// e.g. PIDs for the CUDA backend — a backend-specific concern that a future
+// discovery interface will own per backend).
+func (s *Server) ensureJobRunningIfGPUOccupied(ctx context.Context, jobID, group string) {
+	if s.deploymentMode != "standalone" {
+		return
+	}
+	s.state.RegisterJob(jobID, group)
+	statuses := s.state.GetJobStatus()
+	for _, js := range statuses {
+		if js.JobId == jobID && js.State == pb.JobState_JOB_STATE_IDLE {
+			occupied, err := podutils.HasGPUProcesses(ctx)
+			if err != nil {
+				slog.WarnContext(ctx, "NVML check failed, skipping auto-transition", "error", err)
+				return
+			}
+			if occupied {
+				slog.InfoContext(ctx, "GPU occupied, transitioning job to RUNNING", "jobID", jobID)
+				if err := s.state.TransitionToRunning(jobID, nil); err != nil {
+					slog.WarnContext(ctx, "Failed to auto-transition job", "jobID", jobID, "error", err)
+				}
+			}
+			break
+		}
+	}
 }
 
 // Restore triggers an asynchronous restoration of the accelerator context for a job.

--- a/pkg/snapshot-agent/server/server_internal_test.go
+++ b/pkg/snapshot-agent/server/server_internal_test.go
@@ -447,6 +447,122 @@ func TestServer_Health(t *testing.T) {
 	}
 }
 
+//nolint:nonamedreturns // Conflict between gocritic's unnamedResult and nonamedreturns
+func newModeTestServer(
+	t *testing.T,
+	backendsMap map[backends.BackendType]backends.Backend,
+	defaultBackend backends.BackendType,
+	gpuOccupied bool,
+	mode string,
+) (client pb.SnapshotAgentServiceClient, cleanup func()) {
+	t.Helper()
+
+	origHasGPU := utils.HasGPUProcesses
+	utils.HasGPUProcesses = func(_ context.Context) (bool, error) {
+		return gpuOccupied, nil
+	}
+
+	lisLocal := bufconn.Listen(bufSize)
+	s := grpc.NewServer()
+	srv := NewServer(backendsMap, defaultBackend, mode)
+	pb.RegisterSnapshotAgentServiceServer(s, srv)
+	go func() {
+		if err := s.Serve(lisLocal); err != nil {
+			return
+		}
+	}()
+
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lisLocal.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+
+	cleanup = func() {
+		conn.Close()
+		s.GracefulStop()
+		utils.HasGPUProcesses = origHasGPU
+	}
+	client = pb.NewSnapshotAgentServiceClient(conn)
+	return client, cleanup
+}
+
+func TestServer_Snapshot_StandaloneAutoTransition(t *testing.T) {
+	noopBackend := backends.NewNoopBackend()
+	backendsMap := map[backends.BackendType]backends.Backend{
+		backends.BackendNoop: noopBackend,
+		backends.BackendCuda: noopBackend,
+	}
+
+	t.Run("CUDA with PIDs auto-transitions from IDLE", func(t *testing.T) {
+		client, cleanup := newModeTestServer(t, backendsMap, backends.BackendNoop, true, "standalone")
+		defer cleanup()
+
+		resp, err := client.Snapshot(context.Background(), &pb.SnapshotRequest{
+			JobId: "auto-cuda",
+			BackendConfig: &pb.BackendConfig{
+				Backend: &pb.BackendConfig_Cuda{
+					Cuda: &pb.CudaBackendConfig{
+						ExplicitTarget: &pb.ProcessTarget{Pids: []int32{123}},
+					},
+				},
+			},
+		})
+		if err != nil {
+			t.Fatalf("Expected success with GPU occupied, got: %v", err)
+		}
+		if resp.OperationId == "" {
+			t.Error("Expected operation ID")
+		}
+	})
+
+	t.Run("K8s mode does not auto-transition", func(t *testing.T) {
+		// Even with the GPU occupied, k8s mode must not bootstrap unknown
+		// jobs — the watcher is the single source of state transitions.
+		client, cleanup := newModeTestServer(t, backendsMap, backends.BackendNoop, true, "k8s")
+		defer cleanup()
+
+		_, err := client.Snapshot(context.Background(), &pb.SnapshotRequest{
+			JobId: "watcher-unknown",
+			BackendConfig: &pb.BackendConfig{
+				Backend: &pb.BackendConfig_Cuda{
+					Cuda: &pb.CudaBackendConfig{
+						ExplicitTarget: &pb.ProcessTarget{Pids: []int32{123}},
+					},
+				},
+			},
+		})
+		if err == nil {
+			t.Fatal("Expected failure for watcher-unknown job in k8s mode")
+		}
+	})
+
+	t.Run("Rejects when GPU not occupied", func(t *testing.T) {
+		client, cleanup := newModeTestServer(t, backendsMap, backends.BackendNoop, false, "standalone")
+		defer cleanup()
+
+		_, err := client.Snapshot(context.Background(), &pb.SnapshotRequest{
+			JobId: "no-gpu",
+			BackendConfig: &pb.BackendConfig{
+				Backend: &pb.BackendConfig_Cuda{
+					Cuda: &pb.CudaBackendConfig{
+						ExplicitTarget: &pb.ProcessTarget{Pids: []int32{123}},
+					},
+				},
+			},
+		})
+		if err == nil {
+			t.Fatal("Expected failure when GPU not occupied")
+		}
+		if status.Code(err) != codes.FailedPrecondition {
+			t.Errorf("Expected FailedPrecondition, got: %v", err)
+		}
+	})
+}
+
 func TestServer_Snapshot_StandaloneMode(t *testing.T) {
 	lisDev := bufconn.Listen(bufSize)
 	s := grpc.NewServer()

--- a/pkg/snapshot-agent/utils/pod-utils.go
+++ b/pkg/snapshot-agent/utils/pod-utils.go
@@ -46,6 +46,36 @@ type DeviceInterface interface {
 	GetGraphicsRunningProcesses() ([]nvml.ProcessInfo, nvml.Return)
 }
 
+// HasGPUProcesses checks whether any GPU on the node has running compute processes.
+// This is a lightweight NVML check that does not require K8s.
+var HasGPUProcesses = func(ctx context.Context) (bool, error) {
+	ret := NvmlInit()
+	if ret != nvml.SUCCESS {
+		return false, fmt.Errorf("failed to initialize NVML: %v", nvml.ErrorString(ret))
+	}
+	defer NvmlShutdown() //nolint:errcheck // best-effort cleanup, nothing to do on failure
+
+	count, ret := NvmlDeviceGetCount()
+	if ret != nvml.SUCCESS {
+		return false, fmt.Errorf("failed to get device count: %v", nvml.ErrorString(ret))
+	}
+
+	for i := 0; i < count; i++ {
+		device, ret := NvmlDeviceGetHandleByIndex(i)
+		if ret != nvml.SUCCESS {
+			continue
+		}
+		procs, ret := device.GetComputeRunningProcesses()
+		if ret != nvml.SUCCESS {
+			continue
+		}
+		if len(procs) > 0 {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 // GetLocalPods returns a list of pods running on the same node as the current pod.
 // It uses the NODE_NAME environment variable (populated via the Downward API)
 // to filter pods by node and the snapshot-agent label to filter by managed pods.


### PR DESCRIPTION
## Summary

In standalone mode there is no watcher to move jobs out of IDLE, so a first `Snapshot` request was always rejected. On `Snapshot`, the server now registers the job and — if it is IDLE while the GPU has running compute processes (NVML check) — transitions it to RUNNING.

This applies in **standalone mode only**. Discovery does two things: kicking off the job state machine, and binding jobs to their targets (e.g. PIDs for the CUDA backend). In k8s mode the watcher owns the first for all backends; the second is backend-specific and will move behind a per-backend discovery interface.

## Testing

Unit tests cover the standalone auto-transition (GPU occupied and unoccupied) and that k8s mode does not bootstrap watcher-unknown jobs. `go build`, `go test`, golangci-lint: clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Snapshot requests can now detect active GPU compute workloads and automatically transition the associated job to a running state.
  * CUDA snapshots in standalone mode succeed when GPU compute activity is detected (including when explicit PID targeting is provided).
  * Behavior is gated by server mode, so unsupported requests fail appropriately when GPU is occupied.

* **Bug Fixes**
  * CUDA snapshot requests now fail with a clear precondition error when no GPU workload is active.

* **Tests**
  * Added an in-memory gRPC test harness and coverage for GPU-occupied vs non-occupied snapshot behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->