### PR TITLE
[app-endpoint 1/6] snapshot-agent: refactor Backend interface and split server by mode

### DIFF
--- a/pkg/snapshot-agent/backends/checkpoint.go
+++ b/pkg/snapshot-agent/backends/checkpoint.go
@@ -1,6 +1,10 @@
 package backends
 
-import "context"
+import (
+	"context"
+
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+)
 
 // BackendType represents the type of accelerator backend.
 type BackendType string
@@ -12,16 +16,26 @@ const (
 	BackendNoop BackendType = "noop"
 )
 
+// Request carries one backend invocation: the job it targets and the
+// caller-provided (or server-resolved) backend configuration. Server-side
+// per-job context needed by backends belongs here, keeping the wire API and
+// the Backend interface stable as it grows.
+type Request struct {
+	JobID  string
+	Config *pb.BackendConfig
+}
+
 // Backend defines the interface for checkpoint and restore operations.
+// Each backend extracts what it needs from the Request and validates its
+// own required fields, returning a clear error if inputs are missing.
 type Backend interface {
 	// Snapshot triggers a snapshot of the accelerator context for a job.
-	// Returns storageBytes, deviceBytes, and error.
-	Snapshot(ctx context.Context, pids []string) error
+	Snapshot(ctx context.Context, req Request) error
 
 	// Restore triggers a restoration of the accelerator context for a job.
-	Restore(ctx context.Context, pids []string) error
+	Restore(ctx context.Context, req Request) error
 
-	// HealthCheck checks if the backend is healthy by initializing the backend
-	// and the discovery provider.
+	// HealthCheck checks if the backend is healthy and able to serve
+	// snapshot/restore requests.
 	HealthCheck(ctx context.Context) error
 }

--- a/pkg/snapshot-agent/backends/cuda-checkpoint.go
+++ b/pkg/snapshot-agent/backends/cuda-checkpoint.go
@@ -5,10 +5,12 @@ import (
 	"fmt"
 	"log/slog"
 	"os/exec"
+	"strconv"
 	"sync"
 	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
 )
 
 type nvmlClient interface {
@@ -51,13 +53,17 @@ func NewCudaCheckpoint() *CudaCheckpoint {
 }
 
 // Snapshot triggers a snapshot of the accelerator context for a job.
-func (c *CudaCheckpoint) Snapshot(ctx context.Context, pids []string) error {
+func (c *CudaCheckpoint) Snapshot(ctx context.Context, req Request) error {
+	pids := ExtractPIDStrings(req.Config)
+	if len(pids) == 0 {
+		return fmt.Errorf("at least one PID is required for CUDA snapshot")
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	slog.InfoContext(ctx, "Snapshotting PIDs", "pids", pids)
 
-	// 1. Lock and Checkpoint CUDA
 	t0 := time.Now()
 	if err := c.checkpointPIDs(ctx, pids); err != nil {
 		return fmt.Errorf("cuda-checkpoint checkpoint failed: %w", err)
@@ -67,9 +73,10 @@ func (c *CudaCheckpoint) Snapshot(ctx context.Context, pids []string) error {
 }
 
 // Restore triggers a restoration of the accelerator context for a job.
-func (c *CudaCheckpoint) Restore(ctx context.Context, pids []string) error {
+func (c *CudaCheckpoint) Restore(ctx context.Context, req Request) error {
+	pids := ExtractPIDStrings(req.Config)
 	if len(pids) == 0 {
-		return fmt.Errorf("at least one PID is required")
+		return fmt.Errorf("at least one PID is required for CUDA restore")
 	}
 
 	c.mu.Lock()
@@ -82,6 +89,43 @@ func (c *CudaCheckpoint) Restore(ctx context.Context, pids []string) error {
 	}
 	slog.InfoContext(ctx, "cuda-checkpoint toggle took", "duration", time.Since(t0), "pids", pids)
 	return nil
+}
+
+// ExtractPIDStrings extracts PID strings from a BackendConfig.
+func ExtractPIDStrings(config *pb.BackendConfig) []string {
+	if config == nil {
+		return nil
+	}
+	cuda := config.GetCuda()
+	if cuda == nil {
+		return nil
+	}
+	target := cuda.GetExplicitTarget()
+	if target == nil {
+		return nil
+	}
+	pids := make([]string, 0, len(target.GetPids()))
+	for _, pid := range target.GetPids() {
+		pids = append(pids, strconv.Itoa(int(pid)))
+	}
+	return pids
+}
+
+// BuildCudaConfig wraps PID strings into a BackendConfig.
+func BuildCudaConfig(pidStrings []string) *pb.BackendConfig {
+	pids := make([]int32, 0, len(pidStrings))
+	for _, s := range pidStrings {
+		if pid, err := strconv.ParseInt(s, 10, 32); err == nil {
+			pids = append(pids, int32(pid))
+		}
+	}
+	return &pb.BackendConfig{
+		Backend: &pb.BackendConfig_Cuda{
+			Cuda: &pb.CudaBackendConfig{
+				ExplicitTarget: &pb.ProcessTarget{Pids: pids},
+			},
+		},
+	}
 }
 
 func (c *CudaCheckpoint) getCudaCheckpointPath() string {

--- a/pkg/snapshot-agent/backends/cuda_checkpoint_test.go
+++ b/pkg/snapshot-agent/backends/cuda_checkpoint_test.go
@@ -6,8 +6,19 @@ import (
 	"testing"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/backends"
 )
+
+func cudaConfig(pids ...int32) *pb.BackendConfig {
+	return &pb.BackendConfig{
+		Backend: &pb.BackendConfig_Cuda{
+			Cuda: &pb.CudaBackendConfig{
+				ExplicitTarget: &pb.ProcessTarget{Pids: pids},
+			},
+		},
+	}
+}
 
 type mockNvmlClient struct {
 	initRet        nvml.Return
@@ -30,20 +41,28 @@ func TestNewCudaCheckpoint(t *testing.T) {
 func TestSnapshot(t *testing.T) {
 	tests := []struct {
 		name        string
-		pids        []string
+		config      *pb.BackendConfig
 		execErr     error
 		expectedErr bool
 	}{
 		{
-			name:        "Success",
-			pids:        []string{"123", "456"},
-			execErr:     nil,
-			expectedErr: false,
+			name:   "Success",
+			config: cudaConfig(123, 456),
 		},
 		{
 			name:        "ExecFailure",
-			pids:        []string{"123"},
+			config:      cudaConfig(123),
 			execErr:     fmt.Errorf("exec error"),
+			expectedErr: true,
+		},
+		{
+			name:        "NoPIDs",
+			config:      cudaConfig(),
+			expectedErr: true,
+		},
+		{
+			name:        "NilConfig",
+			config:      nil,
 			expectedErr: true,
 		},
 	}
@@ -51,11 +70,11 @@ func TestSnapshot(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := backends.NewCudaCheckpoint()
-			c.SetExecCommand(func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			c.SetExecCommand(func(_ context.Context, _ string, _ ...string) ([]byte, error) {
 				return nil, tt.execErr
 			})
 
-			err := c.Snapshot(context.Background(), tt.pids)
+			err := c.Snapshot(context.Background(), backends.Request{JobID: "test-job", Config: tt.config})
 			if (err != nil) != tt.expectedErr {
 				t.Errorf("Snapshot() error = %v, expectedErr %v", err, tt.expectedErr)
 			}
@@ -66,25 +85,22 @@ func TestSnapshot(t *testing.T) {
 func TestRestore(t *testing.T) {
 	tests := []struct {
 		name        string
-		pids        []string
+		config      *pb.BackendConfig
 		execErr     error
 		expectedErr bool
 	}{
 		{
-			name:        "Success",
-			pids:        []string{"123"},
-			execErr:     nil,
-			expectedErr: false,
+			name:   "Success",
+			config: cudaConfig(123),
 		},
 		{
 			name:        "NoPIDs",
-			pids:        []string{},
-			execErr:     nil,
+			config:      cudaConfig(),
 			expectedErr: true,
 		},
 		{
 			name:        "ExecFailure",
-			pids:        []string{"123"},
+			config:      cudaConfig(123),
 			execErr:     fmt.Errorf("exec error"),
 			expectedErr: true,
 		},
@@ -93,11 +109,11 @@ func TestRestore(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := backends.NewCudaCheckpoint()
-			c.SetExecCommand(func(ctx context.Context, name string, args ...string) ([]byte, error) {
+			c.SetExecCommand(func(_ context.Context, _ string, _ ...string) ([]byte, error) {
 				return nil, tt.execErr
 			})
 
-			err := c.Restore(context.Background(), tt.pids)
+			err := c.Restore(context.Background(), backends.Request{JobID: "test-job", Config: tt.config})
 			if (err != nil) != tt.expectedErr {
 				t.Errorf("Restore() error = %v, expectedErr %v", err, tt.expectedErr)
 			}
@@ -118,7 +134,6 @@ func TestHealthCheck(t *testing.T) {
 			initRet:        nvml.SUCCESS,
 			deviceCount:    1,
 			deviceCountRet: nvml.SUCCESS,
-			expectedErr:    false,
 		},
 		{
 			name:        "NVMLInitFailure",

--- a/pkg/snapshot-agent/backends/noop.go
+++ b/pkg/snapshot-agent/backends/noop.go
@@ -15,17 +15,15 @@ func NewNoopBackend() *NoopBackend {
 }
 
 // Snapshot simulates a snapshot operation.
-func (b *NoopBackend) Snapshot(ctx context.Context, pids []string) error {
-	slog.InfoContext(ctx, "NoopBackend: Snapshot called", "pids", pids)
-	// Simulate some work
+func (b *NoopBackend) Snapshot(ctx context.Context, _ Request) error {
+	slog.InfoContext(ctx, "NoopBackend: Snapshot called")
 	time.Sleep(500 * time.Millisecond)
 	return nil
 }
 
 // Restore simulates a restore operation.
-func (b *NoopBackend) Restore(ctx context.Context, pids []string) error {
-	slog.InfoContext(ctx, "NoopBackend: Restore called", "pids", pids)
-	// Simulate some work
+func (b *NoopBackend) Restore(ctx context.Context, _ Request) error {
+	slog.InfoContext(ctx, "NoopBackend: Restore called")
 	time.Sleep(500 * time.Millisecond)
 	return nil
 }

--- a/pkg/snapshot-agent/server/server.go
+++ b/pkg/snapshot-agent/server/server.go
@@ -52,19 +52,6 @@ func (s *Server) Snapshot(ctx context.Context, req *pb.SnapshotRequest) (*pb.Sna
 	backendType := s.getSnapshotBackendType(req.GetBackendConfig())
 	slog.InfoContext(ctx, "Snapshot called", "backend", backendType)
 
-	var explicitPIDs []int32
-	if req.GetBackendConfig() != nil {
-		if cudaConfig := req.GetBackendConfig().GetCuda(); cudaConfig != nil {
-			if target := cudaConfig.GetExplicitTarget(); target != nil {
-				explicitPIDs = target.GetPids()
-			}
-		}
-	}
-
-	if s.deploymentMode == "standalone" && len(explicitPIDs) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "explicit target PIDs must be specified in standalone mode")
-	}
-
 	backend, ok := s.backendMap[backendType]
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "backend %s not found", backendType)
@@ -73,22 +60,14 @@ func (s *Server) Snapshot(ctx context.Context, req *pb.SnapshotRequest) (*pb.Sna
 	s.ensureJobRunningIfGPUOccupied(ctx, req.GetJobId(), req.GetGroup())
 
 	bgCtx := context.WithoutCancel(ctx)
-	opID, err := s.state.StartSnapshot(req.GetJobId(), req.GetGroup(), func() error {
-		slog.InfoContext(bgCtx, "Background: Starting snapshot", "backend", backendType)
-		allPIDs, allPIDStrings, err := resolvePIDs(bgCtx, req.GetJobId(), explicitPIDs)
-		if err != nil {
-			return err
-		}
+	config := req.GetBackendConfig()
 
-		err = backend.Snapshot(bgCtx, allPIDStrings)
-		if err != nil {
-			return fmt.Errorf("failed to snapshot job %s: %w", req.GetJobId(), err)
-		}
+	snapshotFn, fnErr := s.buildSnapshotFn(bgCtx, req.GetJobId(), backendType, backend, config)
+	if fnErr != nil {
+		return nil, fnErr
+	}
 
-		s.state.UpdateJobPIDs(req.GetJobId(), allPIDs)
-		slog.InfoContext(bgCtx, "PIDs for job", "pids", allPIDs)
-		return nil
-	})
+	opID, err := s.state.StartSnapshot(req.GetJobId(), req.GetGroup(), snapshotFn)
 	if err != nil {
 		slog.ErrorContext(ctx, "Failed to start snapshot", "error", err)
 		return nil, err
@@ -138,6 +117,101 @@ func (s *Server) ensureJobRunningIfGPUOccupied(ctx context.Context, jobID, group
 	}
 }
 
+// buildSnapshotFn returns the background snapshot function for the given
+// deployment mode and backend. In standalone mode the caller-provided
+// BackendConfig is passed through to the backend as-is. In k8s mode, only the
+// CUDA backend is supported: it needs PID discovery (resolve PIDs from pods
+// via the watcher's job labels, then cache them for restore).
+func (s *Server) buildSnapshotFn(
+	bgCtx context.Context,
+	jobID string,
+	backendType backends.BackendType,
+	backend backends.Backend,
+	config *pb.BackendConfig,
+) (func() error, error) {
+	switch s.deploymentMode {
+	case "standalone":
+		return func() error {
+			slog.InfoContext(bgCtx, "Background: Starting snapshot", "backend", backendType)
+			return backend.Snapshot(bgCtx, backends.Request{JobID: jobID, Config: config})
+		}, nil
+	case "k8s":
+		if backendType == backends.BackendCuda {
+			explicitPIDs := extractExplicitPIDs(config)
+			return func() error {
+				slog.InfoContext(bgCtx, "Background: Starting snapshot", "backend", backendType)
+				allPIDs, allPIDStrings, pidErr := resolvePIDs(bgCtx, jobID, explicitPIDs)
+				if pidErr != nil {
+					return pidErr
+				}
+				cudaReq := backends.Request{JobID: jobID, Config: backends.BuildCudaConfig(allPIDStrings)}
+				if err := backend.Snapshot(bgCtx, cudaReq); err != nil {
+					return fmt.Errorf("failed to snapshot job %s: %w", jobID, err)
+				}
+				s.state.UpdateJobPIDs(jobID, allPIDs)
+				return nil
+			}, nil
+		}
+		return nil, status.Errorf(codes.InvalidArgument, "backend %q is not supported in k8s mode", backendType)
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unknown deployment mode %q", s.deploymentMode)
+	}
+}
+
+// extractExplicitPIDs returns the explicitly targeted PIDs from a CUDA
+// BackendConfig, or nil if none were provided.
+func extractExplicitPIDs(config *pb.BackendConfig) []int32 {
+	cuda := config.GetCuda()
+	if cuda == nil {
+		return nil
+	}
+	target := cuda.GetExplicitTarget()
+	if target == nil {
+		return nil
+	}
+	return target.GetPids()
+}
+
+// buildRestoreFn returns the background restore function for the given
+// deployment mode and backend. In standalone mode the caller-provided
+// BackendConfig is passed through as-is. In k8s mode, only the CUDA backend
+// is supported: it restores from the PIDs cached at snapshot time (NVML
+// cannot re-discover them after checkpoint frees the GPU).
+func (s *Server) buildRestoreFn(
+	bgCtx context.Context,
+	jobID string,
+	backendType backends.BackendType,
+	backend backends.Backend,
+	config *pb.BackendConfig,
+) (func() error, error) {
+	switch s.deploymentMode {
+	case "standalone":
+		return func() error {
+			slog.InfoContext(bgCtx, "Background: Starting restore", "backend", backendType)
+			return backend.Restore(bgCtx, backends.Request{JobID: jobID, Config: config})
+		}, nil
+	case "k8s":
+		if backendType == backends.BackendCuda {
+			return func() error {
+				slog.InfoContext(bgCtx, "Background: Starting restore", "backend", backendType)
+				pids, pidErr := s.state.GetJobPIDs(jobID)
+				if pidErr != nil {
+					return fmt.Errorf("failed to get PIDs for job %s: %w", jobID, pidErr)
+				}
+				var pidStrings []string
+				for _, pid := range pids {
+					pidStrings = append(pidStrings, strconv.Itoa(pid))
+				}
+				slog.InfoContext(bgCtx, "Restoring PIDs", "pids", pidStrings, "backend", backendType)
+				return backend.Restore(bgCtx, backends.Request{JobID: jobID, Config: backends.BuildCudaConfig(pidStrings)})
+			}, nil
+		}
+		return nil, status.Errorf(codes.InvalidArgument, "backend %q is not supported in k8s mode", backendType)
+	default:
+		return nil, status.Errorf(codes.InvalidArgument, "unknown deployment mode %q", s.deploymentMode)
+	}
+}
+
 // Restore triggers an asynchronous restoration of the accelerator context for a job.
 func (s *Server) Restore(ctx context.Context, req *pb.RestoreRequest) (*pb.RestoreResponse, error) {
 	ctx = logging.WithServerMethod(ctx, "Restore")
@@ -153,25 +227,14 @@ func (s *Server) Restore(ctx context.Context, req *pb.RestoreRequest) (*pb.Resto
 	}
 
 	bgCtx := context.WithoutCancel(ctx)
-	opID, err := s.state.StartRestore(req.GetJobId(), req.GetGroup(), func() error {
-		slog.InfoContext(bgCtx, "Background: Starting restore", "backend", backendType)
+	restoreConfig := req.GetBackendConfig()
 
-		pids, err := s.state.GetJobPIDs(req.GetJobId())
-		if err != nil {
-			return fmt.Errorf("failed to get PIDs for job %s: %w", req.GetJobId(), err)
-		}
+	restoreFn, fnErr := s.buildRestoreFn(bgCtx, req.GetJobId(), backendType, backend, restoreConfig)
+	if fnErr != nil {
+		return nil, fnErr
+	}
 
-		var pidStrings []string
-		for _, pid := range pids {
-			pidStrings = append(pidStrings, strconv.Itoa(pid))
-		}
-
-		slog.InfoContext(bgCtx, "Restoring PIDs", "pids", pidStrings, "backend", backendType)
-		if err := backend.Restore(bgCtx, pidStrings); err != nil {
-			return fmt.Errorf("failed to restore job %s: %w", req.GetJobId(), err)
-		}
-		return nil
-	})
+	opID, err := s.state.StartRestore(req.GetJobId(), req.GetGroup(), restoreFn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/snapshot-agent/server/server_internal_test.go
+++ b/pkg/snapshot-agent/server/server_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -59,7 +60,10 @@ func initGRPCServer() {
 		"failing":            failingBackend,
 	}
 
-	testServer = NewServer(backendsMap, backends.BackendNoop, "k8s")
+	// Default to BackendCuda (matching production) so that requests without a
+	// BackendConfig take the k8s CUDA discovery path; the registered
+	// implementation is still the noop backend.
+	testServer = NewServer(backendsMap, backends.BackendCuda, "k8s")
 	pb.RegisterSnapshotAgentServiceServer(s, testServer)
 	grpc_health_v1.RegisterHealthServer(s, NewHealthServer(backendsMap, backends.BackendNoop))
 	go func() {
@@ -593,23 +597,13 @@ func TestServer_Snapshot_StandaloneMode(t *testing.T) {
 	defer conn.Close()
 	client := pb.NewSnapshotAgentServiceClient(conn)
 
-	// Test without PIDs in standalone mode (should fail)
-	_, err = client.Snapshot(ctx, &pb.SnapshotRequest{
-		JobId: "test-job-standalone",
-	})
-	if err == nil {
-		t.Errorf("Expected failure when PIDs are not provided in standalone mode")
-	} else if status.Code(err) != codes.InvalidArgument {
-		t.Errorf("Expected InvalidArgument error, got: %v", err)
-	}
-
 	// Register the job and transition it to RUNNING in the state machine
 	standaloneServer.state.RegisterJob("test-job-standalone", "")
 	if err := standaloneServer.state.TransitionToRunning("test-job-standalone", []int{123}); err != nil {
 		t.Fatalf("Failed to transition job to RUNNING: %v", err)
 	}
 
-	// Test with PIDs in standalone mode (should succeed)
+	// Test with PIDs in standalone mode (should succeed — backend validates)
 	_, err = client.Snapshot(ctx, &pb.SnapshotRequest{
 		JobId: "test-job-standalone",
 		BackendConfig: &pb.BackendConfig{
@@ -624,5 +618,75 @@ func TestServer_Snapshot_StandaloneMode(t *testing.T) {
 	})
 	if err != nil {
 		t.Errorf("Expected success, got error: %v", err)
+	}
+}
+
+// TestServer_Snapshot_StandaloneMode_BackendValidation verifies that in
+// standalone mode the server passes the config through untouched and backend
+// validation failures (here: a CUDA config with no PIDs) surface as a FAILED
+// operation rather than a synchronous RPC error.
+func TestServer_Snapshot_StandaloneMode_BackendValidation(t *testing.T) {
+	lisDev := bufconn.Listen(bufSize)
+	s := grpc.NewServer()
+	backendsMap := map[backends.BackendType]backends.Backend{
+		backends.BackendCuda: backends.NewCudaCheckpoint(),
+	}
+	standaloneServer := NewServer(backendsMap, backends.BackendCuda, "standalone")
+	pb.RegisterSnapshotAgentServiceServer(s, standaloneServer)
+	go func() {
+		if err := s.Serve(lisDev); err != nil {
+			return
+		}
+	}()
+	defer s.GracefulStop()
+
+	ctx := context.Background()
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lisDev.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewSnapshotAgentServiceClient(conn)
+
+	standaloneServer.state.RegisterJob("test-job-standalone-nopids", "")
+	if err := standaloneServer.state.TransitionToRunning("test-job-standalone-nopids", []int{123}); err != nil {
+		t.Fatalf("Failed to transition job to RUNNING: %v", err)
+	}
+
+	// CUDA config with no PIDs: the RPC is accepted (validation is the
+	// backend's job and runs in the background operation).
+	resp, err := client.Snapshot(ctx, &pb.SnapshotRequest{
+		JobId: "test-job-standalone-nopids",
+		BackendConfig: &pb.BackendConfig{
+			Backend: &pb.BackendConfig_Cuda{
+				Cuda: &pb.CudaBackendConfig{},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Expected RPC to be accepted, got error: %v", err)
+	}
+
+	// The operation must end FAILED with the backend's validation error.
+	var opResp *pb.GetOperationResponse
+	for range 50 {
+		opResp, err = client.GetOperation(ctx, &pb.GetOperationRequest{OperationId: resp.GetOperationId()})
+		if err != nil {
+			t.Fatalf("GetOperation failed: %v", err)
+		}
+		if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_PENDING {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_FAILED {
+		t.Fatalf("Expected operation status FAILED, got %v", opResp.GetStatus())
+	}
+	if !strings.Contains(opResp.GetError(), "PID") {
+		t.Errorf("Expected backend PID validation error, got: %q", opResp.GetError())
 	}
 }


### PR DESCRIPTION
## Summary

Refactor the Backend interface and split server handlers by deployment mode.

### Interface change
`Backend.Snapshot` and `Backend.Restore` now take a `backends.Request{JobID, Config *pb.BackendConfig}` instead of `[]string` PIDs. Each backend extracts what it needs from the request and validates its own inputs. `JobID` carries server-side per-job context to backends whose target is not in the wire config (e.g. a future backend that resolves its target by job); adding more such context later extends `Request` without touching the interface or the proto.

### Server split by mode
- **Standalone**: passes the caller-provided `BackendConfig` directly to the backend. No PID extraction, no server-side validation. Adding a new backend requires zero server changes.
- **K8s**: resolves PIDs via pod discovery, wraps in `BuildCudaConfig()`, caches PIDs for restore. Existing behavior unchanged.

### Files changed
- `backends/checkpoint.go` — adds `Request`, interface takes `Request`
- `backends/cuda-checkpoint.go` — extracts PIDs via `ExtractPIDStrings()`, validates both Snapshot and Restore, adds `BuildCudaConfig()` helper
- `backends/noop.go` — updated signature
- `server/server.go` — standalone path passes config through, k8s path unchanged
- `cuda_checkpoint_test.go` — uses `Request`, added NoPIDs/NilConfig cases
- `server_internal_test.go` — removed server-side standalone validation test (backend validates now)

Depends on #84.

## Test plan
- [x] All existing tests pass
- [x] New validation tests: NoPIDs and NilConfig
- [x] Build verified via Cloud Build


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snapshot and restore now accept backend-specific configuration in the request.
  * Standalone mode uses the provided CUDA PID targets/config.
  * Kubernetes-mode CUDA snapshots can discover and reuse process IDs automatically.
* **Bug Fixes**
  * Missing or invalid CUDA PID targets now fail with clearer PID-related errors.
  * Unsupported backend types and deployment modes are rejected consistently.
* **Tests**
  * Updated CUDA checkpoint and server RPC tests to follow the new request/config flow.
  * Added coverage for no-PIDs and asynchronous operation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->