### PR TITLE
Fix: Set DEPLOYMENT_MODE to k8s in snapshot agent daemonset

### DIFF
--- a/deploy/snapshot-agent/templates/daemonset.yaml
+++ b/deploy/snapshot-agent/templates/daemonset.yaml
@@ -39,6 +39,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: DEPLOYMENT_MODE
+              value: "k8s"
             - name: PATH
               value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin
             - name: NODE_NAME


### PR DESCRIPTION
## What does this PR do?

Fix: Set DEPLOYMENT_MODE to k8s in snapshot agent daemonset

## Why is this change needed?

Deployment mode is defaulted to standalone if not specified. Helm charts should specifically set deployment mode as k8s.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DaemonSet deployments now explicitly identify their deployment mode as Kubernetes, improving deployment environment awareness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->