### PR TITLE
Add retries to e2e tests

### DIFF
--- a/test/e2e/acceleratororchestrator/fake_rl_job.go
+++ b/test/e2e/acceleratororchestrator/fake_rl_job.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/google/uuid"
 	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/api/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -73,6 +75,62 @@ func (f *FakeRLJob) RegisterPodTemplate(groupID string, pod *corev1.Pod) {
 	f.podFactory.Register(groupID, pod)
 }
 
+func (f *FakeRLJob) acquireWithRetry(ctx context.Context, groupID string) (*pb.AcquireResponse, error) {
+	maxRetries := 20
+	retryInterval := 500 * time.Millisecond
+	for i := 0; i < maxRetries; i++ {
+		resp, err := f.client.Acquire(ctx, &pb.AcquireRequest{
+			GroupId: groupID,
+			JobId:   f.name,
+		})
+		if err == nil {
+			return resp, nil
+		}
+
+		st, ok := status.FromError(err)
+		if ok && (st.Code() == codes.Unavailable || st.Code() == codes.Internal) {
+			f.t.Logf("[Job %s] WARNING: Acquire for group %s returned transient error (%v), retrying in %v (attempt %d/%d)...",
+				f.name, groupID, err, retryInterval, i+1, maxRetries)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(retryInterval):
+				continue
+			}
+		}
+		return nil, err
+	}
+	return nil, fmt.Errorf("failed to acquire lock for %s after retries", groupID)
+}
+
+func (f *FakeRLJob) yieldWithRetry(ctx context.Context, groupID string) (*pb.YieldResponse, error) {
+	maxRetries := 20
+	retryInterval := 500 * time.Millisecond
+	for i := 0; i < maxRetries; i++ {
+		resp, err := f.client.Yield(ctx, &pb.YieldRequest{
+			GroupId: groupID,
+			JobId:   f.name,
+		})
+		if err == nil {
+			return resp, nil
+		}
+
+		st, ok := status.FromError(err)
+		if ok && (st.Code() == codes.Unavailable || st.Code() == codes.Internal) {
+			f.t.Logf("[Job %s] WARNING: Yield for group %s returned transient error (%v), retrying in %v (attempt %d/%d)...",
+				f.name, groupID, err, retryInterval, i+1, maxRetries)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(retryInterval):
+				continue
+			}
+		}
+		return nil, err
+	}
+	return nil, fmt.Errorf("failed to yield lock for %s after retries", groupID)
+}
+
 func (f *FakeRLJob) Run(ctx context.Context) error {
 	f.t.Logf("[Job %s] Starting RL Job", f.name)
 
@@ -100,10 +158,7 @@ func (f *FakeRLJob) init(ctx context.Context) error {
 
 	// Acquire lock for samplers
 	f.t.Logf("[Job %s] Acquiring lock for samplers...", f.name)
-	resp, err := f.client.Acquire(ctx, &pb.AcquireRequest{
-		GroupId: "samplers",
-		JobId:   f.name,
-	})
+	resp, err := f.acquireWithRetry(ctx, "samplers")
 	if err != nil {
 		return err
 	}
@@ -119,20 +174,14 @@ func (f *FakeRLJob) init(ctx context.Context) error {
 
 	// Yield samplers
 	f.t.Logf("[Job %s] Yielding samplers lock...", f.name)
-	_, err = f.client.Yield(ctx, &pb.YieldRequest{
-		GroupId: "samplers",
-		JobId:   f.name,
-	})
+	_, err = f.yieldWithRetry(ctx, "samplers")
 	if err != nil {
 		return err
 	}
 
 	// Acquire lock for trainers
 	f.t.Logf("[Job %s] Acquiring lock for trainers...", f.name)
-	resp, err = f.client.Acquire(ctx, &pb.AcquireRequest{
-		GroupId: "trainers",
-		JobId:   f.name,
-	})
+	resp, err = f.acquireWithRetry(ctx, "trainers")
 	if err != nil {
 		return err
 	}
@@ -148,10 +197,7 @@ func (f *FakeRLJob) init(ctx context.Context) error {
 
 	// Yield trainers
 	f.t.Logf("[Job %s] Yielding trainers lock...", f.name)
-	_, err = f.client.Yield(ctx, &pb.YieldRequest{
-		GroupId: "trainers",
-		JobId:   f.name,
-	})
+	_, err = f.yieldWithRetry(ctx, "trainers")
 	if err != nil {
 		return err
 	}
@@ -168,10 +214,7 @@ func (f *FakeRLJob) loop(ctx context.Context) error {
 
 		// 1. Lock samplers
 		f.t.Logf("[Job %s] Acquiring lock for samplers...", f.name)
-		resp, err := f.client.Acquire(ctx, &pb.AcquireRequest{
-			GroupId: "samplers",
-			JobId:   f.name,
-		})
+		resp, err := f.acquireWithRetry(ctx, "samplers")
 		if err != nil {
 			return err
 		}
@@ -189,20 +232,14 @@ func (f *FakeRLJob) loop(ctx context.Context) error {
 
 		// Yield samplers
 		f.t.Logf("[Job %s] Yielding samplers lock...", f.name)
-		_, err = f.client.Yield(ctx, &pb.YieldRequest{
-			GroupId: "samplers",
-			JobId:   f.name,
-		})
+		_, err = f.yieldWithRetry(ctx, "samplers")
 		if err != nil {
 			return err
 		}
 
 		// 2. Lock trainers
 		f.t.Logf("[Job %s] Acquiring lock for trainers...", f.name)
-		resp, err = f.client.Acquire(ctx, &pb.AcquireRequest{
-			GroupId: "trainers",
-			JobId:   f.name,
-		})
+		resp, err = f.acquireWithRetry(ctx, "trainers")
 		if err != nil {
 			return err
 		}
@@ -220,10 +257,7 @@ func (f *FakeRLJob) loop(ctx context.Context) error {
 
 		// Yield trainers
 		f.t.Logf("[Job %s] Yielding trainers lock...", f.name)
-		_, err = f.client.Yield(ctx, &pb.YieldRequest{
-			GroupId: "trainers",
-			JobId:   f.name,
-		})
+		_, err = f.yieldWithRetry(ctx, "trainers")
 		if err != nil {
 			return err
 		}

--- a/test/e2e/acceleratororchestrator/fake_rl_job.go
+++ b/test/e2e/acceleratororchestrator/fake_rl_job.go
@@ -103,16 +103,16 @@ func (f *FakeRLJob) acquireWithRetry(ctx context.Context, groupID string) (*pb.A
 	return nil, fmt.Errorf("failed to acquire lock for %s after retries", groupID)
 }
 
-func (f *FakeRLJob) yieldWithRetry(ctx context.Context, groupID string) (*pb.YieldResponse, error) {
+func (f *FakeRLJob) yieldWithRetry(ctx context.Context, groupID string) error {
 	maxRetries := 20
 	retryInterval := 500 * time.Millisecond
 	for i := 0; i < maxRetries; i++ {
-		resp, err := f.client.Yield(ctx, &pb.YieldRequest{
+		_, err := f.client.Yield(ctx, &pb.YieldRequest{
 			GroupId: groupID,
 			JobId:   f.name,
 		})
 		if err == nil {
-			return resp, nil
+			return nil
 		}
 
 		st, ok := status.FromError(err)
@@ -121,14 +121,14 @@ func (f *FakeRLJob) yieldWithRetry(ctx context.Context, groupID string) (*pb.Yie
 				f.name, groupID, err, retryInterval, i+1, maxRetries)
 			select {
 			case <-ctx.Done():
-				return nil, ctx.Err()
+				return ctx.Err()
 			case <-time.After(retryInterval):
 				continue
 			}
 		}
-		return nil, err
+		return err
 	}
-	return nil, fmt.Errorf("failed to yield lock for %s after retries", groupID)
+	return fmt.Errorf("failed to yield lock for %s after retries", groupID)
 }
 
 func (f *FakeRLJob) Run(ctx context.Context) error {
@@ -174,8 +174,7 @@ func (f *FakeRLJob) init(ctx context.Context) error {
 
 	// Yield samplers
 	f.t.Logf("[Job %s] Yielding samplers lock...", f.name)
-	_, err = f.yieldWithRetry(ctx, "samplers")
-	if err != nil {
+	if err := f.yieldWithRetry(ctx, "samplers"); err != nil {
 		return err
 	}
 
@@ -197,8 +196,7 @@ func (f *FakeRLJob) init(ctx context.Context) error {
 
 	// Yield trainers
 	f.t.Logf("[Job %s] Yielding trainers lock...", f.name)
-	_, err = f.yieldWithRetry(ctx, "trainers")
-	if err != nil {
+	if err := f.yieldWithRetry(ctx, "trainers"); err != nil {
 		return err
 	}
 
@@ -232,8 +230,7 @@ func (f *FakeRLJob) loop(ctx context.Context) error {
 
 		// Yield samplers
 		f.t.Logf("[Job %s] Yielding samplers lock...", f.name)
-		_, err = f.yieldWithRetry(ctx, "samplers")
-		if err != nil {
+		if err := f.yieldWithRetry(ctx, "samplers"); err != nil {
 			return err
 		}
 
@@ -257,8 +254,7 @@ func (f *FakeRLJob) loop(ctx context.Context) error {
 
 		// Yield trainers
 		f.t.Logf("[Job %s] Yielding trainers lock...", f.name)
-		_, err = f.yieldWithRetry(ctx, "trainers")
-		if err != nil {
+		if err := f.yieldWithRetry(ctx, "trainers"); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Mostly motivated because during job cleanup, there can be a race between calling snapshot & when the pods get deleted. A pod deletion happening mid snapshot will result in a FAUTLED snapshot. After the pod deletion propogated to the orchstrator, it does correctly clear the FAULTED state.

We do not want customer to need to cleanup RL jobs pods under lock. That means they need retry logic to ignore the temporary FAULTED state. That said, having retries in general is more robust and a good way to do cross component calls.

## What does this PR do?

<!-- Describe the changes and their purpose -->

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

The test logs will have this section when it is seeing that temporary faulted state on deletion of other job:
```
  [INFO] [Job job-a] RL Job completed successfully
  [INFO] [Job job-b] WARNING: Acquire for group trainers returned transient error (rpc error: code = Unavailable desc = group trainers is faulted), retrying in 500ms (attempt 1/20)...
  [INFO] [Job job-b] WARNING: Acquire for group trainers returned transient error (rpc error: code = Unavailable desc = group trainers is faulted), retrying in 500ms (attempt 2/20)...
  [INFO] [Job job-b] WARNING: Acquire for group trainers returned transient error (rpc error: code = Unavailable desc = group trainers is faulted), retrying in 500ms (attempt 3/20)...
  [INFO] [Job job-b] WARNING: Acquire for group trainers returned transient error (rpc error: code = Unavailable desc = group trainers is faulted), retrying in 500ms (attempt 4/20)...
  [INFO] [Job job-b] >>> TRAINING HAPPENING HERE <<<
  [INFO] [Test] Job B training (10ms)...
  [INFO] [Job job-b] Yielding trainers lock...
  [INFO] [Job job-b] Iteration 2/2
  [INFO] [Job job-b] Acquiring lock for samplers...
  [INFO] [Job job-b] >>> SAMPLING HAPPENING HERE <<<
  [INFO] [Test] Job B sampling (10ms)...
  [INFO] [Job job-b] Yielding samplers lock...
  [INFO] [Job job-b] Acquiring lock for trainers...
  [INFO] [Job job-b] >>> TRAINING HAPPENING HERE <<<
  [INFO] [Test] Job B training (10ms)...
  [INFO] [Job job-b] Yielding trainers lock...
  [INFO] [Job job-b] Loop Phase complete
  [INFO] [Job job-b] Entering Cleanup Phase
  [INFO] [Job job-b] Deleted pod pod-job-b-samplers-b277c260
  [INFO] [Job job-b] Deleted pod pod-job-b-trainers-3c91794d
  [INFO] [Job job-b] RL Job completed successfully
  [INFO] Queued RL Jobs Scenario completed successfully
[PASS] Queued RL Jobs Scenario completed successfully
=== E2E Test Final Summary ===
[PASS] Single RL Job Scenario
[PASS] Queued RL Jobs Scenario
E2E Test Result: PASSED
```


## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of accelerator orchestration test jobs by automatically retrying transient gRPC failures during acquire and yield operations.
  * Added warning logs for retryable failures and ensured operations stop promptly when the context is canceled, with a clear terminal error after retries are exhausted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->