### PR TITLE
[app-endpoint 3/6] snapshot-agent: add app-endpoint backend for vLLM and SGLang

### DIFF
--- a/cmd/snapshot-agent/main.go
+++ b/cmd/snapshot-agent/main.go
@@ -47,8 +47,9 @@ func main() {
 	ctx := context.Background()
 
 	registeredBackends := map[backends.BackendType]backends.Backend{
-		backends.BackendCuda: backends.NewCudaCheckpoint(),
-		backends.BackendNoop: backends.NewNoopBackend(),
+		backends.BackendCuda:        backends.NewCudaCheckpoint(),
+		backends.BackendNoop:        backends.NewNoopBackend(),
+		backends.BackendAppEndpoint: backends.NewAppEndpointBackend(),
 	}
 
 	slog.InfoContext(ctx, "Starting Snapshot Agent", "port", *port, "deploymentMode", depMode)

--- a/pkg/snapshot-agent/backends/app_endpoint.go
+++ b/pkg/snapshot-agent/backends/app_endpoint.go
@@ -30,9 +30,9 @@ type AppProfile struct {
 var vllmProfile = &AppProfile{
 	Name: "vllm",
 	BuildSnapshotRequest: func(ctx context.Context, endpoint string, mode pb.SuspendMode, _ []string) (*http.Request, error) {
-		u, err := url.Parse(endpoint + "/sleep")
+		u, err := appURL(endpoint, "sleep")
 		if err != nil {
-			return nil, fmt.Errorf("invalid endpoint %q: %w", endpoint, err)
+			return nil, err
 		}
 		level := "1"
 		if mode == pb.SuspendMode_SUSPEND_MODE_DISCARD {
@@ -44,9 +44,9 @@ var vllmProfile = &AppProfile{
 		return http.NewRequestWithContext(ctx, http.MethodPost, u.String(), http.NoBody)
 	},
 	BuildRestoreRequest: func(ctx context.Context, endpoint string, tags []string) (*http.Request, error) {
-		u, err := url.Parse(endpoint + "/wake_up")
+		u, err := appURL(endpoint, "wake_up")
 		if err != nil {
-			return nil, fmt.Errorf("invalid endpoint %q: %w", endpoint, err)
+			return nil, err
 		}
 		if len(tags) > 0 {
 			q := u.Query()
@@ -65,11 +65,21 @@ var vllmProfile = &AppProfile{
 var sglangProfile = &AppProfile{
 	Name: "sglang",
 	BuildSnapshotRequest: func(ctx context.Context, endpoint string, _ pb.SuspendMode, tags []string) (*http.Request, error) {
-		return buildSGLangRequest(ctx, endpoint+"/release_memory_occupation", tags)
+		return buildSGLangRequest(ctx, endpoint, "release_memory_occupation", tags)
 	},
 	BuildRestoreRequest: func(ctx context.Context, endpoint string, tags []string) (*http.Request, error) {
-		return buildSGLangRequest(ctx, endpoint+"/resume_memory_occupation", tags)
+		return buildSGLangRequest(ctx, endpoint, "resume_memory_occupation", tags)
 	},
+}
+
+// appURL parses the base endpoint once and joins the operation path onto it,
+// preserving any base path and query while normalizing slashes.
+func appURL(endpoint, op string) (*url.URL, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, fmt.Errorf("invalid endpoint %q: %w", endpoint, err)
+	}
+	return u.JoinPath(op), nil
 }
 
 // appProfiles maps the App enum to its HTTP dialect.
@@ -81,9 +91,10 @@ var appProfiles = map[pb.App]*AppProfile{
 // buildSGLangRequest builds a JSON POST request. SGLang requires a JSON body
 // on these endpoints even when no tags are given, so an empty object is sent
 // rather than an empty body.
-func buildSGLangRequest(ctx context.Context, rawURL string, tags []string) (*http.Request, error) {
-	if _, err := url.Parse(rawURL); err != nil {
-		return nil, fmt.Errorf("invalid URL %q: %w", rawURL, err)
+func buildSGLangRequest(ctx context.Context, endpoint, op string, tags []string) (*http.Request, error) {
+	u, err := appURL(endpoint, op)
+	if err != nil {
+		return nil, err
 	}
 	payload := map[string]any{}
 	if len(tags) > 0 {
@@ -93,7 +104,7 @@ func buildSGLangRequest(ctx context.Context, rawURL string, tags []string) (*htt
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request body: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.String(), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
 	}
@@ -143,7 +154,7 @@ func (b *AppEndpointBackend) Snapshot(ctx context.Context, req Request) error {
 			return fmt.Errorf("failed to build snapshot request for %s: %w", ep, err)
 		}
 		slog.InfoContext(ctx, "Sending app snapshot request",
-			"app", profile.Name, "endpoint", ep, "url", req.URL.String())
+			"app", profile.Name, "endpoint", ep, "url", req.URL.Redacted())
 		start := time.Now()
 		if err := b.doRequest(req); err != nil {
 			return fmt.Errorf("snapshot request to %s failed: %w", ep, err)
@@ -166,7 +177,7 @@ func (b *AppEndpointBackend) Restore(ctx context.Context, req Request) error {
 			return fmt.Errorf("failed to build restore request for %s: %w", ep, err)
 		}
 		slog.InfoContext(ctx, "Sending app restore request",
-			"app", profile.Name, "endpoint", ep, "url", req.URL.String())
+			"app", profile.Name, "endpoint", ep, "url", req.URL.Redacted())
 		start := time.Now()
 		if err := b.doRequest(req); err != nil {
 			return fmt.Errorf("restore request to %s failed: %w", ep, err)

--- a/pkg/snapshot-agent/backends/app_endpoint.go
+++ b/pkg/snapshot-agent/backends/app_endpoint.go
@@ -1,0 +1,201 @@
+package backends
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"time"
+
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+)
+
+const defaultHTTPTimeout = 30 * time.Second
+
+// AppProfile defines the HTTP API dialect of an application-aware
+// workload. Adding support for a new HTTP-capable application means adding a
+// profile here and a value to the App enum — no new proto message.
+type AppProfile struct {
+	Name                 string
+	BuildSnapshotRequest func(ctx context.Context, endpoint string, mode pb.SuspendMode, tags []string) (*http.Request, error)
+	BuildRestoreRequest  func(ctx context.Context, endpoint string, tags []string) (*http.Request, error)
+}
+
+// vllmProfile speaks vLLM's dev-mode sleep API. SuspendMode maps to the
+// per-call sleep level: OFFLOAD (default) -> level 1, DISCARD -> level 2.
+var vllmProfile = &AppProfile{
+	Name: "vllm",
+	BuildSnapshotRequest: func(ctx context.Context, endpoint string, mode pb.SuspendMode, _ []string) (*http.Request, error) {
+		u, err := url.Parse(endpoint + "/sleep")
+		if err != nil {
+			return nil, fmt.Errorf("invalid endpoint %q: %w", endpoint, err)
+		}
+		level := "1"
+		if mode == pb.SuspendMode_SUSPEND_MODE_DISCARD {
+			level = "2"
+		}
+		q := u.Query()
+		q.Set("level", level)
+		u.RawQuery = q.Encode()
+		return http.NewRequestWithContext(ctx, http.MethodPost, u.String(), http.NoBody)
+	},
+	BuildRestoreRequest: func(ctx context.Context, endpoint string, tags []string) (*http.Request, error) {
+		u, err := url.Parse(endpoint + "/wake_up")
+		if err != nil {
+			return nil, fmt.Errorf("invalid endpoint %q: %w", endpoint, err)
+		}
+		if len(tags) > 0 {
+			q := u.Query()
+			for _, tag := range tags {
+				q.Add("tags", tag)
+			}
+			u.RawQuery = q.Encode()
+		}
+		return http.NewRequestWithContext(ctx, http.MethodPost, u.String(), http.NoBody)
+	},
+}
+
+// sglangProfile speaks SGLang's memory occupation API. SuspendMode is
+// advisory here: whether released weights are preserved is fixed by the
+// server's launch flags (--enable-weights-cpu-backup), not per call.
+var sglangProfile = &AppProfile{
+	Name: "sglang",
+	BuildSnapshotRequest: func(ctx context.Context, endpoint string, _ pb.SuspendMode, tags []string) (*http.Request, error) {
+		return buildSGLangRequest(ctx, endpoint+"/release_memory_occupation", tags)
+	},
+	BuildRestoreRequest: func(ctx context.Context, endpoint string, tags []string) (*http.Request, error) {
+		return buildSGLangRequest(ctx, endpoint+"/resume_memory_occupation", tags)
+	},
+}
+
+// appProfiles maps the App enum to its HTTP dialect.
+var appProfiles = map[pb.App]*AppProfile{
+	pb.App_APP_VLLM:   vllmProfile,
+	pb.App_APP_SGLANG: sglangProfile,
+}
+
+// buildSGLangRequest builds a JSON POST request. SGLang requires a JSON body
+// on these endpoints even when no tags are given, so an empty object is sent
+// rather than an empty body.
+func buildSGLangRequest(ctx context.Context, rawURL string, tags []string) (*http.Request, error) {
+	if _, err := url.Parse(rawURL); err != nil {
+		return nil, fmt.Errorf("invalid URL %q: %w", rawURL, err)
+	}
+	payload := map[string]any{}
+	if len(tags) > 0 {
+		payload["tags"] = tags
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	return req, nil
+}
+
+// AppEndpointBackend implements Backend for application-aware workloads
+// reached through their HTTP APIs (the app_endpoint transport). The dialect
+// is selected per request from the config's App field.
+type AppEndpointBackend struct {
+	client *http.Client
+}
+
+// NewAppEndpointBackend creates the app-endpoint backend.
+func NewAppEndpointBackend() *AppEndpointBackend {
+	return &AppEndpointBackend{
+		client: &http.Client{Timeout: defaultHTTPTimeout},
+	}
+}
+
+// resolve validates the config and returns the dialect profile and config.
+func (b *AppEndpointBackend) resolve(config *pb.BackendConfig) (*AppProfile, *pb.AppEndpointConfig, error) {
+	appCfg := config.GetAppEndpoint()
+	if appCfg == nil {
+		return nil, nil, fmt.Errorf("app_endpoint config is required")
+	}
+	profile, ok := appProfiles[appCfg.GetApp()]
+	if !ok {
+		return nil, nil, fmt.Errorf("unknown or unspecified app %q", appCfg.GetApp())
+	}
+	if len(appCfg.GetEndpoints()) == 0 {
+		return nil, nil, fmt.Errorf("at least one endpoint is required for %s", profile.Name)
+	}
+	return profile, appCfg, nil
+}
+
+// Snapshot suspends the application on all configured endpoints.
+func (b *AppEndpointBackend) Snapshot(ctx context.Context, req Request) error {
+	profile, appCfg, err := b.resolve(req.Config)
+	if err != nil {
+		return err
+	}
+	for _, ep := range appCfg.GetEndpoints() {
+		req, err := profile.BuildSnapshotRequest(ctx, ep, appCfg.GetMode(), appCfg.GetTags())
+		if err != nil {
+			return fmt.Errorf("failed to build snapshot request for %s: %w", ep, err)
+		}
+		slog.InfoContext(ctx, "Sending app snapshot request",
+			"app", profile.Name, "endpoint", ep, "url", req.URL.String())
+		start := time.Now()
+		if err := b.doRequest(req); err != nil {
+			return fmt.Errorf("snapshot request to %s failed: %w", ep, err)
+		}
+		slog.InfoContext(ctx, "App snapshot request completed",
+			"app", profile.Name, "endpoint", ep, "duration", time.Since(start))
+	}
+	return nil
+}
+
+// Restore resumes the application on all configured endpoints.
+func (b *AppEndpointBackend) Restore(ctx context.Context, req Request) error {
+	profile, appCfg, err := b.resolve(req.Config)
+	if err != nil {
+		return err
+	}
+	for _, ep := range appCfg.GetEndpoints() {
+		req, err := profile.BuildRestoreRequest(ctx, ep, appCfg.GetTags())
+		if err != nil {
+			return fmt.Errorf("failed to build restore request for %s: %w", ep, err)
+		}
+		slog.InfoContext(ctx, "Sending app restore request",
+			"app", profile.Name, "endpoint", ep, "url", req.URL.String())
+		start := time.Now()
+		if err := b.doRequest(req); err != nil {
+			return fmt.Errorf("restore request to %s failed: %w", ep, err)
+		}
+		slog.InfoContext(ctx, "App restore request completed",
+			"app", profile.Name, "endpoint", ep, "duration", time.Since(start))
+	}
+	return nil
+}
+
+// HealthCheck returns nil — endpoints are supplied per-request in the
+// BackendConfig, so there is nothing to probe at the backend level.
+func (b *AppEndpointBackend) HealthCheck(_ context.Context) error {
+	return nil
+}
+
+func (b *AppEndpointBackend) doRequest(req *http.Request) error {
+	resp, err := b.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		body, readErr := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		if readErr != nil {
+			return fmt.Errorf("unexpected status %d (failed to read body: %w)", resp.StatusCode, readErr)
+		}
+		return fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+	return nil
+}

--- a/pkg/snapshot-agent/backends/app_endpoint_test.go
+++ b/pkg/snapshot-agent/backends/app_endpoint_test.go
@@ -75,6 +75,25 @@ func TestVLLMSnapshotDiscard(t *testing.T) {
 	}
 }
 
+func TestTrailingSlashEndpointNormalized(t *testing.T) {
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Snapshot(context.Background(),
+		appConfig(pb.App_APP_VLLM, srv.URL+"/", pb.SuspendMode_SUSPEND_MODE_DISCARD))
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	if gotPath != "/sleep" {
+		t.Errorf("expected /sleep for trailing-slash endpoint, got %s", gotPath)
+	}
+}
+
 func TestVLLMSnapshotDefaultModeIsOffload(t *testing.T) {
 	var gotQuery string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/snapshot-agent/backends/app_endpoint_test.go
+++ b/pkg/snapshot-agent/backends/app_endpoint_test.go
@@ -1,0 +1,321 @@
+package backends_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/backends"
+)
+
+func appConfig(app pb.App, endpoint string, mode pb.SuspendMode, tags ...string) backends.Request {
+	return backends.Request{
+		JobID: "test-job",
+		Config: &pb.BackendConfig{
+			Backend: &pb.BackendConfig_AppEndpoint{
+				AppEndpoint: &pb.AppEndpointConfig{
+					App:       app,
+					Endpoints: []string{endpoint},
+					Mode:      mode,
+					Tags:      tags,
+				},
+			},
+		},
+	}
+}
+
+// readJSONBody reads and unmarshals a JSON request body, reporting failures
+// on the test. It returns nil for an empty body.
+func readJSONBody(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("failed to read request body: %v", err)
+		return nil
+	}
+	if len(body) == 0 {
+		return nil
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		t.Errorf("failed to unmarshal request body %q: %v", string(body), err)
+		return nil
+	}
+	return parsed
+}
+
+func TestVLLMSnapshotDiscard(t *testing.T) {
+	var gotMethod, gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Snapshot(context.Background(),
+		appConfig(pb.App_APP_VLLM, srv.URL, pb.SuspendMode_SUSPEND_MODE_DISCARD))
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotPath != "/sleep" {
+		t.Errorf("expected /sleep, got %s", gotPath)
+	}
+	if gotQuery != "level=2" {
+		t.Errorf("expected level=2 for DISCARD, got %s", gotQuery)
+	}
+}
+
+func TestVLLMSnapshotDefaultModeIsOffload(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Snapshot(context.Background(),
+		appConfig(pb.App_APP_VLLM, srv.URL, pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED))
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	if gotQuery != "level=1" {
+		t.Errorf("expected level=1 for unspecified mode, got %s", gotQuery)
+	}
+}
+
+func TestVLLMSnapshotOffload(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Snapshot(context.Background(),
+		appConfig(pb.App_APP_VLLM, srv.URL, pb.SuspendMode_SUSPEND_MODE_OFFLOAD))
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	if gotQuery != "level=1" {
+		t.Errorf("expected level=1 for OFFLOAD, got %s", gotQuery)
+	}
+}
+
+func TestVLLMRestoreWithTags(t *testing.T) {
+	var gotPath, gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Restore(context.Background(),
+		appConfig(pb.App_APP_VLLM, srv.URL, pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED, "weights", "kv_cache"))
+	if err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+	if gotPath != "/wake_up" {
+		t.Errorf("expected /wake_up, got %s", gotPath)
+	}
+	if gotQuery != "tags=weights&tags=kv_cache" {
+		t.Errorf("expected tags query params, got %s", gotQuery)
+	}
+}
+
+func TestVLLMRestoreNoTags(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Restore(context.Background(),
+		appConfig(pb.App_APP_VLLM, srv.URL, pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED))
+	if err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+	if gotQuery != "" {
+		t.Errorf("expected no query params, got %s", gotQuery)
+	}
+}
+
+func TestSGLangSnapshotWithTags(t *testing.T) {
+	var gotMethod, gotPath, gotContentType string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody = readJSONBody(t, r)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Snapshot(context.Background(),
+		appConfig(pb.App_APP_SGLANG, srv.URL, pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED, "weights", "kv_cache"))
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("expected POST, got %s", gotMethod)
+	}
+	if gotPath != "/release_memory_occupation" {
+		t.Errorf("expected /release_memory_occupation, got %s", gotPath)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("expected application/json, got %s", gotContentType)
+	}
+	tags, ok := gotBody["tags"].([]any)
+	if !ok || len(tags) != 2 {
+		t.Errorf("expected 2 tags, got %v", gotBody["tags"])
+	}
+}
+
+func TestSGLangSnapshotNoTags(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		gotBody = string(body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Snapshot(context.Background(),
+		appConfig(pb.App_APP_SGLANG, srv.URL, pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED))
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	if gotBody != "{}" {
+		t.Errorf("expected empty JSON body {}, got %s", gotBody)
+	}
+}
+
+func TestSGLangRestore(t *testing.T) {
+	var gotPath string
+	var gotBody map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotBody = readJSONBody(t, r)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Restore(context.Background(),
+		appConfig(pb.App_APP_SGLANG, srv.URL, pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED, "weights"))
+	if err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+	if gotPath != "/resume_memory_occupation" {
+		t.Errorf("expected /resume_memory_occupation, got %s", gotPath)
+	}
+	tags, ok := gotBody["tags"].([]any)
+	if !ok || len(tags) != 1 || tags[0] != "weights" {
+		t.Errorf("expected [weights], got %v", gotBody["tags"])
+	}
+}
+
+func TestMultipleEndpoints(t *testing.T) {
+	callCount := 0
+	srv1 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv1.Close()
+	srv2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv2.Close()
+
+	backend := backends.NewAppEndpointBackend()
+	cfg := &pb.BackendConfig{
+		Backend: &pb.BackendConfig_AppEndpoint{
+			AppEndpoint: &pb.AppEndpointConfig{
+				App:       pb.App_APP_VLLM,
+				Endpoints: []string{srv1.URL, srv2.URL},
+			},
+		},
+	}
+	err := backend.Snapshot(context.Background(), backends.Request{JobID: "test-job", Config: cfg})
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 calls, got %d", callCount)
+	}
+}
+
+func TestNoEndpoints(t *testing.T) {
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Snapshot(context.Background(), backends.Request{Config: &pb.BackendConfig{
+		Backend: &pb.BackendConfig_AppEndpoint{
+			AppEndpoint: &pb.AppEndpointConfig{App: pb.App_APP_VLLM},
+		},
+	}})
+	if err == nil {
+		t.Fatal("expected error for no endpoints")
+	}
+}
+
+func TestUnspecifiedApp(t *testing.T) {
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Snapshot(context.Background(), backends.Request{Config: &pb.BackendConfig{
+		Backend: &pb.BackendConfig_AppEndpoint{
+			AppEndpoint: &pb.AppEndpointConfig{Endpoints: []string{"http://localhost:8000"}},
+		},
+	}})
+	if err == nil {
+		t.Fatal("expected error for unspecified app")
+	}
+}
+
+func TestHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		if _, err := w.Write([]byte("engine error")); err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer srv.Close()
+
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Snapshot(context.Background(),
+		appConfig(pb.App_APP_VLLM, srv.URL, pb.SuspendMode_SUSPEND_MODE_DISCARD))
+	if err == nil {
+		t.Fatal("expected error for HTTP 500")
+	}
+}
+
+func TestAppEndpointNilConfig(t *testing.T) {
+	backend := backends.NewAppEndpointBackend()
+	err := backend.Snapshot(context.Background(), backends.Request{})
+	if err == nil {
+		t.Fatal("expected error for nil config")
+	}
+}
+
+func TestInterfaceCompliance(t *testing.T) {
+	var _ backends.Backend = (*backends.AppEndpointBackend)(nil)
+}

--- a/pkg/snapshot-agent/server/server.go
+++ b/pkg/snapshot-agent/server/server.go
@@ -122,9 +122,10 @@ func (s *Server) ensureJobRunningIfGPUOccupied(ctx context.Context, jobID, group
 
 // buildSnapshotFn returns the background snapshot function for the given
 // deployment mode and backend. In standalone mode the caller-provided
-// BackendConfig is passed through to the backend as-is. In k8s mode, only the
-// CUDA backend is supported: it needs PID discovery (resolve PIDs from pods
-// via the watcher's job labels, then cache them for restore).
+// BackendConfig is passed through to the backend as-is. In k8s mode, the CUDA
+// backend needs PID discovery (resolve PIDs from pods via the watcher's job
+// labels, then cache them for restore); inference engine backends carry their
+// targets (HTTP endpoints) in the config itself, so it is passed through.
 func (s *Server) buildSnapshotFn(
 	bgCtx context.Context,
 	jobID string,
@@ -139,7 +140,8 @@ func (s *Server) buildSnapshotFn(
 			return backend.Snapshot(bgCtx, backends.Request{JobID: jobID, Config: config})
 		}, nil
 	case "k8s":
-		if backendType == backends.BackendCuda {
+		switch backendType {
+		case backends.BackendCuda:
 			explicitPIDs := extractExplicitPIDs(config)
 			return func() error {
 				slog.InfoContext(bgCtx, "Background: Starting snapshot", "backend", backendType)
@@ -154,8 +156,14 @@ func (s *Server) buildSnapshotFn(
 				s.state.UpdateJobPIDs(jobID, allPIDs)
 				return nil
 			}, nil
+		case backends.BackendAppEndpoint:
+			return func() error {
+				slog.InfoContext(bgCtx, "Background: Starting snapshot", "backend", backendType)
+				return backend.Snapshot(bgCtx, backends.Request{JobID: jobID, Config: config})
+			}, nil
+		default:
+			return nil, status.Errorf(codes.InvalidArgument, "backend %q is not supported in k8s mode", backendType)
 		}
-		return nil, status.Errorf(codes.InvalidArgument, "backend %q is not supported in k8s mode", backendType)
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "unknown deployment mode %q", s.deploymentMode)
 	}
@@ -177,9 +185,11 @@ func extractExplicitPIDs(config *pb.BackendConfig) []int32 {
 
 // buildRestoreFn returns the background restore function for the given
 // deployment mode and backend. In standalone mode the caller-provided
-// BackendConfig is passed through as-is. In k8s mode, only the CUDA backend
-// is supported: it restores from the PIDs cached at snapshot time (NVML
-// cannot re-discover them after checkpoint frees the GPU).
+// BackendConfig is passed through as-is. In k8s mode, the CUDA backend
+// restores from the PIDs cached at snapshot time (NVML cannot re-discover
+// them after checkpoint frees the GPU); inference engine backends carry
+// their targets (HTTP endpoints) in the config itself, so it is passed
+// through.
 func (s *Server) buildRestoreFn(
 	bgCtx context.Context,
 	jobID string,
@@ -194,7 +204,8 @@ func (s *Server) buildRestoreFn(
 			return backend.Restore(bgCtx, backends.Request{JobID: jobID, Config: config})
 		}, nil
 	case "k8s":
-		if backendType == backends.BackendCuda {
+		switch backendType {
+		case backends.BackendCuda:
 			return func() error {
 				slog.InfoContext(bgCtx, "Background: Starting restore", "backend", backendType)
 				pids, pidErr := s.state.GetJobPIDs(jobID)
@@ -208,8 +219,14 @@ func (s *Server) buildRestoreFn(
 				slog.InfoContext(bgCtx, "Restoring PIDs", "pids", pidStrings, "backend", backendType)
 				return backend.Restore(bgCtx, backends.Request{JobID: jobID, Config: backends.BuildCudaConfig(pidStrings)})
 			}, nil
+		case backends.BackendAppEndpoint:
+			return func() error {
+				slog.InfoContext(bgCtx, "Background: Starting restore", "backend", backendType)
+				return backend.Restore(bgCtx, backends.Request{JobID: jobID, Config: config})
+			}, nil
+		default:
+			return nil, status.Errorf(codes.InvalidArgument, "backend %q is not supported in k8s mode", backendType)
 		}
-		return nil, status.Errorf(codes.InvalidArgument, "backend %q is not supported in k8s mode", backendType)
 	default:
 		return nil, status.Errorf(codes.InvalidArgument, "unknown deployment mode %q", s.deploymentMode)
 	}

--- a/pkg/snapshot-agent/server/server_internal_test.go
+++ b/pkg/snapshot-agent/server/server_internal_test.go
@@ -55,9 +55,10 @@ func initGRPCServer() {
 	noopBackend := backends.NewNoopBackend()
 	failingBackend := &FailingBackend{}
 	backendsMap := map[backends.BackendType]backends.Backend{
-		backends.BackendNoop: noopBackend,
-		backends.BackendCuda: noopBackend,
-		"failing":            failingBackend,
+		backends.BackendNoop:        noopBackend,
+		backends.BackendCuda:        noopBackend,
+		backends.BackendAppEndpoint: noopBackend,
+		"failing":                   failingBackend,
 	}
 
 	// Default to BackendCuda (matching production) so that requests without a
@@ -618,6 +619,63 @@ func TestServer_Snapshot_StandaloneMode(t *testing.T) {
 	})
 	if err != nil {
 		t.Errorf("Expected success, got error: %v", err)
+	}
+}
+
+// TestServer_Snapshot_K8sMode_InferenceEngine verifies that in k8s mode
+// inference engine configs are passed through to the backend without PID
+// discovery: no pods or PIDs are mocked for this job, so the snapshot only
+// succeeds if the server skipped the CUDA discovery path.
+func TestServer_Snapshot_K8sMode_InferenceEngine(t *testing.T) {
+	initGRPCServer()
+	ctx := context.Background()
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewSnapshotAgentServiceClient(conn)
+
+	jobID := "test-job-k8s-vllm"
+	testServer.state.RegisterJob(jobID, "")
+	if err := testServer.state.TransitionToRunning(jobID, nil); err != nil {
+		t.Fatalf("Failed to transition job to RUNNING: %v", err)
+	}
+
+	resp, err := client.Snapshot(ctx, &pb.SnapshotRequest{
+		JobId: jobID,
+		BackendConfig: &pb.BackendConfig{
+			Backend: &pb.BackendConfig_AppEndpoint{
+				AppEndpoint: &pb.AppEndpointConfig{
+					App:       pb.App_APP_VLLM,
+					Endpoints: []string{"http://localhost:8000"},
+					Mode:      pb.SuspendMode_SUSPEND_MODE_OFFLOAD,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Expected vLLM snapshot to be accepted in k8s mode, got error: %v", err)
+	}
+
+	// The noop backend registered under BackendAppEndpoint succeeds immediately; the
+	// operation completing proves the config was passed through without PID
+	// discovery (which would have failed — no pods exist for this job).
+	var opResp *pb.GetOperationResponse
+	for range 50 {
+		opResp, err = client.GetOperation(ctx, &pb.GetOperationRequest{OperationId: resp.GetOperationId()})
+		if err != nil {
+			t.Fatalf("GetOperation failed: %v", err)
+		}
+		if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_PENDING {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_COMPLETE {
+		t.Fatalf("Expected operation status COMPLETE, got %v (error: %q)", opResp.GetStatus(), opResp.GetError())
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements the endpoint transport for application-aware backends. Part 4 of the app-aware backends series (stacked on #97).

A single `AppEndpointBackend` suspends/resumes workloads through their HTTP APIs; the dialect is selected per request from the config's `App` enum. The backend is scoped by transport, not workload type — any HTTP-capable application-aware workload is an `App` enum value plus an `AppProfile`, never a new backend.

| | vLLM | SGLang |
|---|---|---|
| Snapshot | `POST /sleep?level=N` | `POST /release_memory_occupation` (JSON body) |
| Restore | `POST /wake_up?tags=...` | `POST /resume_memory_occupation` (JSON body) |
| SuspendMode | OFFLOAD→level 1 (default), DISCARD→level 2 | advisory (fixed by server launch flags) |

Server: k8s mode passes `app_endpoint` configs through to the backend (no PID discovery); backend registered in `main.go`.

## Testing

Unit tests cover dialect encoding, SuspendMode mapping and defaults, multiple endpoints, and error paths. `go build`, `go test`, golangci-lint: clean. Exercised end to end on H100 by the integration suite in #100.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for snapshotting and restoring application workloads via configured HTTP endpoints.
  * Enabled application endpoint backends for vLLM and SGLang workflows.
  * Supports multiple endpoints per request with app-specific request formatting.
  * Enabled application endpoint backends in Kubernetes deployment mode, with pass-through for inference-engine scenarios.
* **Bug Fixes**
  * Improved validation and error reporting for missing, unsupported, or unsuccessful endpoint configurations.
* **Tests**
  * Added unit and server integration coverage for app-endpoint wiring, request behavior, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->