### PR TITLE
[app-endpoint 4/6] snapshot-agent: add backends section to user guide

### DIFF
--- a/guides/snapshot-agent/README.md
+++ b/guides/snapshot-agent/README.md
@@ -124,7 +124,181 @@ result = client.snapshot_and_wait(job_id="my-k8s-job-id")
 
 ---
 
-## 3. Monitoring and Troubleshooting
+## 3. Backends
+
+The Snapshot Agent supports multiple backends for different GPU memory management strategies. Each backend is selected per-request via the `backend_config` field.
+
+| Backend | Config | How it works | VRAM Freed | Resume Time |
+|---------|--------|-------------|------------|-------------|
+| CUDA Checkpoint | `cuda` | Process-level CUDA state save/restore via `cuda-checkpoint` | ~100% | ~1-3s |
+| Application-Aware | `app_endpoint` | Suspend/resume through the application's own HTTP API (vLLM, SGLang) | ~96% | ~50-100ms |
+
+### CUDA Checkpoint
+
+Saves and restores the entire CUDA context of a process. Works with any GPU workload regardless of framework.
+
+```python
+from timeslice.snapshot_agent import SnapshotAgentClient, snapshot_agent_pb2
+
+with SnapshotAgentClient("localhost:9001") as client:
+    # Checkpoint
+    result = client.snapshot_and_wait(
+        job_id="my-job",
+        backend_config=snapshot_agent_pb2.BackendConfig(
+            cuda=snapshot_agent_pb2.CudaBackendConfig(
+                explicit_target=snapshot_agent_pb2.ProcessTarget(pids=[1234])
+            )
+        ),
+    )
+
+    # Restore
+    result = client.restore_and_wait(
+        job_id="my-job",
+        backend_config=snapshot_agent_pb2.BackendConfig(
+            cuda=snapshot_agent_pb2.CudaBackendConfig(
+                explicit_target=snapshot_agent_pb2.ProcessTarget(pids=[1234])
+            )
+        ),
+    )
+```
+
+In Kubernetes mode, PIDs are discovered automatically — omit `explicit_target`:
+```python
+result = client.snapshot_and_wait(
+    job_id="my-k8s-job",
+    backend_config=snapshot_agent_pb2.BackendConfig(
+        cuda=snapshot_agent_pb2.CudaBackendConfig()
+    ),
+)
+```
+
+### Application-Aware (app_endpoint)
+
+Suspends and resumes an application-aware workload through its own HTTP API. The `app` field selects the application; `endpoints` targets the server(s).
+
+**Suspend mode** states what happens to the workload's durable state while suspended:
+
+| Mode | Behavior | Use Case |
+|------|----------|----------|
+| `SUSPEND_MODE_OFFLOAD` (default) | State preserved in host memory; Restore copies it back | Standard suspend/resume |
+| `SUSPEND_MODE_DISCARD` | State dropped; the application re-provisions it after Restore | RL training — push new weights after resume |
+
+**Tags** select memory regions (`weights`, `kv_cache`, ...). If omitted, the application's full region set is used. On Snapshot, tags select what to suspend (where the application supports it); on Restore, what to bring back.
+
+#### vLLM
+
+Server requirements:
+
+```bash
+VLLM_SERVER_DEV_MODE=1 python -m vllm.entrypoints.openai.api_server \
+  --model <model> \
+  --enable-sleep-mode
+```
+
+```python
+with SnapshotAgentClient("localhost:9001") as client:
+    # Suspend: offload weights to CPU, discard KV cache
+    client.snapshot_and_wait(
+        job_id="my-vllm-job",
+        backend_config=snapshot_agent_pb2.BackendConfig(
+            app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
+                app=snapshot_agent_pb2.APP_VLLM,
+                endpoints=["http://localhost:8000"],
+            )
+        ),
+    )
+
+    # Resume: restore all
+    client.restore_and_wait(
+        job_id="my-vllm-job",
+        backend_config=snapshot_agent_pb2.BackendConfig(
+            app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
+                app=snapshot_agent_pb2.APP_VLLM,
+                endpoints=["http://localhost:8000"],
+            )
+        ),
+    )
+```
+
+Partial resume — bring back only specific regions:
+```python
+app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
+    app=snapshot_agent_pb2.APP_VLLM,
+    endpoints=["http://localhost:8000"],
+    tags=["weights"],
+)
+```
+
+#### SGLang
+
+Server requirements:
+
+```bash
+python -m sglang.launch_server \
+  --model-path <model> \
+  --enable-memory-saver \
+  --enable-weights-cpu-backup
+```
+
+For SGLang the effective suspend mode is fixed by the server's launch flags, not per call: with `--enable-weights-cpu-backup` weights are preserved (OFFLOAD behavior); without it they are discarded (DISCARD behavior) and inference produces incorrect results after resume unless the application pushes new weights.
+
+```python
+with SnapshotAgentClient("localhost:9001") as client:
+    # Suspend: release GPU memory
+    client.snapshot_and_wait(
+        job_id="my-sglang-job",
+        backend_config=snapshot_agent_pb2.BackendConfig(
+            app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
+                app=snapshot_agent_pb2.APP_SGLANG,
+                endpoints=["http://localhost:30000"],
+            )
+        ),
+    )
+
+    # Resume: restore GPU memory
+    client.restore_and_wait(
+        job_id="my-sglang-job",
+        backend_config=snapshot_agent_pb2.BackendConfig(
+            app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
+                app=snapshot_agent_pb2.APP_SGLANG,
+                endpoints=["http://localhost:30000"],
+            )
+        ),
+    )
+```
+
+### Composing Backends
+
+Application-aware suspend and CUDA checkpoint are separate operations that compose. Suspend first, then checkpoint; restore in reverse order:
+
+```python
+# 1. Application-level suspend (frees ~96% VRAM)
+client.snapshot_and_wait(
+    job_id="app-job",
+    backend_config=snapshot_agent_pb2.BackendConfig(
+        app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
+            app=snapshot_agent_pb2.APP_VLLM,
+            endpoints=["http://localhost:8000"],
+        )
+    ),
+)
+
+# 2. CUDA checkpoint (frees the remaining CUDA context)
+client.snapshot_and_wait(
+    job_id="cuda-job",
+    backend_config=snapshot_agent_pb2.BackendConfig(
+        cuda=snapshot_agent_pb2.CudaBackendConfig(
+            explicit_target=snapshot_agent_pb2.ProcessTarget(pids=[1234])
+        )
+    ),
+)
+
+# Restore: 3. CUDA restore, then 4. application-level resume
+```
+
+---
+
+## 4. Monitoring and Troubleshooting
 
 ### Checking Agent Status
 You can query the agent for the status of all managed jobs:
@@ -173,3 +347,5 @@ grpcurl -plaintext \
 - **Permission Denied:** Ensure the Snapshot Agent pod is running as `privileged: true`.
 - **Connection Refused:** Verify the `AGENT_ENDPOINT` environment variable correctly points to `$(NODE_IP):9001`.
 - **GPU Not Found:** Check that the `nvidia.driver.hostPath` in the agent's configuration matches your node's setup.
+- **Garbage inference after resume (vLLM):** The workload was suspended with `SUSPEND_MODE_DISCARD`, which drops weights. Use the default `SUSPEND_MODE_OFFLOAD`, or have the application push new weights after resume.
+- **Garbage inference after SGLang resume:** The SGLang server was started without `--enable-weights-cpu-backup`. Restart with this flag.

--- a/guides/snapshot-agent/README.md
+++ b/guides/snapshot-agent/README.md
@@ -59,14 +59,14 @@ pip install "git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#s
 Trigger a snapshot by passing the target PIDs using a `BackendConfig` object:
 ```python
 from timeslice.snapshot_agent import SnapshotAgentClient
-from timeslice.snapshot_agent import snapshot_agent_pb2
+from timeslice.snapshot_agent import snapshot_agent_pb2 as snapshot
 
 # Connect to the local agent
 with SnapshotAgentClient("localhost:9001") as client:
     # Define the backend config with target PIDs
-    backend_config = snapshot_agent_pb2.BackendConfig(
-        cuda=snapshot_agent_pb2.CudaBackendConfig(
-            explicit_target=snapshot_agent_pb2.ProcessTarget(pids=[1234])
+    backend_config = snapshot.BackendConfig(
+        cuda=snapshot.CudaBackendConfig(
+            explicit_target=snapshot.ProcessTarget(pids=[1234])
         )
     )
 
@@ -133,55 +133,50 @@ The Snapshot Agent supports multiple backends for different GPU memory managemen
 | CUDA Checkpoint | `cuda` | Process-level CUDA state save/restore via `cuda-checkpoint` | ~100% | ~1-3s |
 | Application-Aware | `app_endpoint` | Suspend/resume through the application's own HTTP API (vLLM, SGLang) | ~96% | ~50-100ms |
 
+The VRAM Freed and Resume Time figures are illustrative, measured with a small model (Qwen2.5-0.5B) on an H100; actual numbers depend on the model size, hardware, and engine version.
+
 ### CUDA Checkpoint
 
 Saves and restores the entire CUDA context of a process. Works with any GPU workload regardless of framework.
 
 ```python
-from timeslice.snapshot_agent import SnapshotAgentClient, snapshot_agent_pb2
+from timeslice.snapshot_agent import SnapshotAgentClient
+from timeslice.snapshot_agent import snapshot_agent_pb2 as snapshot
+
+cuda_config = snapshot.BackendConfig(
+    cuda=snapshot.CudaBackendConfig(
+        explicit_target=snapshot.ProcessTarget(pids=[1234])
+    )
+)
 
 with SnapshotAgentClient("localhost:9001") as client:
     # Checkpoint
-    result = client.snapshot_and_wait(
-        job_id="my-job",
-        backend_config=snapshot_agent_pb2.BackendConfig(
-            cuda=snapshot_agent_pb2.CudaBackendConfig(
-                explicit_target=snapshot_agent_pb2.ProcessTarget(pids=[1234])
-            )
-        ),
-    )
+    result = client.snapshot_and_wait(job_id="my-job", backend_config=cuda_config)
 
     # Restore
-    result = client.restore_and_wait(
-        job_id="my-job",
-        backend_config=snapshot_agent_pb2.BackendConfig(
-            cuda=snapshot_agent_pb2.CudaBackendConfig(
-                explicit_target=snapshot_agent_pb2.ProcessTarget(pids=[1234])
-            )
-        ),
-    )
+    result = client.restore_and_wait(job_id="my-job", backend_config=cuda_config)
 ```
 
 In Kubernetes mode, PIDs are discovered automatically — omit `explicit_target`:
 ```python
 result = client.snapshot_and_wait(
     job_id="my-k8s-job",
-    backend_config=snapshot_agent_pb2.BackendConfig(
-        cuda=snapshot_agent_pb2.CudaBackendConfig()
-    ),
+    backend_config=snapshot.BackendConfig(cuda=snapshot.CudaBackendConfig()),
 )
 ```
 
 ### Application-Aware (app_endpoint)
 
-Suspends and resumes an application-aware workload through its own HTTP API. The `app` field selects the application; `endpoints` targets the server(s).
+This backend implements application-aware snapshot/restore: suspend and resume are HTTP calls to an endpoint on the running application, and the application itself offloads or drops its GPU state in response (vLLM's sleep API, SGLang's memory-occupation API). The `app` field selects the application; `endpoints` targets the server(s).
 
 **Suspend mode** states what happens to the workload's durable state while suspended:
 
 | Mode | Behavior | Use Case |
 |------|----------|----------|
-| `SUSPEND_MODE_OFFLOAD` (default) | State preserved in host memory; Restore copies it back | Standard suspend/resume |
+| `SUSPEND_MODE_OFFLOAD` | State preserved in host memory; Restore copies it back | Standard suspend/resume |
 | `SUSPEND_MODE_DISCARD` | State dropped; the application re-provisions it after Restore | RL training — push new weights after resume |
+
+When the mode is unspecified (`SUSPEND_MODE_UNSPECIFIED`), the application's default behavior applies: for vLLM that is OFFLOAD; for SGLang the launch flags decide either way (see below).
 
 **Tags** select memory regions (`weights`, `kv_cache`, ...). If omitted, the application's full region set is used. On Snapshot, tags select what to suspend (where the application supports it); on Restore, what to bring back.
 
@@ -196,34 +191,25 @@ VLLM_SERVER_DEV_MODE=1 python -m vllm.entrypoints.openai.api_server \
 ```
 
 ```python
+vllm_config = snapshot.BackendConfig(
+    app_endpoint=snapshot.AppEndpointConfig(
+        app=snapshot.APP_VLLM,
+        endpoints=["http://localhost:8000"],
+    )
+)
+
 with SnapshotAgentClient("localhost:9001") as client:
     # Suspend: offload weights to CPU, discard KV cache
-    client.snapshot_and_wait(
-        job_id="my-vllm-job",
-        backend_config=snapshot_agent_pb2.BackendConfig(
-            app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
-                app=snapshot_agent_pb2.APP_VLLM,
-                endpoints=["http://localhost:8000"],
-            )
-        ),
-    )
+    client.snapshot_and_wait(job_id="my-vllm-job", backend_config=vllm_config)
 
     # Resume: restore all
-    client.restore_and_wait(
-        job_id="my-vllm-job",
-        backend_config=snapshot_agent_pb2.BackendConfig(
-            app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
-                app=snapshot_agent_pb2.APP_VLLM,
-                endpoints=["http://localhost:8000"],
-            )
-        ),
-    )
+    client.restore_and_wait(job_id="my-vllm-job", backend_config=vllm_config)
 ```
 
 Partial resume — bring back only specific regions:
 ```python
-app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
-    app=snapshot_agent_pb2.APP_VLLM,
+app_endpoint=snapshot.AppEndpointConfig(
+    app=snapshot.APP_VLLM,
     endpoints=["http://localhost:8000"],
     tags=["weights"],
 )
@@ -243,28 +229,19 @@ python -m sglang.launch_server \
 For SGLang the effective suspend mode is fixed by the server's launch flags, not per call: with `--enable-weights-cpu-backup` weights are preserved (OFFLOAD behavior); without it they are discarded (DISCARD behavior) and inference produces incorrect results after resume unless the application pushes new weights.
 
 ```python
+sglang_config = snapshot.BackendConfig(
+    app_endpoint=snapshot.AppEndpointConfig(
+        app=snapshot.APP_SGLANG,
+        endpoints=["http://localhost:30000"],
+    )
+)
+
 with SnapshotAgentClient("localhost:9001") as client:
     # Suspend: release GPU memory
-    client.snapshot_and_wait(
-        job_id="my-sglang-job",
-        backend_config=snapshot_agent_pb2.BackendConfig(
-            app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
-                app=snapshot_agent_pb2.APP_SGLANG,
-                endpoints=["http://localhost:30000"],
-            )
-        ),
-    )
+    client.snapshot_and_wait(job_id="my-sglang-job", backend_config=sglang_config)
 
     # Resume: restore GPU memory
-    client.restore_and_wait(
-        job_id="my-sglang-job",
-        backend_config=snapshot_agent_pb2.BackendConfig(
-            app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
-                app=snapshot_agent_pb2.APP_SGLANG,
-                endpoints=["http://localhost:30000"],
-            )
-        ),
-    )
+    client.restore_and_wait(job_id="my-sglang-job", backend_config=sglang_config)
 ```
 
 ### Composing Backends
@@ -272,26 +249,23 @@ with SnapshotAgentClient("localhost:9001") as client:
 Application-aware suspend and CUDA checkpoint are separate operations that compose. Suspend first, then checkpoint; restore in reverse order:
 
 ```python
-# 1. Application-level suspend (frees ~96% VRAM)
-client.snapshot_and_wait(
-    job_id="app-job",
-    backend_config=snapshot_agent_pb2.BackendConfig(
-        app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
-            app=snapshot_agent_pb2.APP_VLLM,
-            endpoints=["http://localhost:8000"],
-        )
-    ),
+app_config = snapshot.BackendConfig(
+    app_endpoint=snapshot.AppEndpointConfig(
+        app=snapshot.APP_VLLM,
+        endpoints=["http://localhost:8000"],
+    )
+)
+cuda_config = snapshot.BackendConfig(
+    cuda=snapshot.CudaBackendConfig(
+        explicit_target=snapshot.ProcessTarget(pids=[1234])
+    )
 )
 
+# 1. Application-level suspend (frees most VRAM)
+client.snapshot_and_wait(job_id="app-job", backend_config=app_config)
+
 # 2. CUDA checkpoint (frees the remaining CUDA context)
-client.snapshot_and_wait(
-    job_id="cuda-job",
-    backend_config=snapshot_agent_pb2.BackendConfig(
-        cuda=snapshot_agent_pb2.CudaBackendConfig(
-            explicit_target=snapshot_agent_pb2.ProcessTarget(pids=[1234])
-        )
-    ),
-)
+client.snapshot_and_wait(job_id="cuda-job", backend_config=cuda_config)
 
 # Restore: 3. CUDA restore, then 4. application-level resume
 ```
@@ -347,5 +321,5 @@ grpcurl -plaintext \
 - **Permission Denied:** Ensure the Snapshot Agent pod is running as `privileged: true`.
 - **Connection Refused:** Verify the `AGENT_ENDPOINT` environment variable correctly points to `$(NODE_IP):9001`.
 - **GPU Not Found:** Check that the `nvidia.driver.hostPath` in the agent's configuration matches your node's setup.
-- **Garbage inference after resume (vLLM):** The workload was suspended with `SUSPEND_MODE_DISCARD`, which drops weights. Use the default `SUSPEND_MODE_OFFLOAD`, or have the application push new weights after resume.
+- **Garbage inference after resume (vLLM):** The workload was suspended with `SUSPEND_MODE_DISCARD`, which drops weights. Suspend with `SUSPEND_MODE_OFFLOAD` (vLLM's default when the mode is unspecified), or have the application push new weights after resume.
 - **Garbage inference after SGLang resume:** The SGLang server was started without `--enable-weights-cpu-backup`. Restart with this flag.


### PR DESCRIPTION
## Summary

Adds a Backends section to the snapshot-agent user guide. Part 5 of the app-aware backends series (stacked on #98).

- Comparison table for the CUDA checkpoint (`cuda`) and application-aware (`app_endpoint`) backends
- Python client examples for each backend and deployment mode
- `SuspendMode` semantics and region tags
- Per-application server requirements (vLLM dev mode + sleep mode; SGLang memory saver + weights CPU backup) and the SGLang launch-flag behavior
- Composing application-aware suspend with CUDA checkpoint, including restore ordering
- Troubleshooting entries for incorrect inference after resume

Docs only — no code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new **“3. Backends”** section covering per-request backend selection via `backend_config`, including a backend comparison table.
  * Documented **CUDA Checkpoint** and **Application-Aware** backends, with suspend/restore sequencing details and Kubernetes guidance (including `explicit_target` omission).
  * Expanded troubleshooting for **garbage inference after resume** in **vLLM** and **SGLang**.
  * Updated a Python Snapshot request example’s protobuf import alias for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->