### PR TITLE
[app-endpoint 5/6] snapshot-agent: add integration test harness

### DIFF
--- a/Dockerfile.snapshot-agent-runtime
+++ b/Dockerfile.snapshot-agent-runtime
@@ -1,0 +1,20 @@
+FROM golang:1.25-bookworm AS builder
+
+RUN apt-get update && apt-get install -y protobuf-compiler && rm -rf /var/lib/apt/lists/*
+RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+
+WORKDIR /workspace
+COPY . .
+
+RUN cd pkg/snapshot-agent/api/v1alpha1 && \
+    protoc --go_out=. --go_opt=paths=source_relative \
+           --go-grpc_out=. --go-grpc_opt=paths=source_relative \
+           snapshot_agent.proto
+
+RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w" -o /workspace/snapshot-agent ./cmd/snapshot-agent
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /workspace/snapshot-agent /snapshot-agent
+ENTRYPOINT ["/snapshot-agent"]

--- a/cloudbuild-image.yaml
+++ b/cloudbuild-image.yaml
@@ -1,0 +1,16 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-f'
+      - 'Dockerfile.snapshot-agent-runtime'
+      - '-t'
+      - '${_IMAGE}'
+      - '.'
+images:
+  - '${_IMAGE}'
+substitutions:
+  _IMAGE: 'gcr.io/${PROJECT_ID}/snapshot-agent:dev'
+timeout: '600s'
+options:
+  machineType: 'E2_HIGHCPU_8'

--- a/go.mod
+++ b/go.mod
@@ -27,14 +27,17 @@ require (
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/moby/spdystream v0.5.1 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/NVIDIA/go-nvml v0.13.3-1 h1:P76U2h88OZSiMtdhRsJjSF5DXyXUqHIXKeDicVAaae0=
 github.com/NVIDIA/go-nvml v0.13.3-1/go.mod h1:ahi2psRYoa+wYUBIrZPRO+wJs9lcvMhxSSkjjvsJJNQ=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -37,6 +39,8 @@ github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674 h1:JeSE6pjso5THxAzdVpqr6/geYxZytqFMBCOtn/ujyeo=
+github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674/go.mod h1:r4w70xmWCQKmi1ONH4KIaBptdivuRPyosB9RmPlGEwA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -58,6 +62,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y=
+github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -66,6 +72,8 @@ github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee h1:W5t00kpgFd
 github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
+github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=

--- a/tests/integration/snapshot-agent/README.md
+++ b/tests/integration/snapshot-agent/README.md
@@ -1,0 +1,71 @@
+# Snapshot Agent Integration Tests
+
+End-to-end tests for snapshot-agent backends on real GPU hardware, in both standalone and K8s deployment modes.
+
+The test suite is written in Go and runs inside the cluster: `run.sh` deploys a test-runner pod, copies the repo source into it, and executes `go test` there. The Go harness deploys the snapshot-agent and inference engine pods itself — one engine at a time, so a single free GPU is enough.
+
+All snapshot/restore calls go through the **Python client** (`timeslice.snapshot_agent`, invoked via `agentctl.py`), so the entire client layer is covered.
+
+- `run.sh` — launcher (deploy runner, copy source, install the Python client, `go test`, cleanup)
+- `runner.yaml` — test-runner pod + RBAC
+- `harness.go` / `engines.go` — harness: pod lifecycle, exec/HTTP helpers, pod specs
+- `agentctl.py` — thin CLI over the Python client; builds `BackendConfig` protos in Python from primitive flags
+- `standalone_test.go` / `k8s_test.go` — the test cases
+
+## Adding a test
+
+Add a `t.Run(...)` inside the engine group that provides the pods it needs, using the harness helpers:
+
+```go
+h.WithEngine(t, VLLM, func(t *testing.T, e *Engine) {
+    t.Run("MyNewTest", func(t *testing.T) {
+        before := h.Inference(t, e)                            // deterministic completion
+        h.SnapshotOK(t, "my-job", vllmSleepConfig(e.Endpoint(), 1))
+        vram := h.VRAMMiB(t, e)                                // GPU memory in use
+        h.RestoreOK(t, "my-job", vllmWakeConfig(e.Endpoint()))
+        RequireFreedAndCorrect(t, vram, before, h.Inference(t, e))
+    })
+})
+```
+
+A new engine is an `EngineSpec` in `engines.go`.
+
+## Prerequisites
+
+- A GKE cluster with at least 1 free GPU
+- `gcloud` and `kubectl` on the machine running the tests
+  (Go and everything else run inside the cluster)
+- A snapshot-agent image. Build one from the repo root with:
+
+```bash
+gcloud builds submit --config=cloudbuild-image.yaml \
+  --substitutions=_IMAGE=gcr.io/<your-project>/snapshot-agent:dev .
+```
+
+This builds from your working directory, so local modifications are included — no commit needed. Requires the Cloud Build API (`gcloud services enable cloudbuild.googleapis.com`) and permission to push to the project's registry; GKE nodes in the same project can pull from `gcr.io/<project>` by default.
+
+## Running
+
+```bash
+./tests/integration/snapshot-agent/run.sh \
+  --image gcr.io/<your-project>/snapshot-agent:dev \
+  --project <your-project> \
+  --cluster <your-cluster> \
+  --zone <your-zone>
+```
+
+## Options
+
+```
+--image IMAGE        Snapshot-agent container image (required)
+--project PROJECT    GCP project (runs gcloud get-credentials)
+--cluster CLUSTER    GKE cluster name
+--zone ZONE          GKE cluster zone
+--model MODEL        Model to load (default: Qwen/Qwen2.5-0.5B)
+--phase PHASE        "standalone", "k8s", or "both" (default: both)
+--skip-cleanup       Leave the test-runner pod running for debugging
+```
+
+## Exit code
+
+`go test`'s exit code (0 = all passed).

--- a/tests/integration/snapshot-agent/README.md
+++ b/tests/integration/snapshot-agent/README.md
@@ -56,7 +56,7 @@ This builds from your working directory, so local modifications are included —
 
 ## Options
 
-```
+```text
 --image IMAGE        Snapshot-agent container image (required)
 --project PROJECT    GCP project (runs gcloud get-credentials)
 --cluster CLUSTER    GKE cluster name

--- a/tests/integration/snapshot-agent/agentctl.py
+++ b/tests/integration/snapshot-agent/agentctl.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""CLI used by the integration tests to drive the snapshot-agent.
+
+All snapshot/restore calls in the test suite go through this script so that
+the tests exercise the real production path: the Python client
+(timeslice.snapshot_agent) talking gRPC to the Go agent. Configs are
+constructed here, in Python, the same way a real workload would build them.
+
+Usage:
+  agentctl.py --agent HOST:PORT snapshot|restore --job-id ID --backend cuda|app
+              [--pids 1,2,3]                       (cuda)
+              [--app vllm|sglang] [--endpoints URL,URL]
+              [--mode offload|discard] [--tags a,b] (app)
+
+Exits 0 when the operation completes, 1 otherwise.
+"""
+
+import argparse
+import sys
+
+from timeslice.snapshot_agent import SnapshotAgentClient, snapshot_agent_pb2
+
+APPS = {
+    "vllm": snapshot_agent_pb2.APP_VLLM,
+    "sglang": snapshot_agent_pb2.APP_SGLANG,
+}
+
+MODES = {
+    "": snapshot_agent_pb2.SUSPEND_MODE_UNSPECIFIED,
+    "offload": snapshot_agent_pb2.SUSPEND_MODE_OFFLOAD,
+    "discard": snapshot_agent_pb2.SUSPEND_MODE_DISCARD,
+}
+
+
+def build_config(args: argparse.Namespace) -> snapshot_agent_pb2.BackendConfig:
+    if args.backend == "cuda":
+        cuda = snapshot_agent_pb2.CudaBackendConfig()
+        if args.pids:
+            cuda.explicit_target.pids.extend(int(p) for p in args.pids.split(","))
+        return snapshot_agent_pb2.BackendConfig(cuda=cuda)
+
+    if args.backend == "app":
+        app_endpoint = snapshot_agent_pb2.AppEndpointConfig(
+            app=APPS[args.app],
+            endpoints=args.endpoints.split(",") if args.endpoints else [],
+            mode=MODES[args.mode],
+        )
+        if args.tags:
+            app_endpoint.tags.extend(args.tags.split(","))
+        return snapshot_agent_pb2.BackendConfig(app_endpoint=app_endpoint)
+
+    raise ValueError(f"unknown backend {args.backend!r}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("action", choices=["snapshot", "restore"])
+    parser.add_argument("--agent", required=True, help="agent endpoint HOST:PORT")
+    parser.add_argument("--job-id", required=True)
+    parser.add_argument("--group", default="test")
+    parser.add_argument("--backend", required=True, choices=["cuda", "app"])
+    parser.add_argument("--pids", default="", help="comma-separated PIDs (cuda)")
+    parser.add_argument("--app", default="", choices=["", "vllm", "sglang"], help="application (app backend)")
+    parser.add_argument("--endpoints", default="", help="comma-separated application URLs")
+    parser.add_argument("--mode", default="", choices=["", "offload", "discard"], help="suspend mode")
+    parser.add_argument("--tags", default="", help="comma-separated region tags")
+    args = parser.parse_args()
+
+    config = build_config(args)
+
+    with SnapshotAgentClient(args.agent) as client:
+        if args.action == "snapshot":
+            result = client.snapshot_and_wait(args.job_id, args.group, backend_config=config)
+        else:
+            result = client.restore_and_wait(args.job_id, args.group, backend_config=config)
+
+    if result.status != "OPERATION_STATUS_COMPLETE":
+        print(
+            f"{args.action} {args.job_id} finished with {result.status}: {result.error}",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"{args.action} {args.job_id} complete in {result.elapsed_ms}ms")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/snapshot-agent/agentctl.py
+++ b/tests/integration/snapshot-agent/agentctl.py
@@ -40,6 +40,8 @@ def build_config(args: argparse.Namespace) -> snapshot_agent_pb2.BackendConfig:
         return snapshot_agent_pb2.BackendConfig(cuda=cuda)
 
     if args.backend == "app":
+        if args.app not in APPS:
+            raise ValueError(f"--app is required for --backend app (one of {sorted(APPS)})")
         app_endpoint = snapshot_agent_pb2.AppEndpointConfig(
             app=APPS[args.app],
             endpoints=args.endpoints.split(",") if args.endpoints else [],

--- a/tests/integration/snapshot-agent/engines.go
+++ b/tests/integration/snapshot-agent/engines.go
@@ -112,9 +112,10 @@ func agentPod(image, node, mode string) *corev1.Pod {
 			HostPID:            true,
 			Tolerations:        gpuTolerations(),
 			InitContainers: []corev1.Container{{
-				Name:    "install-cuda-checkpoint",
-				Image:   "alpine:latest",
-				Command: []string{"sh", "-c", "apk add --no-cache wget && wget -qO /opt/bin/cuda-checkpoint https://raw.githubusercontent.com/NVIDIA/cuda-checkpoint/main/bin/x86_64_Linux/cuda-checkpoint && chmod +x /opt/bin/cuda-checkpoint"},
+				Name:  "install-cuda-checkpoint",
+				Image: "alpine:latest",
+				// Pinned to an immutable commit rather than the mutable main ref.
+				Command: []string{"sh", "-c", "apk add --no-cache wget && wget -qO /opt/bin/cuda-checkpoint https://raw.githubusercontent.com/NVIDIA/cuda-checkpoint/00d5cce84c628088d6caa203fc4af40c1538b6f7/bin/x86_64_Linux/cuda-checkpoint && chmod +x /opt/bin/cuda-checkpoint"},
 				VolumeMounts: []corev1.VolumeMount{
 					{Name: "bin-dir", MountPath: "/opt/bin"},
 				},

--- a/tests/integration/snapshot-agent/engines.go
+++ b/tests/integration/snapshot-agent/engines.go
@@ -1,0 +1,163 @@
+//go:build integration
+
+package integration
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// EngineSpec describes how to deploy an inference engine for testing.
+type EngineSpec struct {
+	Name       string // pod name is <Name>-test
+	Port       int
+	PIDPattern string // pattern to locate the engine process in /proc
+	BuildPod   func(h *Harness) *corev1.Pod
+}
+
+// VLLM runs vLLM with sleep mode enabled.
+var VLLM = EngineSpec{
+	Name:       "vllm",
+	Port:       8000,
+	PIDPattern: "vllm.entrypoints",
+	BuildPod: func(h *Harness) *corev1.Pod {
+		return enginePod(h, "vllm", "vllm/vllm-openai:latest",
+			[]string{"python3", "-m", "vllm.entrypoints.openai.api_server"},
+			[]string{
+				"--model=" + h.Model,
+				"--enable-sleep-mode",
+				"--host=0.0.0.0",
+				"--port=8000",
+				"--gpu-memory-utilization=0.5",
+			},
+			[]corev1.EnvVar{{Name: "VLLM_SERVER_DEV_MODE", Value: "1"}},
+		)
+	},
+}
+
+// SGLang runs SGLang with the memory saver and CPU weight backup enabled.
+var SGLang = EngineSpec{
+	Name:       "sglang",
+	Port:       30000,
+	PIDPattern: "sglang.launch_server",
+	BuildPod: func(h *Harness) *corev1.Pod {
+		return enginePod(h, "sglang", "lmsysorg/sglang:latest",
+			[]string{"python3", "-m", "sglang.launch_server"},
+			[]string{
+				"--model-path=" + h.Model,
+				"--enable-memory-saver",
+				"--enable-weights-cpu-backup",
+				"--host=0.0.0.0",
+				"--port=30000",
+				"--mem-fraction-static=0.5",
+			},
+			nil,
+		)
+	},
+}
+
+func enginePod(h *Harness, name, image string, command, args []string, env []corev1.EnvVar) *corev1.Pod {
+	labels := map[string]string{
+		"app":        name + "-test",
+		"test-suite": "snapshot-agent-integration",
+	}
+	// In k8s mode the watcher discovers jobs from these labels.
+	if h.Mode == "k8s" {
+		labels["timeslice.io/job-id"] = name + "-k8s"
+		labels["timeslice.io/group"] = "test"
+	}
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name + "-test",
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "snapshot-agent-test",
+			RestartPolicy:      corev1.RestartPolicyNever,
+			NodeName:           h.Node,
+			Tolerations:        gpuTolerations(),
+			Containers: []corev1.Container{{
+				Name:    name,
+				Image:   image,
+				Command: command,
+				Args:    args,
+				Env:     env,
+				Resources: corev1.ResourceRequirements{
+					Limits:   corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
+					Requests: corev1.ResourceList{"nvidia.com/gpu": resource.MustParse("1")},
+				},
+			}},
+		},
+	}
+}
+
+func agentPod(image, node, mode string) *corev1.Pod {
+	privileged := true
+	hostPathDir := corev1.HostPathDirectory
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agentPodName,
+			Namespace: namespace,
+			Labels: map[string]string{
+				"app":        agentPodName,
+				"test-suite": "snapshot-agent-integration",
+			},
+		},
+		Spec: corev1.PodSpec{
+			ServiceAccountName: "snapshot-agent-test",
+			RestartPolicy:      corev1.RestartPolicyNever,
+			NodeName:           node,
+			HostPID:            true,
+			Tolerations:        gpuTolerations(),
+			InitContainers: []corev1.Container{{
+				Name:    "install-cuda-checkpoint",
+				Image:   "alpine:latest",
+				Command: []string{"sh", "-c", "apk add --no-cache wget && wget -qO /opt/bin/cuda-checkpoint https://raw.githubusercontent.com/NVIDIA/cuda-checkpoint/main/bin/x86_64_Linux/cuda-checkpoint && chmod +x /opt/bin/cuda-checkpoint"},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "bin-dir", MountPath: "/opt/bin"},
+				},
+			}},
+			Containers: []corev1.Container{{
+				Name:  "snapshot-agent",
+				Image: image,
+				Args:  []string{"--port=9001", "--deployment-mode=" + mode},
+				Env: []corev1.EnvVar{
+					{Name: "PATH", Value: "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin"},
+					{Name: "NODE_NAME", ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "spec.nodeName"},
+					}},
+					{Name: "NVIDIA_VISIBLE_DEVICES", Value: "all"},
+					{Name: "NVIDIA_DRIVER_CAPABILITIES", Value: "compute,utility"},
+					{Name: "LD_LIBRARY_PATH", Value: "/usr/local/nvidia/lib64"},
+				},
+				Ports:           []corev1.ContainerPort{{ContainerPort: agentPort}},
+				SecurityContext: &corev1.SecurityContext{Privileged: &privileged},
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: "bin-dir", MountPath: "/opt/bin"},
+					{Name: "nvidia-driver", MountPath: "/usr/local/nvidia", ReadOnly: true},
+				},
+			}},
+			Volumes: []corev1.Volume{
+				{Name: "bin-dir", VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				}},
+				{Name: "nvidia-driver", VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/home/kubernetes/bin/nvidia",
+						Type: &hostPathDir,
+					},
+				}},
+			},
+		},
+	}
+}
+
+func gpuTolerations() []corev1.Toleration {
+	return []corev1.Toleration{{
+		Key:      "nvidia.com/gpu",
+		Operator: corev1.TolerationOpExists,
+		Effect:   corev1.TaintEffectNoSchedule,
+	}}
+}

--- a/tests/integration/snapshot-agent/harness.go
+++ b/tests/integration/snapshot-agent/harness.go
@@ -1,0 +1,438 @@
+//go:build integration
+
+// Package integration contains end-to-end tests for snapshot-agent backends.
+//
+// The harness runs INSIDE the cluster (see run.sh): it deploys the
+// snapshot-agent and inference engine pods via the Kubernetes API. All
+// snapshot/restore calls go through the Python client (via agentctl.py) —
+// the production path for workloads — never a Go gRPC client. The harness
+// talks to the engines over HTTP directly for inference checks.
+//
+// Test cases live in standalone_test.go and k8s_test.go. To add a test, add
+// a t.Run(...) inside the engine group that provides the pods it needs.
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+const (
+	namespace     = "default"
+	agentPodName  = "snapshot-agent-test"
+	agentPort     = 9001
+	podTimeout    = 5 * time.Minute
+	healthTimeout = 5 * time.Minute
+	// opTimeout bounds one agentctl.py invocation (RPC + operation polling);
+	// it also guards against the client's unbounded wait_for_operation.
+	opTimeout = 120 * time.Second
+	// vramFreedMiB is the threshold below which we consider GPU memory freed.
+	vramFreedMiB = 5000
+)
+
+// Harness manages the test stack for one deployment mode.
+type Harness struct {
+	Client *kubernetes.Clientset
+	Config *rest.Config
+	Node   string
+	Image  string
+	Model  string
+	Mode   string // "standalone" or "k8s"
+
+	AgentIP string
+}
+
+// NewHarness connects to the cluster, picks a GPU node, and deploys the
+// snapshot-agent in the given mode. The agent is deleted via t.Cleanup.
+func NewHarness(t *testing.T, mode string) *Harness {
+	t.Helper()
+
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		t.Fatalf("in-cluster config: %v", err)
+	}
+	client, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		t.Fatalf("k8s client: %v", err)
+	}
+
+	image := os.Getenv("AGENT_IMAGE")
+	if image == "" {
+		t.Fatal("AGENT_IMAGE env var is required")
+	}
+	model := os.Getenv("MODEL")
+	if model == "" {
+		model = "Qwen/Qwen2.5-0.5B"
+	}
+
+	h := &Harness{Client: client, Config: cfg, Image: image, Model: model, Mode: mode}
+	h.Node = h.pickGPUNode(t)
+	t.Logf("using node %s, image %s, mode %s", h.Node, h.Image, h.Mode)
+
+	h.deployAgent(t)
+	return h
+}
+
+// pickGPUNode returns the first node with at least one FREE GPU
+// (allocatable minus what running pods have requested). Engines run one at a
+// time, so a single free GPU is enough.
+func (h *Harness) pickGPUNode(t *testing.T) string {
+	t.Helper()
+	nodes, err := h.Client.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
+		LabelSelector: "cloud.google.com/gke-accelerator",
+	})
+	if err != nil {
+		t.Fatalf("listing GPU nodes: %v", err)
+	}
+	for i := range nodes.Items {
+		node := &nodes.Items[i]
+		alloc := node.Status.Allocatable[corev1.ResourceName("nvidia.com/gpu")]
+		if alloc.Value() < 1 {
+			continue
+		}
+		used, err := h.gpusRequestedOnNode(node.Name)
+		if err != nil {
+			t.Fatalf("counting GPU requests on %s: %v", node.Name, err)
+		}
+		if alloc.Value()-used >= 1 {
+			return node.Name
+		}
+		t.Logf("node %s has no free GPUs (%d/%d requested), skipping", node.Name, used, alloc.Value())
+	}
+	t.Fatal("no node with a free GPU found")
+	return ""
+}
+
+// gpusRequestedOnNode sums nvidia.com/gpu requests of non-terminated pods on
+// the node.
+func (h *Harness) gpusRequestedOnNode(node string) (int64, error) {
+	pods, err := h.Client.CoreV1().Pods("").List(context.Background(), metav1.ListOptions{
+		FieldSelector: "spec.nodeName=" + node,
+	})
+	if err != nil {
+		return 0, err
+	}
+	var used int64
+	for i := range pods.Items {
+		pod := &pods.Items[i]
+		if pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed {
+			continue
+		}
+		for j := range pod.Spec.Containers {
+			req := pod.Spec.Containers[j].Resources.Requests[corev1.ResourceName("nvidia.com/gpu")]
+			used += req.Value()
+		}
+	}
+	return used, nil
+}
+
+func (h *Harness) deployAgent(t *testing.T) {
+	t.Helper()
+	h.deletePodAndWait(t, agentPodName)
+
+	pod := agentPod(h.Image, h.Node, h.Mode)
+	if _, err := h.Client.CoreV1().Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("creating agent pod: %v", err)
+	}
+	t.Cleanup(func() { h.deletePodAndWait(t, agentPodName) })
+
+	h.AgentIP = h.waitPodReady(t, agentPodName)
+	t.Logf("agent ready at %s:%d", h.AgentIP, agentPort)
+}
+
+// WithEngine deploys an inference engine, waits until its HTTP server has
+// loaded the model, runs fn, and deletes the engine (freeing the GPU).
+func (h *Harness) WithEngine(t *testing.T, spec EngineSpec, fn func(t *testing.T, e *Engine)) {
+	t.Helper()
+	podName := spec.Name + "-test"
+	h.deletePodAndWait(t, podName)
+
+	pod := spec.BuildPod(h)
+	if _, err := h.Client.CoreV1().Pods(namespace).Create(context.Background(), pod, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("creating %s pod: %v", spec.Name, err)
+	}
+	defer h.deletePodAndWait(t, podName)
+
+	ip := h.waitPodReady(t, podName)
+	t.Logf("%s pod ready at %s, waiting for model load...", spec.Name, ip)
+	h.waitHTTP(t, fmt.Sprintf("http://%s:%d/health", ip, spec.Port))
+
+	e := &Engine{Spec: spec, IP: ip, PodName: podName}
+	if h.Mode == "standalone" {
+		e.PID = h.findPID(t, spec.PIDPattern)
+		t.Logf("%s PID: %d", spec.Name, e.PID)
+	} else {
+		// Give the watcher time to spot the labeled pod's GPU activity and
+		// register the job.
+		t.Log("waiting 10s for watcher to register the job...")
+		time.Sleep(10 * time.Second)
+	}
+
+	fn(t, e)
+}
+
+// Engine is a running inference engine instance.
+type Engine struct {
+	Spec    EngineSpec
+	IP      string
+	PodName string
+	PID     int32 // standalone mode only
+}
+
+// Endpoint returns the engine's HTTP base URL as seen from inside the cluster.
+func (e *Engine) Endpoint() string {
+	return fmt.Sprintf("http://%s:%d", e.IP, e.Spec.Port)
+}
+
+// --- Pod helpers ---
+
+func (h *Harness) waitPodReady(t *testing.T, name string) string {
+	t.Helper()
+	deadline := time.Now().Add(podTimeout)
+	for time.Now().Before(deadline) {
+		pod, err := h.Client.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if err == nil {
+			for _, cond := range pod.Status.Conditions {
+				if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+					return pod.Status.PodIP
+				}
+			}
+		}
+		time.Sleep(3 * time.Second)
+	}
+	t.Fatalf("timeout waiting for pod %s to become ready", name)
+	return ""
+}
+
+func (h *Harness) deletePodAndWait(t *testing.T, name string) {
+	t.Helper()
+	zero := int64(0)
+	err := h.Client.CoreV1().Pods(namespace).Delete(context.Background(), name, metav1.DeleteOptions{
+		GracePeriodSeconds: &zero,
+	})
+	if apierrors.IsNotFound(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("deleting pod %s: %v", name, err)
+	}
+	deadline := time.Now().Add(2 * time.Minute)
+	for time.Now().Before(deadline) {
+		_, err := h.Client.CoreV1().Pods(namespace).Get(context.Background(), name, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return
+		}
+		time.Sleep(2 * time.Second)
+	}
+	t.Fatalf("timeout waiting for pod %s to be deleted", name)
+}
+
+// waitHTTP polls url until it returns 200. Pod readiness only means the
+// container started; engines need additional time to load the model.
+func (h *Harness) waitHTTP(t *testing.T, url string) {
+	t.Helper()
+	client := &http.Client{Timeout: 5 * time.Second}
+	deadline := time.Now().Add(healthTimeout)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+		}
+		time.Sleep(5 * time.Second)
+	}
+	t.Fatalf("timeout waiting for %s", url)
+}
+
+// execPod runs a command in a pod container and returns stdout.
+func (h *Harness) execPod(pod, container string, command ...string) (string, error) {
+	req := h.Client.CoreV1().RESTClient().Post().
+		Resource("pods").Name(pod).Namespace(namespace).SubResource("exec").
+		VersionedParams(&corev1.PodExecOptions{
+			Container: container,
+			Command:   command,
+			Stdout:    true,
+			Stderr:    true,
+		}, scheme.ParameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(h.Config, "POST", req.URL())
+	if err != nil {
+		return "", fmt.Errorf("creating executor: %w", err)
+	}
+	var stdout, stderr bytes.Buffer
+	err = exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
+		Stdout: &stdout,
+		Stderr: &stderr,
+	})
+	if err != nil {
+		return "", fmt.Errorf("exec failed: %w (stderr: %s)", err, stderr.String())
+	}
+	return stdout.String(), nil
+}
+
+// findPID locates the engine process on the node via the agent pod (hostPID).
+func (h *Harness) findPID(t *testing.T, pattern string) int32 {
+	t.Helper()
+	script := fmt.Sprintf(
+		`for p in /proc/[0-9]*/cmdline; do grep -ql '%s' $p 2>/dev/null && echo $p | cut -d/ -f3 && break; done`,
+		pattern)
+	out, err := h.execPod(agentPodName, "snapshot-agent", "sh", "-c", script)
+	if err != nil {
+		t.Fatalf("finding PID for %q: %v", pattern, err)
+	}
+	pid, err := strconv.ParseInt(strings.TrimSpace(out), 10, 32)
+	if err != nil {
+		t.Fatalf("parsing PID from %q: %v", out, err)
+	}
+	return int32(pid)
+}
+
+// VRAMMiB returns the GPU memory used (MiB) as seen from the engine pod.
+func (h *Harness) VRAMMiB(t *testing.T, e *Engine) int {
+	t.Helper()
+	out, err := h.execPod(e.PodName, e.Spec.Name,
+		"nvidia-smi", "--query-gpu=memory.used", "--format=csv,noheader,nounits")
+	if err != nil {
+		t.Fatalf("querying VRAM on %s: %v", e.PodName, err)
+	}
+	mib, err := strconv.Atoi(strings.TrimSpace(strings.Split(out, "\n")[0]))
+	if err != nil {
+		t.Fatalf("parsing VRAM from %q: %v", out, err)
+	}
+	return mib
+}
+
+// --- Agent call helpers ---
+//
+// All snapshot/restore calls go through the Python client via agentctl.py —
+// the production path for workloads. The Go tests never dial the agent
+// directly. BackendArgs describes a config with primitives; agentctl.py
+// constructs the actual BackendConfig proto in Python, the same way a real
+// workload does.
+
+// BackendArgs are the agentctl.py flags describing a backend config.
+type BackendArgs []string
+
+func cudaConfig(pids ...int32) BackendArgs {
+	args := BackendArgs{"--backend", "cuda"}
+	if len(pids) > 0 {
+		strs := make([]string, len(pids))
+		for i, pid := range pids {
+			strs[i] = strconv.Itoa(int(pid))
+		}
+		args = append(args, "--pids", strings.Join(strs, ","))
+	}
+	return args
+}
+
+// appConfig targets an application-aware workload via its HTTP API.
+// mode may be "" (application default), "offload", or "discard".
+func appConfig(app, endpoint, mode string) BackendArgs {
+	args := BackendArgs{"--backend", "app", "--app", app, "--endpoints", endpoint}
+	if mode != "" {
+		args = append(args, "--mode", mode)
+	}
+	return args
+}
+
+// SnapshotOK snapshots via the Python client and fails the test if the
+// operation does not complete.
+func (h *Harness) SnapshotOK(t *testing.T, jobID string, cfg BackendArgs) {
+	t.Helper()
+	h.agentctl(t, "snapshot", jobID, cfg)
+}
+
+// RestoreOK restores via the Python client and fails the test if the
+// operation does not complete.
+func (h *Harness) RestoreOK(t *testing.T, jobID string, cfg BackendArgs) {
+	t.Helper()
+	h.agentctl(t, "restore", jobID, cfg)
+}
+
+func (h *Harness) agentctl(t *testing.T, action, jobID string, cfg BackendArgs) {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+	defer cancel()
+
+	// go test runs with the package directory as the working directory.
+	args := []string{"agentctl.py", action,
+		"--agent", fmt.Sprintf("%s:%d", h.AgentIP, agentPort),
+		"--job-id", jobID}
+	args = append(args, cfg...)
+
+	cmd := exec.CommandContext(ctx, "python3", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s(%s) via python client failed: %v\n%s", action, jobID, err, string(out))
+	}
+	t.Logf("%s", strings.TrimSpace(string(out)))
+}
+
+// --- Inference helpers ---
+
+// Inference runs a fixed deterministic prompt against the engine's
+// OpenAI-compatible API and returns the completion text.
+func (h *Harness) Inference(t *testing.T, e *Engine) string {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{
+		"model":       h.Model,
+		"prompt":      "The capital of France is",
+		"max_tokens":  15,
+		"temperature": 0,
+	})
+	if err != nil {
+		t.Fatalf("marshaling inference request: %v", err)
+	}
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Post(e.Endpoint()+"/v1/completions", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("inference request to %s: %v", e.Endpoint(), err)
+	}
+	defer resp.Body.Close()
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading inference response: %v", err)
+	}
+	var parsed struct {
+		Choices []struct {
+			Text string `json:"text"`
+		} `json:"choices"`
+	}
+	if err := json.Unmarshal(raw, &parsed); err != nil || len(parsed.Choices) == 0 {
+		t.Fatalf("unexpected inference response (status %d): %s", resp.StatusCode, string(raw))
+	}
+	return parsed.Choices[0].Text
+}
+
+// RequireFreedAndCorrect asserts VRAM was actually freed while the engine was
+// asleep and that inference output is identical after restore.
+func RequireFreedAndCorrect(t *testing.T, vramWhileAsleep int, before, after string) {
+	t.Helper()
+	if vramWhileAsleep >= vramFreedMiB {
+		t.Errorf("VRAM not freed: %d MiB (want < %d)", vramWhileAsleep, vramFreedMiB)
+	}
+	if before != after {
+		t.Errorf("inference changed after restore: before=%q after=%q", before, after)
+	}
+}
+

--- a/tests/integration/snapshot-agent/harness.go
+++ b/tests/integration/snapshot-agent/harness.go
@@ -266,6 +266,8 @@ func (h *Harness) waitHTTP(t *testing.T, url string) {
 
 // execPod runs a command in a pod container and returns stdout.
 func (h *Harness) execPod(pod, container string, command ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), opTimeout)
+	defer cancel()
 	req := h.Client.CoreV1().RESTClient().Post().
 		Resource("pods").Name(pod).Namespace(namespace).SubResource("exec").
 		VersionedParams(&corev1.PodExecOptions{
@@ -280,7 +282,7 @@ func (h *Harness) execPod(pod, container string, command ...string) (string, err
 		return "", fmt.Errorf("creating executor: %w", err)
 	}
 	var stdout, stderr bytes.Buffer
-	err = exec.StreamWithContext(context.Background(), remotecommand.StreamOptions{
+	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{
 		Stdout: &stdout,
 		Stderr: &stderr,
 	})

--- a/tests/integration/snapshot-agent/k8s_test.go
+++ b/tests/integration/snapshot-agent/k8s_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+package integration
+
+import "testing"
+
+// TestK8s exercises all backends in k8s mode: the watcher registers jobs from
+// pod labels, CUDA PIDs are discovered from pods (no explicit target), and
+// inference engine configs pass through to the backend.
+func TestK8s(t *testing.T) {
+	h := NewHarness(t, "k8s")
+
+	h.WithEngine(t, VLLM, func(t *testing.T, e *Engine) {
+		// All k8s-mode job IDs match the pod's timeslice.io/job-id label: the
+		// watcher is the only source of job registration in k8s mode. The empty
+		// CUDA config exercises PID discovery.
+		t.Run("CUDAWatcherDiscoveredPIDs", func(t *testing.T) {
+			before := h.Inference(t, e)
+			h.SnapshotOK(t, "vllm-k8s", cudaConfig())
+			h.RestoreOK(t, "vllm-k8s", cudaConfig())
+			after := h.Inference(t, e)
+			if before != after {
+				t.Errorf("inference changed after restore: before=%q after=%q", before, after)
+			}
+		})
+
+		t.Run("VLLMSleepWake", func(t *testing.T) {
+			before := h.Inference(t, e)
+			h.SnapshotOK(t, "vllm-k8s", appConfig("vllm", e.Endpoint(), ""))
+			vramAsleep := h.VRAMMiB(t, e)
+			t.Logf("VRAM after sleep: %d MiB", vramAsleep)
+			h.RestoreOK(t, "vllm-k8s", appConfig("vllm", e.Endpoint(), ""))
+			after := h.Inference(t, e)
+			RequireFreedAndCorrect(t, vramAsleep, before, after)
+		})
+	})
+
+	h.WithEngine(t, SGLang, func(t *testing.T, e *Engine) {
+		t.Run("SGLangReleaseResume", func(t *testing.T) {
+			before := h.Inference(t, e)
+			h.SnapshotOK(t, "sglang-k8s", appConfig("sglang", e.Endpoint(), ""))
+			vramReleased := h.VRAMMiB(t, e)
+			t.Logf("VRAM after release: %d MiB", vramReleased)
+			h.RestoreOK(t, "sglang-k8s", appConfig("sglang", e.Endpoint(), ""))
+			after := h.Inference(t, e)
+			RequireFreedAndCorrect(t, vramReleased, before, after)
+		})
+	})
+}

--- a/tests/integration/snapshot-agent/run.sh
+++ b/tests/integration/snapshot-agent/run.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Launcher for the snapshot-agent integration tests.
+#
+# The test suite itself is written in Go (see *_test.go) and runs INSIDE the
+# cluster: this script deploys the test-runner pod, copies the repo source
+# into it, and executes `go test` there. The Go harness deploys the agent and
+# engine pods itself, one engine at a time, so a single free GPU is enough.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+K="${KUBECTL:-kubectl}"
+
+IMAGE=""
+PROJECT=""
+CLUSTER=""
+ZONE=""
+MODEL=""
+PHASE="both"
+SKIP_CLEANUP=false
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --image)        IMAGE="$2"; shift 2 ;;
+    --project)      PROJECT="$2"; shift 2 ;;
+    --cluster)      CLUSTER="$2"; shift 2 ;;
+    --zone)         ZONE="$2"; shift 2 ;;
+    --model)        MODEL="$2"; shift 2 ;;
+    --phase)        PHASE="$2"; shift 2 ;;
+    --skip-cleanup) SKIP_CLEANUP=true; shift ;;
+    *) echo "Unknown option: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$IMAGE" ]]; then
+  echo "Error: --image is required"
+  echo "Usage: $0 --image IMAGE [--project PROJECT --cluster CLUSTER --zone ZONE] [--model MODEL] [--phase standalone|k8s|both]"
+  exit 1
+fi
+
+case "$PHASE" in
+  standalone) RUN_PATTERN='^TestStandalone$' ;;
+  k8s)        RUN_PATTERN='^TestK8s$' ;;
+  both)       RUN_PATTERN='^(TestStandalone|TestK8s)$' ;;
+  *) echo "Unknown phase: $PHASE"; exit 1 ;;
+esac
+
+log() { echo "$(date +%H:%M:%S) $*"; }
+
+if [[ -n "$CLUSTER" ]]; then
+  ZONE_FLAG=""
+  [[ -n "$ZONE" ]] && ZONE_FLAG="--zone ${ZONE}"
+  PROJECT_FLAG=""
+  [[ -n "$PROJECT" ]] && PROJECT_FLAG="--project ${PROJECT}"
+  log "Getting credentials for cluster ${CLUSTER}..."
+  # shellcheck disable=SC2086
+  gcloud container clusters get-credentials "$CLUSTER" $ZONE_FLAG $PROJECT_FLAG 2>&1
+fi
+
+log "Deploying test runner..."
+$K apply -f "${SCRIPT_DIR}/runner.yaml"
+$K wait --for=condition=Ready pod/test-runner --timeout=300s
+
+log "Copying repo source into test runner..."
+tar -czf - -C "$REPO_ROOT" --exclude .git . \
+  | $K exec -i test-runner -- sh -c "rm -rf /workspace && mkdir -p /workspace && tar -xzf - -C /workspace"
+
+log "Installing the Python client in the test runner (tests drive the agent through it)..."
+$K exec test-runner -- sh -c "apt-get update -qq > /dev/null && apt-get install -y -qq python3 python3-pip > /dev/null && pip3 install --break-system-packages -q /workspace/pkg/client/python"
+
+log "Running Go test suite in-cluster (this deploys agent + engine pods)..."
+EXIT=0
+$K exec test-runner -- env "AGENT_IMAGE=${IMAGE}" "MODEL=${MODEL}" \
+  sh -c "cd /workspace && go test -tags=integration -count=1 -v -timeout 40m -run '${RUN_PATTERN}' ./tests/integration/snapshot-agent/" \
+  || EXIT=$?
+
+if [[ "$SKIP_CLEANUP" == "false" ]]; then
+  log "Cleaning up..."
+  $K delete pods -l test-suite=snapshot-agent-integration --force --grace-period=0 2>/dev/null || true
+  $K delete -f "${SCRIPT_DIR}/runner.yaml" --force --grace-period=0 2>/dev/null || true
+fi
+
+exit "$EXIT"

--- a/tests/integration/snapshot-agent/runner.yaml
+++ b/tests/integration/snapshot-agent/runner.yaml
@@ -1,0 +1,75 @@
+# Bootstrap for the integration tests: the test-runner pod executes the Go
+# test suite in-cluster (see run.sh), deploying the agent and engine pods
+# itself via the Kubernetes API.
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-agent-test
+  namespace: default
+---
+# The agent's watcher lists pods to discover jobs (k8s mode).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: snapshot-agent-test
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-agent-test
+    namespace: default
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: snapshot-agent-test-runner
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: snapshot-agent-test-runner
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: snapshot-agent-test-runner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: snapshot-agent-test-runner
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-agent-test-runner
+    namespace: default
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-runner
+  labels:
+    app: test-runner
+    test-suite: snapshot-agent-integration
+spec:
+  serviceAccountName: snapshot-agent-test-runner
+  containers:
+    - name: runner
+      image: golang:1.25-bookworm
+      command: ["sleep", "infinity"]
+  restartPolicy: Never

--- a/tests/integration/snapshot-agent/runner.yaml
+++ b/tests/integration/snapshot-agent/runner.yaml
@@ -28,6 +28,8 @@ metadata:
   name: snapshot-agent-test-runner
   namespace: default
 ---
+# Cluster-wide read-only: node discovery and the all-namespaces pod listing
+# used to find a free GPU. Pod CRUD/exec stays namespace-local below.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -38,13 +40,7 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["get", "list", "watch", "create", "delete"]
-  - apiGroups: [""]
-    resources: ["pods/exec"]
-    verbs: ["create"]
-  - apiGroups: [""]
-    resources: ["pods/log"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -53,6 +49,36 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  name: snapshot-agent-test-runner
+subjects:
+  - kind: ServiceAccount
+    name: snapshot-agent-test-runner
+    namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: snapshot-agent-test-runner
+  namespace: default
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: snapshot-agent-test-runner
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
   name: snapshot-agent-test-runner
 subjects:
   - kind: ServiceAccount

--- a/tests/integration/snapshot-agent/standalone_test.go
+++ b/tests/integration/snapshot-agent/standalone_test.go
@@ -1,0 +1,84 @@
+//go:build integration
+
+package integration
+
+import "testing"
+
+// TestStandalone exercises all backends in standalone mode: the caller
+// provides the full BackendConfig (explicit PIDs for CUDA) and the agent's
+// NVML check bootstraps jobs on first snapshot.
+func TestStandalone(t *testing.T) {
+	h := NewHarness(t, "standalone")
+
+	h.WithEngine(t, VLLM, func(t *testing.T, e *Engine) {
+		t.Run("CUDACheckpointRestore", func(t *testing.T) {
+			before := h.Inference(t, e)
+			h.SnapshotOK(t, "s-cuda", cudaConfig(e.PID))
+			h.RestoreOK(t, "s-cuda", cudaConfig(e.PID))
+			after := h.Inference(t, e)
+			if before != after {
+				t.Errorf("inference changed after restore: before=%q after=%q", before, after)
+			}
+		})
+
+		t.Run("VLLMSleepWake", func(t *testing.T) {
+			before := h.Inference(t, e)
+			h.SnapshotOK(t, "s-vllm", appConfig("vllm", e.Endpoint(), ""))
+			vramAsleep := h.VRAMMiB(t, e)
+			t.Logf("VRAM after sleep: %d MiB", vramAsleep)
+			h.RestoreOK(t, "s-vllm", appConfig("vllm", e.Endpoint(), ""))
+			after := h.Inference(t, e)
+			RequireFreedAndCorrect(t, vramAsleep, before, after)
+		})
+
+		// Compound: app-level sleep, then CUDA checkpoint of the slept
+		// process, restored in reverse order.
+		t.Run("VLLMCompound", func(t *testing.T) {
+			before := h.Inference(t, e)
+			h.SnapshotOK(t, "s-vllm-c", appConfig("vllm", e.Endpoint(), "offload"))
+			vramAsleep := h.VRAMMiB(t, e)
+			h.SnapshotOK(t, "s-cuda-c", cudaConfig(e.PID))
+			h.RestoreOK(t, "s-cuda-c", cudaConfig(e.PID))
+			h.RestoreOK(t, "s-vllm-c", appConfig("vllm", e.Endpoint(), ""))
+			after := h.Inference(t, e)
+			RequireFreedAndCorrect(t, vramAsleep, before, after)
+		})
+
+		// DISCARD drops the weights: the engine cannot serve correct inference
+		// afterwards without an application-level weight push, so this test
+		// verifies the suspend/resume operations and VRAM only. It runs last
+		// in the group — the engine's weights are garbage after it.
+		t.Run("VLLMSuspendDiscard", func(t *testing.T) {
+			h.SnapshotOK(t, "s-vllm-d", appConfig("vllm", e.Endpoint(), "discard"))
+			vramSuspended := h.VRAMMiB(t, e)
+			t.Logf("VRAM after discard suspend: %d MiB", vramSuspended)
+			if vramSuspended >= vramFreedMiB {
+				t.Errorf("VRAM not freed: %d MiB (want < %d)", vramSuspended, vramFreedMiB)
+			}
+			h.RestoreOK(t, "s-vllm-d", appConfig("vllm", e.Endpoint(), ""))
+		})
+	})
+
+	h.WithEngine(t, SGLang, func(t *testing.T, e *Engine) {
+		t.Run("SGLangReleaseResume", func(t *testing.T) {
+			before := h.Inference(t, e)
+			h.SnapshotOK(t, "s-sgl", appConfig("sglang", e.Endpoint(), ""))
+			vramReleased := h.VRAMMiB(t, e)
+			t.Logf("VRAM after release: %d MiB", vramReleased)
+			h.RestoreOK(t, "s-sgl", appConfig("sglang", e.Endpoint(), ""))
+			after := h.Inference(t, e)
+			RequireFreedAndCorrect(t, vramReleased, before, after)
+		})
+
+		t.Run("SGLangCompound", func(t *testing.T) {
+			before := h.Inference(t, e)
+			h.SnapshotOK(t, "s-sgl-c", appConfig("sglang", e.Endpoint(), ""))
+			vramReleased := h.VRAMMiB(t, e)
+			h.SnapshotOK(t, "s-cuda-sc", cudaConfig(e.PID))
+			h.RestoreOK(t, "s-cuda-sc", cudaConfig(e.PID))
+			h.RestoreOK(t, "s-sgl-c", appConfig("sglang", e.Endpoint(), ""))
+			after := h.Inference(t, e)
+			RequireFreedAndCorrect(t, vramReleased, before, after)
+		})
+	})
+}


### PR DESCRIPTION
## Summary

End-to-end integration tests for all snapshot-agent backends on real GPU hardware. Part 6 of the app-aware backends series (stacked on #99). The CI gating workflow comes in the next PR.

### Design

The suite is Go (`go test`) and runs inside the cluster: `run.sh` deploys a test-runner pod, copies the repo source in, and executes `go test -tags=integration` there. The machine running the tests needs only `gcloud` and `kubectl`.

All snapshot/restore calls go through the Python client (`timeslice.snapshot_agent`, via `agentctl.py`), so the entire client layer is covered. `agentctl.py` builds `BackendConfig` protos in Python from primitive flags.

The Go harness owns everything that isn't the client: agent/engine pod lifecycle via client-go — one engine at a time, so a single free GPU is enough — model-load waits, VRAM measurement via in-pod exec, inference correctness checks. Node selection counts free GPUs (allocatable minus requested), so the suite avoids nodes occupied by other workloads. In k8s mode, all job IDs match the pods' `timeslice.io/job-id` labels — the watcher is the only source of job registration.

### Layout

- `run.sh` — launcher (deploy runner, copy source, pip install the client, `go test`, cleanup)
- `runner.yaml` — test-runner pod + RBAC
- `harness.go` / `engines.go` — pod lifecycle, exec/HTTP helpers, pod specs
- `agentctl.py` — thin CLI over the Python client (`--backend cuda|app`, `--app`, `--mode`, `--tags`)
- `standalone_test.go` / `k8s_test.go` — the test cases
- `Dockerfile.snapshot-agent-runtime` + parameterized `cloudbuild-image.yaml` — agent image build from the working tree

Tests verify VRAM is actually freed and inference output is identical after restore. Compound cases validate that application-aware suspend and CUDA checkpoint compose (suspend → cuda-ckpt → cuda-restore → resume).

### Test results (H100 80GB, GKE us-west1-c, this PR's suite)

```
--- PASS: TestStandalone (168.24s)
    --- PASS: TestStandalone/CUDACheckpointRestore
    --- PASS: TestStandalone/VLLMSleepWake          (VRAM after suspend: 1247 MiB)
    --- PASS: TestStandalone/VLLMCompound
    --- PASS: TestStandalone/VLLMSuspendDiscard     (operations + VRAM only; DISCARD drops weights)
    --- PASS: TestStandalone/SGLangReleaseResume    (VRAM after suspend: 2046 MiB)
    --- PASS: TestStandalone/SGLangCompound
--- PASS: TestK8s (200.83s)
    --- PASS: TestK8s/CUDAWatcherDiscoveredPIDs
    --- PASS: TestK8s/VLLMSleepWake                 (VRAM after suspend: 1247 MiB)
    --- PASS: TestK8s/SGLangReleaseResume           (VRAM after suspend: 2046 MiB)
PASS
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a multi-stage container image build for the snapshot agent.
  * Added automated image build and publishing configuration.
  * Added end-to-end snapshot/restore integration testing for both Kubernetes and standalone.
  * Added engine coverage for vLLM and SGLang, including inference consistency and GPU memory release verification.
* **Documentation**
  * Added detailed setup, prerequisites, usage, and troubleshooting guidance for running the integration test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->