### PR TITLE
[app-endpoint 6/6] snapshot-agent: gate PRs on manual integration testing

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,6 @@
+needs-integration-test:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'pkg/snapshot-agent/**'
+          - 'cmd/snapshot-agent/**'
+          - 'pkg/client/python/timeslice/snapshot_agent/**'

--- a/.github/workflows/label-integration-test.yaml
+++ b/.github/workflows/label-integration-test.yaml
@@ -1,0 +1,33 @@
+name: Integration test gate
+on:
+  pull_request:
+    types: [opened, synchronize, labeled, unlabeled]
+
+jobs:
+  label:
+    name: Auto-label snapshot-agent PRs
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml
+
+  gate:
+    name: Integration test required
+    runs-on: ubuntu-latest
+    needs: label
+    steps:
+      - name: Block merge if integration test not completed
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+        run: |
+          if echo "$LABELS" | grep -q "needs-integration-test"; then
+            echo "::error::This PR modifies snapshot-agent and requires manual integration testing."
+            echo "::error::See tests/integration/snapshot-agent/README.md for how to run the integration tests."
+            echo "::error::Post the test results as a comment on this PR, or if integration tests are not applicable, comment a justification. Then remove the 'needs-integration-test' label."
+            exit 1
+          fi
+          echo "No integration test label found. Merge allowed."

--- a/.github/workflows/label-integration-test.yaml
+++ b/.github/workflows/label-integration-test.yaml
@@ -30,6 +30,13 @@ jobs:
     permissions:
       pull-requests: read
     steps:
+      # Fail closed: if the labeler errored, we cannot know whether this PR
+      # needs integration testing. (Skipped is fine — that's the unlabeled path.)
+      - name: Fail if the labeler failed
+        if: ${{ needs.label.result == 'failure' }}
+        run: |
+          echo "::error::Auto-labeler failed; cannot determine whether integration testing is required."
+          exit 1
       - name: Block merge if integration test not completed
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/label-integration-test.yaml
+++ b/.github/workflows/label-integration-test.yaml
@@ -1,11 +1,18 @@
 name: Integration test gate
+# pull_request_target so the labeler can write labels on fork PRs too.
+# Safe: this workflow never checks out or executes PR code.
 on:
-  pull_request:
-    types: [opened, synchronize, labeled, unlabeled]
+  pull_request_target:
+    types: [opened, reopened, synchronize, labeled, unlabeled]
+
+permissions: {}
 
 jobs:
   label:
     name: Auto-label snapshot-agent PRs
+    # Skip on unlabeled: re-running the labeler would immediately re-add the
+    # label that was just removed, so manual removal would never stick.
+    if: github.event.action != 'unlabeled'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,12 +26,20 @@ jobs:
     name: Integration test required
     runs-on: ubuntu-latest
     needs: label
+    if: ${{ !cancelled() }}
+    permissions:
+      pull-requests: read
     steps:
       - name: Block merge if integration test not completed
         env:
-          LABELS: ${{ join(github.event.pull_request.labels.*.name, ',') }}
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        # Query live labels rather than the event payload: the payload
+        # predates whatever the label job just did in this same run.
         run: |
-          if echo "$LABELS" | grep -q "needs-integration-test"; then
+          labels=$(gh api "repos/$REPO/issues/$PR/labels" --jq '.[].name')
+          if printf '%s\n' "$labels" | grep -Fxq "needs-integration-test"; then
             echo "::error::This PR modifies snapshot-agent and requires manual integration testing."
             echo "::error::See tests/integration/snapshot-agent/README.md for how to run the integration tests."
             echo "::error::Post the test results as a comment on this PR, or if integration tests are not applicable, comment a justification. Then remove the 'needs-integration-test' label."


### PR DESCRIPTION
## Summary

CI gate requiring manual integration testing for snapshot-agent changes. Part 7 (final) of the app-aware backends series (stacked on #100).

- PRs touching `pkg/snapshot-agent/**` or `cmd/snapshot-agent/**` are auto-labeled `needs-integration-test` (actions/labeler)
- The **Integration test required** check fails while the label is present, pointing to `tests/integration/snapshot-agent/README.md` for how to run the tests
- Workflow: run the integration tests and post the results as a comment on the PR — or, if integration tests are not applicable, comment a justification — then remove the label to unblock merge

### Post-merge action

Add **Integration test required** as a required status check in main's branch protection — the check alone doesn't block merging until it's required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic labeling for changes affecting snapshot-agent components.
  * Added an “Integration test gate” workflow that blocks merging when the required integration-test label is present, prompting for results or a brief justification, then instructing removal of the label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->