### PR TITLE
[app-channel 2] snapshot-agent: add workload channel for registered application workloads

### DIFF
--- a/cmd/snapshot-agent/main.go
+++ b/cmd/snapshot-agent/main.go
@@ -59,14 +59,18 @@ func main() {
 	}
 	ctx := context.Background()
 
+	// The channel registry is shared between the app-channel backend and the
+	// server's WorkloadChannel RPC handler.
+	channelRegistry := backends.NewChannelRegistry()
 	registeredBackends := map[backends.BackendType]backends.Backend{
 		backends.BackendCuda:        backends.NewCudaCheckpoint(),
 		backends.BackendNoop:        backends.NewNoopBackend(),
 		backends.BackendAppEndpoint: backends.NewAppEndpointBackend(),
+		backends.BackendAppChannel:  backends.NewAppChannelBackend(channelRegistry),
 	}
 
 	slog.InfoContext(ctx, "Starting Snapshot Agent", "port", listenPort, "deploymentMode", depMode)
-	if err := server.StartServer(ctx, listenPort, registeredBackends, backends.BackendCuda, depMode); err != nil {
+	if err := server.StartServer(ctx, listenPort, registeredBackends, backends.BackendCuda, depMode, channelRegistry); err != nil {
 		slog.ErrorContext(ctx, "Failed to start server", "error", err)
 		os.Exit(1)
 	}

--- a/pkg/snapshot-agent/backends/app_channel.go
+++ b/pkg/snapshot-agent/backends/app_channel.go
@@ -1,0 +1,264 @@
+package backends
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+)
+
+// defaultCommandTimeout bounds how long a dispatched command waits for the
+// workload's CommandResult. It covers the workload executing the suspend or
+// resume (e.g. offloading weights to host memory), not just the round trip.
+const defaultCommandTimeout = 2 * time.Minute
+
+// WorkloadSession is one registered workload stream. It routes commands to
+// the stream's send function and matches CommandResults to in-flight
+// commands by command_id.
+type WorkloadSession struct {
+	jobID string
+	caps  *pb.WorkloadCapabilities
+
+	// sendMu serializes writes to the underlying gRPC stream, which does not
+	// allow concurrent Sends.
+	sendMu sync.Mutex
+	send   func(*pb.AgentCommand) error
+
+	mu      sync.Mutex
+	pending map[string]chan *pb.CommandResult
+
+	closeOnce sync.Once
+	closed    chan struct{}
+}
+
+// Capabilities returns the capabilities the workload declared at registration.
+func (s *WorkloadSession) Capabilities() *pb.WorkloadCapabilities {
+	return s.caps
+}
+
+// HandleResult routes a CommandResult from the stream to the in-flight
+// command waiting on it. Results for unknown command IDs are dropped (the
+// command may have timed out).
+func (s *WorkloadSession) HandleResult(res *pb.CommandResult) {
+	s.mu.Lock()
+	ch, ok := s.pending[res.GetCommandId()]
+	if ok {
+		delete(s.pending, res.GetCommandId())
+	}
+	s.mu.Unlock()
+	if ok {
+		ch <- res
+	}
+}
+
+// close marks the session as gone, failing any in-flight dispatches.
+func (s *WorkloadSession) close() {
+	s.closeOnce.Do(func() { close(s.closed) })
+}
+
+// Dispatch assigns the command a unique ID, sends it once, and waits for the
+// matching CommandResult, the session to drop, or ctx to expire.
+func (s *WorkloadSession) Dispatch(ctx context.Context, cmd *pb.AgentCommand) error {
+	cmd.CommandId = uuid.New().String()
+
+	ch := make(chan *pb.CommandResult, 1)
+	s.mu.Lock()
+	s.pending[cmd.CommandId] = ch
+	s.mu.Unlock()
+	defer func() {
+		s.mu.Lock()
+		delete(s.pending, cmd.CommandId)
+		s.mu.Unlock()
+	}()
+
+	s.sendMu.Lock()
+	err := s.send(cmd)
+	s.sendMu.Unlock()
+	if err != nil {
+		return fmt.Errorf("failed to send command to workload %s: %w", s.jobID, err)
+	}
+
+	select {
+	case res := <-ch:
+		if !res.GetOk() {
+			return fmt.Errorf("workload %s failed command: %s", s.jobID, res.GetError())
+		}
+		return nil
+	case <-s.closed:
+		return fmt.Errorf("workload %s disconnected before completing command", s.jobID)
+	case <-ctx.Done():
+		return fmt.Errorf("timed out waiting for workload %s to complete command: %w", s.jobID, ctx.Err())
+	}
+}
+
+// ChannelRegistry tracks the workload session registered for each job. It is
+// shared between the WorkloadChannel RPC handler (which registers streams)
+// and the AppChannelBackend (which dispatches commands to them).
+type ChannelRegistry struct {
+	mu       sync.Mutex
+	sessions map[string]*WorkloadSession
+}
+
+// NewChannelRegistry creates an empty registry.
+func NewChannelRegistry() *ChannelRegistry {
+	return &ChannelRegistry{sessions: make(map[string]*WorkloadSession)}
+}
+
+// Register creates a session for jobID backed by the given send function.
+// A previously registered session for the same job is replaced and closed.
+func (r *ChannelRegistry) Register(
+	jobID string,
+	caps *pb.WorkloadCapabilities,
+	send func(*pb.AgentCommand) error,
+) *WorkloadSession {
+	session := &WorkloadSession{
+		jobID:   jobID,
+		caps:    caps,
+		send:    send,
+		pending: make(map[string]chan *pb.CommandResult),
+		closed:  make(chan struct{}),
+	}
+	r.mu.Lock()
+	old := r.sessions[jobID]
+	r.sessions[jobID] = session
+	r.mu.Unlock()
+	if old != nil {
+		slog.Info("Replacing existing workload channel registration", "jobID", jobID)
+		old.close()
+	}
+	return session
+}
+
+// Unregister removes the session if it is still the current one for its job
+// (a replaced session must not evict its replacement) and closes it.
+func (r *ChannelRegistry) Unregister(session *WorkloadSession) {
+	r.mu.Lock()
+	if r.sessions[session.jobID] == session {
+		delete(r.sessions, session.jobID)
+	}
+	r.mu.Unlock()
+	session.close()
+}
+
+// Session returns the current session for jobID, or an error if no workload
+// is registered.
+func (r *ChannelRegistry) Session(jobID string) (*WorkloadSession, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	session, ok := r.sessions[jobID]
+	if !ok {
+		return nil, fmt.Errorf("no workload channel registered for job %q", jobID)
+	}
+	return session, nil
+}
+
+// resolveSuspendMode resolves the effective suspend mode from the request and
+// the workload's registered capabilities: explicit request mode, then the
+// workload's default, then OFFLOAD. The result is validated against the
+// workload's supported modes when it declared any.
+func resolveSuspendMode(requested pb.SuspendMode, caps *pb.WorkloadCapabilities) (pb.SuspendMode, error) {
+	mode := requested
+	if mode == pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED {
+		mode = caps.GetDefaultMode()
+	}
+	if mode == pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED {
+		mode = pb.SuspendMode_SUSPEND_MODE_OFFLOAD
+	}
+	supported := caps.GetSupportedModes()
+	if len(supported) == 0 {
+		return mode, nil
+	}
+	for _, m := range supported {
+		if m == mode {
+			return mode, nil
+		}
+	}
+	return pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED,
+		fmt.Errorf("workload does not support suspend mode %s (supports %v)", mode, supported)
+}
+
+// AppChannelBackend implements Backend for application-aware workloads
+// reached through their registered workload channels (the app_channel
+// transport). The target is resolved from the job ID via the registry.
+type AppChannelBackend struct {
+	registry       *ChannelRegistry
+	commandTimeout time.Duration
+}
+
+// NewAppChannelBackend creates the app-channel backend around a registry.
+func NewAppChannelBackend(registry *ChannelRegistry) *AppChannelBackend {
+	return &AppChannelBackend{
+		registry:       registry,
+		commandTimeout: defaultCommandTimeout,
+	}
+}
+
+// Snapshot pushes a SNAPSHOT command to the workload registered for jobID
+// and waits for it to complete.
+func (b *AppChannelBackend) Snapshot(ctx context.Context, req Request) error {
+	channelCfg := req.Config.GetAppChannel()
+	if channelCfg == nil {
+		return fmt.Errorf("app_channel config is required")
+	}
+	session, err := b.registry.Session(req.JobID)
+	if err != nil {
+		return err
+	}
+	mode, err := resolveSuspendMode(channelCfg.GetMode(), session.Capabilities())
+	if err != nil {
+		return fmt.Errorf("cannot snapshot job %s: %w", req.JobID, err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, b.commandTimeout)
+	defer cancel()
+
+	slog.InfoContext(ctx, "Dispatching snapshot command to workload", "jobID", req.JobID, "mode", mode)
+	start := time.Now()
+	if err := session.Dispatch(ctx, &pb.AgentCommand{
+		Command: &pb.AgentCommand_Snapshot{
+			Snapshot: &pb.SnapshotCommand{Mode: mode, Tags: channelCfg.GetTags()},
+		},
+	}); err != nil {
+		return err
+	}
+	slog.InfoContext(ctx, "Workload completed snapshot command", "jobID", req.JobID, "duration", time.Since(start))
+	return nil
+}
+
+// Restore pushes a RESTORE command to the workload registered for jobID and
+// waits for it to complete.
+func (b *AppChannelBackend) Restore(ctx context.Context, req Request) error {
+	channelCfg := req.Config.GetAppChannel()
+	if channelCfg == nil {
+		return fmt.Errorf("app_channel config is required")
+	}
+	session, err := b.registry.Session(req.JobID)
+	if err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, b.commandTimeout)
+	defer cancel()
+
+	slog.InfoContext(ctx, "Dispatching restore command to workload", "jobID", req.JobID)
+	start := time.Now()
+	if err := session.Dispatch(ctx, &pb.AgentCommand{
+		Command: &pb.AgentCommand_Restore{
+			Restore: &pb.RestoreCommand{Tags: channelCfg.GetTags()},
+		},
+	}); err != nil {
+		return err
+	}
+	slog.InfoContext(ctx, "Workload completed restore command", "jobID", req.JobID, "duration", time.Since(start))
+	return nil
+}
+
+// HealthCheck returns nil — sessions come and go with workload lifecycles,
+// so there is nothing to probe at the backend level.
+func (b *AppChannelBackend) HealthCheck(_ context.Context) error {
+	return nil
+}

--- a/pkg/snapshot-agent/backends/app_channel_test.go
+++ b/pkg/snapshot-agent/backends/app_channel_test.go
@@ -1,0 +1,235 @@
+package backends_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/backends"
+)
+
+// echoWorkload registers a session that immediately acknowledges every
+// command, recording it. Returns the channel of observed commands.
+func echoWorkload(registry *backends.ChannelRegistry, jobID string, caps *pb.WorkloadCapabilities) chan *pb.AgentCommand {
+	commands := make(chan *pb.AgentCommand, 16)
+	var session *backends.WorkloadSession
+	session = registry.Register(jobID, caps, func(cmd *pb.AgentCommand) error {
+		commands <- cmd
+		go session.HandleResult(&pb.CommandResult{CommandId: cmd.GetCommandId(), Ok: true})
+		return nil
+	})
+	return commands
+}
+
+func channelReq(jobID string, mode pb.SuspendMode, tags ...string) backends.Request {
+	return backends.Request{
+		JobID: jobID,
+		Config: &pb.BackendConfig{
+			Backend: &pb.BackendConfig_AppChannel{
+				AppChannel: &pb.AppChannelConfig{Mode: mode, Tags: tags},
+			},
+		},
+	}
+}
+
+func TestAppChannelSnapshotAndRestore(t *testing.T) {
+	registry := backends.NewChannelRegistry()
+	backend := backends.NewAppChannelBackend(registry)
+	commands := echoWorkload(registry, "job-1", nil)
+
+	err := backend.Snapshot(context.Background(),
+		channelReq("job-1", pb.SuspendMode_SUSPEND_MODE_DISCARD, "weights"))
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	cmd := <-commands
+	if cmd.GetCommandId() == "" {
+		t.Error("Expected a non-empty command_id")
+	}
+	if cmd.GetSnapshot() == nil {
+		t.Fatalf("Expected a snapshot command, got %v", cmd)
+	}
+	if cmd.GetSnapshot().GetMode() != pb.SuspendMode_SUSPEND_MODE_DISCARD {
+		t.Errorf("Expected DISCARD mode, got %v", cmd.GetSnapshot().GetMode())
+	}
+	if len(cmd.GetSnapshot().GetTags()) != 1 || cmd.GetSnapshot().GetTags()[0] != "weights" {
+		t.Errorf("Expected tags [weights], got %v", cmd.GetSnapshot().GetTags())
+	}
+
+	err = backend.Restore(context.Background(),
+		channelReq("job-1", pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED, "weights"))
+	if err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+	cmd = <-commands
+	if cmd.GetRestore() == nil {
+		t.Fatalf("Expected a restore command, got %v", cmd)
+	}
+	if len(cmd.GetRestore().GetTags()) != 1 || cmd.GetRestore().GetTags()[0] != "weights" {
+		t.Errorf("Expected tags [weights], got %v", cmd.GetRestore().GetTags())
+	}
+}
+
+func TestAppChannelUnregisteredJobFailsFast(t *testing.T) {
+	backend := backends.NewAppChannelBackend(backends.NewChannelRegistry())
+	err := backend.Snapshot(context.Background(),
+		channelReq("ghost", pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED))
+	if err == nil || !strings.Contains(err.Error(), "no workload channel registered") {
+		t.Errorf("Expected unregistered-job error, got: %v", err)
+	}
+}
+
+func TestAppChannelMissingConfig(t *testing.T) {
+	backend := backends.NewAppChannelBackend(backends.NewChannelRegistry())
+	err := backend.Snapshot(context.Background(), backends.Request{JobID: "job-1", Config: &pb.BackendConfig{}})
+	if err == nil || !strings.Contains(err.Error(), "app_channel config is required") {
+		t.Errorf("Expected missing-config error, got: %v", err)
+	}
+}
+
+func TestAppChannelWorkloadFailurePropagates(t *testing.T) {
+	registry := backends.NewChannelRegistry()
+	backend := backends.NewAppChannelBackend(registry)
+	var session *backends.WorkloadSession
+	session = registry.Register("job-1", nil, func(cmd *pb.AgentCommand) error {
+		go session.HandleResult(&pb.CommandResult{
+			CommandId: cmd.GetCommandId(),
+			Ok:        false,
+			Error:     "engine exploded",
+		})
+		return nil
+	})
+
+	err := backend.Snapshot(context.Background(),
+		channelReq("job-1", pb.SuspendMode_SUSPEND_MODE_OFFLOAD))
+	if err == nil || !strings.Contains(err.Error(), "engine exploded") {
+		t.Errorf("Expected workload error to propagate, got: %v", err)
+	}
+}
+
+func TestAppChannelCommandTimeout(t *testing.T) {
+	registry := backends.NewChannelRegistry()
+	backend := backends.NewAppChannelBackend(registry)
+	backend.SetCommandTimeout(50 * time.Millisecond)
+	// Workload accepts commands but never replies.
+	registry.Register("job-1", nil, func(*pb.AgentCommand) error { return nil })
+
+	err := backend.Snapshot(context.Background(),
+		channelReq("job-1", pb.SuspendMode_SUSPEND_MODE_OFFLOAD))
+	if err == nil || !strings.Contains(err.Error(), "timed out") {
+		t.Errorf("Expected timeout error, got: %v", err)
+	}
+}
+
+func TestAppChannelDisconnectFailsInflightCommand(t *testing.T) {
+	registry := backends.NewChannelRegistry()
+	backend := backends.NewAppChannelBackend(registry)
+	var session *backends.WorkloadSession
+	// Workload drops the connection right after receiving the command.
+	session = registry.Register("job-1", nil, func(*pb.AgentCommand) error {
+		go registry.Unregister(session)
+		return nil
+	})
+
+	err := backend.Snapshot(context.Background(),
+		channelReq("job-1", pb.SuspendMode_SUSPEND_MODE_OFFLOAD))
+	if err == nil || !strings.Contains(err.Error(), "disconnected") {
+		t.Errorf("Expected disconnect error, got: %v", err)
+	}
+}
+
+func TestAppChannelReregistrationReplacesSession(t *testing.T) {
+	registry := backends.NewChannelRegistry()
+	backend := backends.NewAppChannelBackend(registry)
+
+	// First registration never replies; its replacement acknowledges.
+	old := registry.Register("job-1", nil, func(*pb.AgentCommand) error { return nil })
+	commands := echoWorkload(registry, "job-1", nil)
+
+	// Unregistering the replaced session must not evict the replacement.
+	registry.Unregister(old)
+
+	err := backend.Snapshot(context.Background(),
+		channelReq("job-1", pb.SuspendMode_SUSPEND_MODE_OFFLOAD))
+	if err != nil {
+		t.Fatalf("Snapshot failed after re-registration: %v", err)
+	}
+	if len(commands) != 1 {
+		t.Errorf("Expected the replacement session to receive the command")
+	}
+}
+
+func TestAppChannelModeResolution(t *testing.T) {
+	offloadOnly := &pb.WorkloadCapabilities{
+		SupportedModes: []pb.SuspendMode{pb.SuspendMode_SUSPEND_MODE_OFFLOAD},
+	}
+	discardDefault := &pb.WorkloadCapabilities{
+		SupportedModes: []pb.SuspendMode{pb.SuspendMode_SUSPEND_MODE_OFFLOAD, pb.SuspendMode_SUSPEND_MODE_DISCARD},
+		DefaultMode:    pb.SuspendMode_SUSPEND_MODE_DISCARD,
+	}
+	tests := []struct {
+		name      string
+		requested pb.SuspendMode
+		caps      *pb.WorkloadCapabilities
+		want      pb.SuspendMode
+		wantErr   bool
+	}{
+		{
+			"unspecified defaults to offload",
+			pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED, nil,
+			pb.SuspendMode_SUSPEND_MODE_OFFLOAD, false,
+		},
+		{
+			"unspecified uses workload default",
+			pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED, discardDefault,
+			pb.SuspendMode_SUSPEND_MODE_DISCARD, false,
+		},
+		{
+			"explicit mode overrides default",
+			pb.SuspendMode_SUSPEND_MODE_OFFLOAD, discardDefault,
+			pb.SuspendMode_SUSPEND_MODE_OFFLOAD, false,
+		},
+		{
+			"unsupported mode rejected",
+			pb.SuspendMode_SUSPEND_MODE_DISCARD, offloadOnly,
+			pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED, true,
+		},
+		{
+			"no declared modes skips validation",
+			pb.SuspendMode_SUSPEND_MODE_DISCARD, nil,
+			pb.SuspendMode_SUSPEND_MODE_DISCARD, false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := backends.ResolveSuspendMode(tt.requested, tt.caps)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveSuspendMode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ResolveSuspendMode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAppChannelUnsupportedModeFailsBeforeDispatch verifies capability
+// validation happens before any command reaches the workload.
+func TestAppChannelUnsupportedModeFailsBeforeDispatch(t *testing.T) {
+	registry := backends.NewChannelRegistry()
+	backend := backends.NewAppChannelBackend(registry)
+	commands := echoWorkload(registry, "trainer-1", &pb.WorkloadCapabilities{
+		SupportedModes: []pb.SuspendMode{pb.SuspendMode_SUSPEND_MODE_OFFLOAD},
+	})
+
+	err := backend.Snapshot(context.Background(),
+		channelReq("trainer-1", pb.SuspendMode_SUSPEND_MODE_DISCARD))
+	if err == nil || !strings.Contains(err.Error(), "does not support suspend mode") {
+		t.Errorf("Expected unsupported-mode error, got: %v", err)
+	}
+	if len(commands) != 0 {
+		t.Errorf("Expected no command to be dispatched, got %d", len(commands))
+	}
+}

--- a/pkg/snapshot-agent/backends/app_channel_test.go
+++ b/pkg/snapshot-agent/backends/app_channel_test.go
@@ -72,71 +72,90 @@ func TestAppChannelSnapshotAndRestore(t *testing.T) {
 	}
 }
 
-func TestAppChannelUnregisteredJobFailsFast(t *testing.T) {
-	backend := backends.NewAppChannelBackend(backends.NewChannelRegistry())
-	err := backend.Snapshot(context.Background(),
-		channelReq("ghost", pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED))
-	if err == nil || !strings.Contains(err.Error(), "no workload channel registered") {
-		t.Errorf("Expected unregistered-job error, got: %v", err)
+func TestAppChannelSnapshotErrors(t *testing.T) {
+	tests := []struct {
+		name         string
+		setup        func(*backends.ChannelRegistry, *backends.AppChannelBackend) chan *pb.AgentCommand
+		req          backends.Request
+		wantErr      string
+		wantDispatch int // expected commands dispatched; -1 = don't check
+	}{
+		{
+			name:    "unregistered job fails fast",
+			setup:   func(*backends.ChannelRegistry, *backends.AppChannelBackend) chan *pb.AgentCommand { return nil },
+			req:     channelReq("ghost", pb.SuspendMode_SUSPEND_MODE_UNSPECIFIED),
+			wantErr: "no workload channel registered",
+		},
+		{
+			name: "missing app_channel config",
+			setup: func(r *backends.ChannelRegistry, _ *backends.AppChannelBackend) chan *pb.AgentCommand {
+				echoWorkload(r, "job-1", nil)
+				return nil
+			},
+			req:     backends.Request{JobID: "job-1", Config: &pb.BackendConfig{}},
+			wantErr: "app_channel config is required",
+		},
+		{
+			name: "workload failure propagates",
+			setup: func(r *backends.ChannelRegistry, _ *backends.AppChannelBackend) chan *pb.AgentCommand {
+				var session *backends.WorkloadSession
+				session = r.Register("job-1", nil, func(cmd *pb.AgentCommand) error {
+					go session.HandleResult(&pb.CommandResult{CommandId: cmd.GetCommandId(), Ok: false, Error: "engine exploded"})
+					return nil
+				})
+				return nil
+			},
+			req:     channelReq("job-1", pb.SuspendMode_SUSPEND_MODE_OFFLOAD),
+			wantErr: "engine exploded",
+		},
+		{
+			name: "command timeout",
+			setup: func(r *backends.ChannelRegistry, b *backends.AppChannelBackend) chan *pb.AgentCommand {
+				b.SetCommandTimeout(50 * time.Millisecond)
+				r.Register("job-1", nil, func(*pb.AgentCommand) error { return nil })
+				return nil
+			},
+			req:     channelReq("job-1", pb.SuspendMode_SUSPEND_MODE_OFFLOAD),
+			wantErr: "timed out",
+		},
+		{
+			name: "disconnect fails inflight command",
+			setup: func(r *backends.ChannelRegistry, _ *backends.AppChannelBackend) chan *pb.AgentCommand {
+				var session *backends.WorkloadSession
+				session = r.Register("job-1", nil, func(*pb.AgentCommand) error {
+					go r.Unregister(session)
+					return nil
+				})
+				return nil
+			},
+			req:     channelReq("job-1", pb.SuspendMode_SUSPEND_MODE_OFFLOAD),
+			wantErr: "disconnected",
+		},
+		{
+			name: "unsupported mode rejected before dispatch",
+			setup: func(r *backends.ChannelRegistry, _ *backends.AppChannelBackend) chan *pb.AgentCommand {
+				return echoWorkload(r, "trainer-1", &pb.WorkloadCapabilities{
+					SupportedModes: []pb.SuspendMode{pb.SuspendMode_SUSPEND_MODE_OFFLOAD},
+				})
+			},
+			req:          channelReq("trainer-1", pb.SuspendMode_SUSPEND_MODE_DISCARD),
+			wantErr:      "does not support suspend mode",
+			wantDispatch: 0,
+		},
 	}
-}
-
-func TestAppChannelMissingConfig(t *testing.T) {
-	backend := backends.NewAppChannelBackend(backends.NewChannelRegistry())
-	err := backend.Snapshot(context.Background(), backends.Request{JobID: "job-1", Config: &pb.BackendConfig{}})
-	if err == nil || !strings.Contains(err.Error(), "app_channel config is required") {
-		t.Errorf("Expected missing-config error, got: %v", err)
-	}
-}
-
-func TestAppChannelWorkloadFailurePropagates(t *testing.T) {
-	registry := backends.NewChannelRegistry()
-	backend := backends.NewAppChannelBackend(registry)
-	var session *backends.WorkloadSession
-	session = registry.Register("job-1", nil, func(cmd *pb.AgentCommand) error {
-		go session.HandleResult(&pb.CommandResult{
-			CommandId: cmd.GetCommandId(),
-			Ok:        false,
-			Error:     "engine exploded",
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			registry := backends.NewChannelRegistry()
+			backend := backends.NewAppChannelBackend(registry)
+			commands := tt.setup(registry, backend)
+			err := backend.Snapshot(context.Background(), tt.req)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("Expected error containing %q, got: %v", tt.wantErr, err)
+			}
+			if tt.wantDispatch >= 0 && commands != nil && len(commands) != tt.wantDispatch {
+				t.Errorf("Expected %d dispatched commands, got %d", tt.wantDispatch, len(commands))
+			}
 		})
-		return nil
-	})
-
-	err := backend.Snapshot(context.Background(),
-		channelReq("job-1", pb.SuspendMode_SUSPEND_MODE_OFFLOAD))
-	if err == nil || !strings.Contains(err.Error(), "engine exploded") {
-		t.Errorf("Expected workload error to propagate, got: %v", err)
-	}
-}
-
-func TestAppChannelCommandTimeout(t *testing.T) {
-	registry := backends.NewChannelRegistry()
-	backend := backends.NewAppChannelBackend(registry)
-	backend.SetCommandTimeout(50 * time.Millisecond)
-	// Workload accepts commands but never replies.
-	registry.Register("job-1", nil, func(*pb.AgentCommand) error { return nil })
-
-	err := backend.Snapshot(context.Background(),
-		channelReq("job-1", pb.SuspendMode_SUSPEND_MODE_OFFLOAD))
-	if err == nil || !strings.Contains(err.Error(), "timed out") {
-		t.Errorf("Expected timeout error, got: %v", err)
-	}
-}
-
-func TestAppChannelDisconnectFailsInflightCommand(t *testing.T) {
-	registry := backends.NewChannelRegistry()
-	backend := backends.NewAppChannelBackend(registry)
-	var session *backends.WorkloadSession
-	// Workload drops the connection right after receiving the command.
-	session = registry.Register("job-1", nil, func(*pb.AgentCommand) error {
-		go registry.Unregister(session)
-		return nil
-	})
-
-	err := backend.Snapshot(context.Background(),
-		channelReq("job-1", pb.SuspendMode_SUSPEND_MODE_OFFLOAD))
-	if err == nil || !strings.Contains(err.Error(), "disconnected") {
-		t.Errorf("Expected disconnect error, got: %v", err)
 	}
 }
 
@@ -212,24 +231,5 @@ func TestAppChannelModeResolution(t *testing.T) {
 				t.Errorf("ResolveSuspendMode() = %v, want %v", got, tt.want)
 			}
 		})
-	}
-}
-
-// TestAppChannelUnsupportedModeFailsBeforeDispatch verifies capability
-// validation happens before any command reaches the workload.
-func TestAppChannelUnsupportedModeFailsBeforeDispatch(t *testing.T) {
-	registry := backends.NewChannelRegistry()
-	backend := backends.NewAppChannelBackend(registry)
-	commands := echoWorkload(registry, "trainer-1", &pb.WorkloadCapabilities{
-		SupportedModes: []pb.SuspendMode{pb.SuspendMode_SUSPEND_MODE_OFFLOAD},
-	})
-
-	err := backend.Snapshot(context.Background(),
-		channelReq("trainer-1", pb.SuspendMode_SUSPEND_MODE_DISCARD))
-	if err == nil || !strings.Contains(err.Error(), "does not support suspend mode") {
-		t.Errorf("Expected unsupported-mode error, got: %v", err)
-	}
-	if len(commands) != 0 {
-		t.Errorf("Expected no command to be dispatched, got %d", len(commands))
 	}
 }

--- a/pkg/snapshot-agent/backends/checkpoint.go
+++ b/pkg/snapshot-agent/backends/checkpoint.go
@@ -17,6 +17,9 @@ const (
 	// BackendAppEndpoint suspends/resumes application-aware workloads
 	// (vLLM, SGLang, ...) through their HTTP APIs.
 	BackendAppEndpoint BackendType = "app-endpoint"
+	// BackendAppChannel suspends/resumes application-aware workloads through
+	// their registered workload channels (see the WorkloadChannel RPC).
+	BackendAppChannel BackendType = "app-channel"
 )
 
 // Request carries one backend invocation: the job it targets and the

--- a/pkg/snapshot-agent/backends/export_test.go
+++ b/pkg/snapshot-agent/backends/export_test.go
@@ -1,6 +1,16 @@
 package backends
 
-import "context"
+import (
+	"context"
+	"time"
+)
+
+// ResolveSuspendMode exposes resolveSuspendMode for tests.
+var ResolveSuspendMode = resolveSuspendMode
+
+func (b *AppChannelBackend) SetCommandTimeout(d time.Duration) {
+	b.commandTimeout = d
+}
 
 func (c *CudaCheckpoint) SetExecCommand(f func(ctx context.Context, name string, args ...string) ([]byte, error)) {
 	c.execCommand = f

--- a/pkg/snapshot-agent/server/server.go
+++ b/pkg/snapshot-agent/server/server.go
@@ -23,23 +23,28 @@ import (
 // Server implements the SnapshotAgentService gRPC server.
 type Server struct {
 	pb.UnimplementedSnapshotAgentServiceServer
-	state          *sm.StateManager
-	backendMap     map[backends.BackendType]backends.Backend
-	defaultBackend backends.BackendType
-	deploymentMode string
+	state           *sm.StateManager
+	backendMap      map[backends.BackendType]backends.Backend
+	defaultBackend  backends.BackendType
+	deploymentMode  string
+	channelRegistry *backends.ChannelRegistry
 }
 
-// NewServer creates a new Server instance.
+// NewServer creates a new Server instance. channelRegistry is shared with
+// the app-channel backend so workloads registered through the
+// WorkloadChannel RPC are reachable by Snapshot/Restore.
 func NewServer(
 	backendMap map[backends.BackendType]backends.Backend,
 	defaultBackend backends.BackendType,
 	deploymentMode string,
+	channelRegistry *backends.ChannelRegistry,
 ) *Server {
 	return &Server{
-		state:          sm.NewStateManager(),
-		backendMap:     backendMap,
-		defaultBackend: defaultBackend,
-		deploymentMode: deploymentMode,
+		state:           sm.NewStateManager(),
+		backendMap:      backendMap,
+		defaultBackend:  defaultBackend,
+		deploymentMode:  deploymentMode,
+		channelRegistry: channelRegistry,
 	}
 }
 
@@ -86,6 +91,9 @@ func (s *Server) getSnapshotBackendType(config *pb.BackendConfig) backends.Backe
 	if config.GetAppEndpoint() != nil {
 		return backends.BackendAppEndpoint
 	}
+	if config.GetAppChannel() != nil {
+		return backends.BackendAppChannel
+	}
 	return s.defaultBackend
 }
 
@@ -124,8 +132,9 @@ func (s *Server) ensureJobRunningIfGPUOccupied(ctx context.Context, jobID, group
 // deployment mode and backend. In standalone mode the caller-provided
 // BackendConfig is passed through to the backend as-is. In k8s mode, the CUDA
 // backend needs PID discovery (resolve PIDs from pods via the watcher's job
-// labels, then cache them for restore); inference engine backends carry their
-// targets (HTTP endpoints) in the config itself, so it is passed through.
+// labels, then cache them for restore); application-aware backends resolve
+// their targets themselves (HTTP endpoints from the config, or the workload
+// channel registered under the job ID), so the config is passed through.
 func (s *Server) buildSnapshotFn(
 	bgCtx context.Context,
 	jobID string,
@@ -156,7 +165,7 @@ func (s *Server) buildSnapshotFn(
 				s.state.UpdateJobPIDs(jobID, allPIDs)
 				return nil
 			}, nil
-		case backends.BackendAppEndpoint:
+		case backends.BackendAppEndpoint, backends.BackendAppChannel:
 			return func() error {
 				slog.InfoContext(bgCtx, "Background: Starting snapshot", "backend", backendType)
 				return backend.Snapshot(bgCtx, backends.Request{JobID: jobID, Config: config})
@@ -187,9 +196,9 @@ func extractExplicitPIDs(config *pb.BackendConfig) []int32 {
 // deployment mode and backend. In standalone mode the caller-provided
 // BackendConfig is passed through as-is. In k8s mode, the CUDA backend
 // restores from the PIDs cached at snapshot time (NVML cannot re-discover
-// them after checkpoint frees the GPU); inference engine backends carry
-// their targets (HTTP endpoints) in the config itself, so it is passed
-// through.
+// them after checkpoint frees the GPU); application-aware backends resolve
+// their targets themselves (HTTP endpoints from the config, or the workload
+// channel registered under the job ID), so the config is passed through.
 func (s *Server) buildRestoreFn(
 	bgCtx context.Context,
 	jobID string,
@@ -219,7 +228,7 @@ func (s *Server) buildRestoreFn(
 				slog.InfoContext(bgCtx, "Restoring PIDs", "pids", pidStrings, "backend", backendType)
 				return backend.Restore(bgCtx, backends.Request{JobID: jobID, Config: backends.BuildCudaConfig(pidStrings)})
 			}, nil
-		case backends.BackendAppEndpoint:
+		case backends.BackendAppEndpoint, backends.BackendAppChannel:
 			return func() error {
 				slog.InfoContext(bgCtx, "Background: Starting restore", "backend", backendType)
 				return backend.Restore(bgCtx, backends.Request{JobID: jobID, Config: config})
@@ -360,6 +369,7 @@ func StartServer(
 	backendMap map[backends.BackendType]backends.Backend,
 	defaultBackend backends.BackendType,
 	deploymentMode string,
+	channelRegistry *backends.ChannelRegistry,
 ) error {
 	lc := net.ListenConfig{}
 	lis, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", port))
@@ -374,7 +384,7 @@ func StartServer(
 	}
 
 	// 2. Create Server (which creates StateManager internally)
-	srv := NewServer(backendMap, defaultBackend, deploymentMode)
+	srv := NewServer(backendMap, defaultBackend, deploymentMode, channelRegistry)
 
 	// 3. Start the Watcher internally
 	watcher, err := NewWatcher(k8sClient, srv.state)

--- a/pkg/snapshot-agent/server/server_internal_test.go
+++ b/pkg/snapshot-agent/server/server_internal_test.go
@@ -64,7 +64,7 @@ func initGRPCServer() {
 	// Default to BackendCuda (matching production) so that requests without a
 	// BackendConfig take the k8s CUDA discovery path; the registered
 	// implementation is still the noop backend.
-	testServer = NewServer(backendsMap, backends.BackendCuda, "k8s")
+	testServer = NewServer(backendsMap, backends.BackendCuda, "k8s", backends.NewChannelRegistry())
 	pb.RegisterSnapshotAgentServiceServer(s, testServer)
 	grpc_health_v1.RegisterHealthServer(s, NewHealthServer(backendsMap, backends.BackendNoop))
 	go func() {
@@ -469,7 +469,7 @@ func newModeTestServer(
 
 	lisLocal := bufconn.Listen(bufSize)
 	s := grpc.NewServer()
-	srv := NewServer(backendsMap, defaultBackend, mode)
+	srv := NewServer(backendsMap, defaultBackend, mode, backends.NewChannelRegistry())
 	pb.RegisterSnapshotAgentServiceServer(s, srv)
 	go func() {
 		if err := s.Serve(lisLocal); err != nil {
@@ -577,7 +577,7 @@ func TestServer_Snapshot_StandaloneMode(t *testing.T) {
 		backends.BackendCuda: noopBackend,
 	}
 	// enable standalone mode
-	standaloneServer := NewServer(backendsMap, backends.BackendNoop, "standalone")
+	standaloneServer := NewServer(backendsMap, backends.BackendNoop, "standalone", backends.NewChannelRegistry())
 	pb.RegisterSnapshotAgentServiceServer(s, standaloneServer)
 	go func() {
 		if err := s.Serve(lisDev); err != nil {
@@ -689,7 +689,7 @@ func TestServer_Snapshot_StandaloneMode_BackendValidation(t *testing.T) {
 	backendsMap := map[backends.BackendType]backends.Backend{
 		backends.BackendCuda: backends.NewCudaCheckpoint(),
 	}
-	standaloneServer := NewServer(backendsMap, backends.BackendCuda, "standalone")
+	standaloneServer := NewServer(backendsMap, backends.BackendCuda, "standalone", backends.NewChannelRegistry())
 	pb.RegisterSnapshotAgentServiceServer(s, standaloneServer)
 	go func() {
 		if err := s.Serve(lisDev); err != nil {

--- a/pkg/snapshot-agent/server/workload_channel.go
+++ b/pkg/snapshot-agent/server/workload_channel.go
@@ -1,0 +1,63 @@
+package server
+
+import (
+	"errors"
+	"io"
+	"log/slog"
+
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/logging"
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// WorkloadChannel handles a workload's long-lived registration stream. The
+// first message must be a RegisterWorkload; the handler then routes
+// CommandResults back to in-flight commands until the stream ends.
+// Registration only binds the job to this stream — state-machine transitions
+// stay with their existing owners (the watcher in k8s mode).
+func (s *Server) WorkloadChannel(stream pb.SnapshotAgentService_WorkloadChannelServer) error {
+	ctx := logging.WithServerMethod(stream.Context(), "WorkloadChannel")
+
+	msg, err := stream.Recv()
+	if err != nil {
+		return status.Errorf(codes.InvalidArgument, "failed to receive registration message: %v", err)
+	}
+	reg := msg.GetRegister()
+	if reg == nil {
+		return status.Errorf(codes.InvalidArgument, "first message on the workload channel must be a RegisterWorkload")
+	}
+	if reg.GetJobId() == "" {
+		return status.Errorf(codes.InvalidArgument, "job_id is required to register a workload")
+	}
+
+	ctx = logging.WithJobID(ctx, reg.GetJobId())
+	ctx = logging.WithGroupID(ctx, reg.GetGroup())
+	slog.InfoContext(ctx, "Workload registered", "capabilities", reg.GetCapabilities())
+
+	session := s.channelRegistry.Register(reg.GetJobId(), reg.GetCapabilities(), stream.Send)
+	defer func() {
+		s.channelRegistry.Unregister(session)
+		slog.InfoContext(ctx, "Workload channel closed")
+	}()
+
+	// Make the job visible to Status and the state machine.
+	s.state.RegisterJob(reg.GetJobId(), reg.GetGroup())
+
+	for {
+		msg, err := stream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+		if res := msg.GetResult(); res != nil {
+			session.HandleResult(res)
+			continue
+		}
+		if msg.GetRegister() != nil {
+			return status.Errorf(codes.InvalidArgument, "workload is already registered on this stream")
+		}
+	}
+}

--- a/pkg/snapshot-agent/server/workload_channel_internal_test.go
+++ b/pkg/snapshot-agent/server/workload_channel_internal_test.go
@@ -1,0 +1,226 @@
+package server
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/backends"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+// newChannelTestServer starts a server whose app-channel backend shares a
+// registry with the WorkloadChannel handler, and returns a connected client.
+func newChannelTestServer(t *testing.T) (*Server, *backends.ChannelRegistry, pb.SnapshotAgentServiceClient) {
+	t.Helper()
+	lisChan := bufconn.Listen(bufSize)
+	s := grpc.NewServer()
+	registry := backends.NewChannelRegistry()
+	backendsMap := map[backends.BackendType]backends.Backend{
+		backends.BackendAppChannel: backends.NewAppChannelBackend(registry),
+	}
+	srv := NewServer(backendsMap, backends.BackendAppChannel, "k8s", registry)
+	pb.RegisterSnapshotAgentServiceServer(s, srv)
+	go func() {
+		if err := s.Serve(lisChan); err != nil {
+			return
+		}
+	}()
+	t.Cleanup(s.GracefulStop)
+
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lisChan.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return srv, registry, pb.NewSnapshotAgentServiceClient(conn)
+}
+
+// registerWorkload opens a WorkloadChannel stream, registers jobID, and
+// starts an echo loop acknowledging every command. It blocks until the
+// registration is visible in the registry.
+func registerWorkload(
+	ctx context.Context,
+	t *testing.T,
+	client pb.SnapshotAgentServiceClient,
+	registry *backends.ChannelRegistry,
+	jobID string,
+	caps *pb.WorkloadCapabilities,
+) {
+	t.Helper()
+	stream, err := client.WorkloadChannel(ctx)
+	if err != nil {
+		t.Fatalf("Failed to open workload channel: %v", err)
+	}
+	err = stream.Send(&pb.WorkloadMessage{
+		Message: &pb.WorkloadMessage_Register{
+			Register: &pb.RegisterWorkload{JobId: jobID, Capabilities: caps},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Failed to send registration: %v", err)
+	}
+	for range 100 {
+		if _, sErr := registry.Session(jobID); sErr == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if _, sErr := registry.Session(jobID); sErr != nil {
+		t.Fatalf("Workload registration never became visible: %v", sErr)
+	}
+
+	go func() {
+		for {
+			cmd, rErr := stream.Recv()
+			if rErr != nil {
+				return
+			}
+			sErr := stream.Send(&pb.WorkloadMessage{
+				Message: &pb.WorkloadMessage_Result{
+					Result: &pb.CommandResult{CommandId: cmd.GetCommandId(), Ok: true},
+				},
+			})
+			if sErr != nil {
+				return
+			}
+		}
+	}()
+}
+
+func waitForOperation(
+	ctx context.Context,
+	t *testing.T,
+	client pb.SnapshotAgentServiceClient,
+	opID string,
+) *pb.GetOperationResponse {
+	t.Helper()
+	var opResp *pb.GetOperationResponse
+	var err error
+	for range 100 {
+		opResp, err = client.GetOperation(ctx, &pb.GetOperationRequest{OperationId: opID})
+		if err != nil {
+			t.Fatalf("GetOperation failed: %v", err)
+		}
+		if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_PENDING {
+			return opResp
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("Operation %s never left PENDING", opID)
+	return nil
+}
+
+func TestServer_WorkloadChannel_SnapshotRestoreRoundTrip(t *testing.T) {
+	srv, registry, client := newChannelTestServer(t)
+	ctx := context.Background()
+
+	registerWorkload(ctx, t, client, registry, "chan-job", &pb.WorkloadCapabilities{
+		SupportedModes: []pb.SuspendMode{
+			pb.SuspendMode_SUSPEND_MODE_OFFLOAD,
+			pb.SuspendMode_SUSPEND_MODE_DISCARD,
+		},
+		DefaultMode: pb.SuspendMode_SUSPEND_MODE_OFFLOAD,
+	})
+
+	// Registration binds the stream but does not transition state.
+	if err := srv.state.TransitionToRunning("chan-job", nil); err != nil {
+		t.Fatalf("Failed to transition job to RUNNING: %v", err)
+	}
+
+	channelCfg := &pb.BackendConfig{
+		Backend: &pb.BackendConfig_AppChannel{AppChannel: &pb.AppChannelConfig{}},
+	}
+	snapResp, err := client.Snapshot(ctx, &pb.SnapshotRequest{JobId: "chan-job", BackendConfig: channelCfg})
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	opResp := waitForOperation(ctx, t, client, snapResp.GetOperationId())
+	if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_COMPLETE {
+		t.Fatalf("Expected snapshot COMPLETE, got %v (error: %q)", opResp.GetStatus(), opResp.GetError())
+	}
+
+	restoreResp, err := client.Restore(ctx, &pb.RestoreRequest{JobId: "chan-job", BackendConfig: channelCfg})
+	if err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+	opResp = waitForOperation(ctx, t, client, restoreResp.GetOperationId())
+	if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_COMPLETE {
+		t.Fatalf("Expected restore COMPLETE, got %v (error: %q)", opResp.GetStatus(), opResp.GetError())
+	}
+}
+
+func TestServer_WorkloadChannel_UnregisteredJobFails(t *testing.T) {
+	srv, _, client := newChannelTestServer(t)
+	ctx := context.Background()
+
+	srv.state.RegisterJob("no-channel-job", "")
+	if err := srv.state.TransitionToRunning("no-channel-job", nil); err != nil {
+		t.Fatalf("Failed to transition job to RUNNING: %v", err)
+	}
+
+	snapResp, err := client.Snapshot(ctx, &pb.SnapshotRequest{
+		JobId: "no-channel-job",
+		BackendConfig: &pb.BackendConfig{
+			Backend: &pb.BackendConfig_AppChannel{AppChannel: &pb.AppChannelConfig{}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Snapshot RPC should be accepted, got: %v", err)
+	}
+	opResp := waitForOperation(ctx, t, client, snapResp.GetOperationId())
+	if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_FAILED {
+		t.Fatalf("Expected FAILED for unregistered job, got %v", opResp.GetStatus())
+	}
+	if !strings.Contains(opResp.GetError(), "no workload channel registered") {
+		t.Errorf("Expected unregistered-channel error, got: %q", opResp.GetError())
+	}
+}
+
+func TestServer_WorkloadChannel_RegistrationValidation(t *testing.T) {
+	_, _, client := newChannelTestServer(t)
+	ctx := context.Background()
+
+	// First message must be a registration.
+	stream, err := client.WorkloadChannel(ctx)
+	if err != nil {
+		t.Fatalf("Failed to open workload channel: %v", err)
+	}
+	err = stream.Send(&pb.WorkloadMessage{
+		Message: &pb.WorkloadMessage_Result{Result: &pb.CommandResult{CommandId: "x"}},
+	})
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+	_, err = stream.Recv()
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("Expected InvalidArgument for non-registration first message, got: %v", err)
+	}
+
+	// job_id is required.
+	stream, err = client.WorkloadChannel(ctx)
+	if err != nil {
+		t.Fatalf("Failed to open workload channel: %v", err)
+	}
+	err = stream.Send(&pb.WorkloadMessage{
+		Message: &pb.WorkloadMessage_Register{Register: &pb.RegisterWorkload{}},
+	})
+	if err != nil {
+		t.Fatalf("Send failed: %v", err)
+	}
+	_, err = stream.Recv()
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("Expected InvalidArgument for missing job_id, got: %v", err)
+	}
+}

--- a/pkg/snapshot-agent/server/workload_channel_internal_test.go
+++ b/pkg/snapshot-agent/server/workload_channel_internal_test.go
@@ -189,38 +189,40 @@ func TestServer_WorkloadChannel_UnregisteredJobFails(t *testing.T) {
 }
 
 func TestServer_WorkloadChannel_RegistrationValidation(t *testing.T) {
-	_, _, client := newChannelTestServer(t)
-	ctx := context.Background()
-
-	// First message must be a registration.
-	stream, err := client.WorkloadChannel(ctx)
-	if err != nil {
-		t.Fatalf("Failed to open workload channel: %v", err)
+	tests := []struct {
+		name    string
+		msg     *pb.WorkloadMessage
+		wantMsg string
+	}{
+		{
+			name:    "first message must be a registration",
+			msg:     &pb.WorkloadMessage{Message: &pb.WorkloadMessage_Result{Result: &pb.CommandResult{CommandId: "x"}}},
+			wantMsg: "first message on the workload channel must be a RegisterWorkload",
+		},
+		{
+			name:    "job_id is required",
+			msg:     &pb.WorkloadMessage{Message: &pb.WorkloadMessage_Register{Register: &pb.RegisterWorkload{}}},
+			wantMsg: "job_id is required",
+		},
 	}
-	err = stream.Send(&pb.WorkloadMessage{
-		Message: &pb.WorkloadMessage_Result{Result: &pb.CommandResult{CommandId: "x"}},
-	})
-	if err != nil {
-		t.Fatalf("Send failed: %v", err)
-	}
-	_, err = stream.Recv()
-	if status.Code(err) != codes.InvalidArgument {
-		t.Errorf("Expected InvalidArgument for non-registration first message, got: %v", err)
-	}
-
-	// job_id is required.
-	stream, err = client.WorkloadChannel(ctx)
-	if err != nil {
-		t.Fatalf("Failed to open workload channel: %v", err)
-	}
-	err = stream.Send(&pb.WorkloadMessage{
-		Message: &pb.WorkloadMessage_Register{Register: &pb.RegisterWorkload{}},
-	})
-	if err != nil {
-		t.Fatalf("Send failed: %v", err)
-	}
-	_, err = stream.Recv()
-	if status.Code(err) != codes.InvalidArgument {
-		t.Errorf("Expected InvalidArgument for missing job_id, got: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, client := newChannelTestServer(t)
+			ctx := context.Background()
+			stream, err := client.WorkloadChannel(ctx)
+			if err != nil {
+				t.Fatalf("Failed to open workload channel: %v", err)
+			}
+			if err := stream.Send(tt.msg); err != nil {
+				t.Fatalf("Send failed: %v", err)
+			}
+			_, err = stream.Recv()
+			if status.Code(err) != codes.InvalidArgument {
+				t.Errorf("Expected InvalidArgument, got: %v", err)
+			}
+			if !strings.Contains(status.Convert(err).Message(), tt.wantMsg) {
+				t.Errorf("Expected error containing %q, got: %v", tt.wantMsg, err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Design doc: https://docs.google.com/document/d/1QPi1NzlCq2_OXmT2-_bFdGF4eSE__KzkqjHjQKGGEzQ/

## Summary

Agent-side implementation of the **app-channel** transport (protos in #103): workloads that registered through `WorkloadChannel` are suspended/resumed by pushing commands over their stream.

- **`WorkloadChannel` handler**: validates the registration (first message, non-empty `job_id`), binds the job to the stream, and routes `CommandResult`s back to in-flight commands. Registration only binds — state-machine transitions stay with their existing owners (the watcher in k8s mode).
- **`app-channel` backend** dispatches commands via a `ChannelRegistry` shared with the handler: fails fast if no workload is registered, assigns a unique `command_id` per command (sent at most once), and enforces a per-command deadline (2 min). Re-registration replaces the previous stream; in-flight commands fail cleanly on disconnect.
- **Suspend mode resolution**: explicit request mode > workload's registered default > OFFLOAD, validated against the workload's supported modes before any command is dispatched (e.g. DISCARD against a trainer that only supports OFFLOAD is rejected).
- Server routing: a `BackendConfig` carrying `app_channel` selects the new backend; the config passes through in both deployment modes (the backend resolves its target from `Request.JobID`).

## Testing

Unit tests cover registry lifecycle (replace-on-reconnect, evict-on-drop, disconnect mid-command), mode resolution and capability validation, command timeout and failure propagation, and a full gRPC round trip (register → snapshot → restore) over bufconn.

End-to-end integration with a real engine requires the workload-side client library and lands with the next PR (Python `register_workload` + vLLM adapter), which will carry the integration test run for both.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added app-channel support for routing snapshot and restore operations through registered workload connections.
  * Added workload channel registration with capability-based suspend mode selection.
  * Added validation and clear failures for missing or disconnected workload channels.
* **Bug Fixes**
  * Improved command tracking, timeout handling, and result delivery for app-channel operations.
* **Tests**
  * Added coverage for snapshot/restore routing, registration validation, mode resolution, timeouts, and reconnect scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->