### PR TITLE
[app-channel 3] snapshot-agent: add workload registration to the Python client

### DIFF
--- a/pkg/client/python/tests/test_workload_channel.py
+++ b/pkg/client/python/tests/test_workload_channel.py
@@ -1,0 +1,281 @@
+import queue
+import threading
+import unittest
+from concurrent import futures
+
+import grpc
+
+from timeslice.snapshot_agent import register_workload
+from timeslice.snapshot_agent import snapshot_agent_pb2 as pb2
+from timeslice.snapshot_agent import snapshot_agent_pb2_grpc as pb2_grpc
+from timeslice.snapshot_agent.adapters import resolve_adapter
+
+_END = object()
+
+
+class FakeAgent(pb2_grpc.SnapshotAgentServiceServicer):
+    """In-process agent: records registrations, pushes queued commands,
+    collects results. drop_streams ends that many streams right after
+    registration to exercise reconnect."""
+
+    def __init__(self, drop_streams=0):
+        self.registrations = []
+        self.registered = threading.Event()
+        self.results = queue.Queue()
+        self.commands = queue.Queue()
+        self.drop_streams = drop_streams
+
+    def WorkloadChannel(self, request_iterator, context):  # noqa: N802 - grpc method name
+        first = next(request_iterator)
+        self.registrations.append(first.register)
+        self.registered.set()
+        if self.drop_streams > 0:
+            self.drop_streams -= 1
+            return
+
+        def read_results():
+            for msg in request_iterator:
+                self.results.put(msg.result)
+
+        reader = threading.Thread(target=read_results, daemon=True)
+        reader.start()
+        # Poll so the worker thread is released when the test stops the
+        # server (a blocking get would pin a non-daemon grpc thread forever).
+        while context.is_active():
+            try:
+                cmd = self.commands.get(timeout=0.2)
+            except queue.Empty:
+                continue
+            if cmd is _END:
+                return
+            yield cmd
+
+
+class RecordingWorkload:
+    """Snapshottable test double."""
+
+    supported_modes = ["offload", "discard"]
+    default_mode = "offload"
+
+    def __init__(self, fail_with=None):
+        self.calls = []
+        self.fail_with = fail_with
+
+    def snapshot(self, mode, tags):
+        self.calls.append(("snapshot", mode, tags))
+        if self.fail_with:
+            raise self.fail_with
+
+    def restore(self, tags):
+        self.calls.append(("restore", tags))
+
+
+class WorkloadChannelTest(unittest.TestCase):
+    def start_agent(self, drop_streams=0):
+        self.agent = FakeAgent(drop_streams=drop_streams)
+        self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
+        pb2_grpc.add_SnapshotAgentServiceServicer_to_server(self.agent, self.server)
+        port = self.server.add_insecure_port("127.0.0.1:0")
+        self.server.start()
+        self.addCleanup(self.server.stop, 0)
+        return f"127.0.0.1:{port}"
+
+    def register(self, address, workload, **kwargs):
+        handle = register_workload(
+            address, job_id="test-job", group="g1", workload=workload, **kwargs
+        )
+        self.addCleanup(handle.close)
+        return handle
+
+    def send_and_wait(self, cmd):
+        self.agent.commands.put(cmd)
+        return self.agent.results.get(timeout=10)
+
+    def test_registration_carries_capabilities(self):
+        address = self.start_agent()
+        self.register(address, RecordingWorkload())
+        self.assertTrue(self.agent.registered.wait(timeout=10))
+        reg = self.agent.registrations[0]
+        self.assertEqual(reg.job_id, "test-job")
+        self.assertEqual(reg.group, "g1")
+        self.assertEqual(
+            list(reg.capabilities.supported_modes),
+            [pb2.SUSPEND_MODE_OFFLOAD, pb2.SUSPEND_MODE_DISCARD],
+        )
+        self.assertEqual(reg.capabilities.default_mode, pb2.SUSPEND_MODE_OFFLOAD)
+
+    def test_snapshot_restore_round_trip(self):
+        address = self.start_agent()
+        workload = RecordingWorkload()
+        self.register(address, workload)
+        self.assertTrue(self.agent.registered.wait(timeout=10))
+
+        result = self.send_and_wait(
+            pb2.AgentCommand(
+                command_id="c1",
+                snapshot=pb2.SnapshotCommand(
+                    mode=pb2.SUSPEND_MODE_DISCARD, tags=["weights"]
+                ),
+            )
+        )
+        self.assertEqual(result.command_id, "c1")
+        self.assertTrue(result.ok)
+
+        result = self.send_and_wait(
+            pb2.AgentCommand(
+                command_id="c2", restore=pb2.RestoreCommand(tags=["weights"])
+            )
+        )
+        self.assertEqual(result.command_id, "c2")
+        self.assertTrue(result.ok)
+
+        self.assertEqual(
+            workload.calls,
+            [("snapshot", "discard", ["weights"]), ("restore", ["weights"])],
+        )
+
+    def test_workload_failure_reported(self):
+        address = self.start_agent()
+        self.register(
+            address, RecordingWorkload(fail_with=RuntimeError("engine exploded"))
+        )
+        self.assertTrue(self.agent.registered.wait(timeout=10))
+
+        result = self.send_and_wait(
+            pb2.AgentCommand(command_id="c1", snapshot=pb2.SnapshotCommand())
+        )
+        self.assertFalse(result.ok)
+        self.assertIn("engine exploded", result.error)
+
+    def test_reconnects_and_reregisters(self):
+        address = self.start_agent(drop_streams=1)
+        workload = RecordingWorkload()
+        self.register(address, workload)
+
+        # First stream is dropped by the agent right after registration; the
+        # client must reconnect with backoff and register again.
+        deadline = threading.Event()
+        for _ in range(100):
+            if len(self.agent.registrations) >= 2:
+                break
+            deadline.wait(0.1)
+        self.assertGreaterEqual(len(self.agent.registrations), 2)
+
+        result = self.send_and_wait(
+            pb2.AgentCommand(command_id="c1", snapshot=pb2.SnapshotCommand())
+        )
+        self.assertTrue(result.ok)
+
+    def test_capability_overrides(self):
+        address = self.start_agent()
+        self.register(
+            address,
+            RecordingWorkload(),
+            supported_modes=["offload"],
+            default_mode="offload",
+            tags=["weights"],
+        )
+        self.assertTrue(self.agent.registered.wait(timeout=10))
+        caps = self.agent.registrations[0].capabilities
+        self.assertEqual(list(caps.supported_modes), [pb2.SUSPEND_MODE_OFFLOAD])
+        self.assertEqual(list(caps.tags), ["weights"])
+
+
+class FakeVLLMEngines:
+    """Builds classes that look like vLLM engines (module + name) without vllm."""
+
+    @staticmethod
+    def make(name, async_api=False):
+        calls = []
+        if async_api:
+
+            async def sleep(self, level):
+                calls.append(("sleep", level))
+
+            async def wake_up(self, tags=None):
+                calls.append(("wake_up", tags))
+        else:
+
+            def sleep(self, level):
+                calls.append(("sleep", level))
+
+            def wake_up(self, tags=None):
+                calls.append(("wake_up", tags))
+
+        cls = type(name, (), {"sleep": sleep, "wake_up": wake_up})
+        cls.__module__ = "vllm.engine.fake"
+        return cls(), calls
+
+
+class VLLMAdapterTest(unittest.TestCase):
+    def test_mode_maps_to_sleep_level(self):
+        engine, calls = FakeVLLMEngines.make("AsyncLLMEngine")
+        adapter = resolve_adapter(engine, None, None)
+        self.assertEqual(adapter.name, "vllm")
+
+        adapter.snapshot(pb2.SUSPEND_MODE_OFFLOAD, [])
+        adapter.snapshot(pb2.SUSPEND_MODE_DISCARD, [])
+        adapter.snapshot(pb2.SUSPEND_MODE_UNSPECIFIED, [])
+        adapter.restore([])
+        adapter.restore(["weights"])
+        self.assertEqual(
+            calls,
+            [
+                ("sleep", 1),
+                ("sleep", 2),
+                ("sleep", 1),
+                ("wake_up", None),
+                ("wake_up", ["weights"]),
+            ],
+        )
+
+    def test_async_engine_through_channel(self):
+        engine, calls = FakeVLLMEngines.make("AsyncLLM", async_api=True)
+        agent = FakeAgent()
+        server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
+        pb2_grpc.add_SnapshotAgentServiceServicer_to_server(agent, server)
+        port = server.add_insecure_port("127.0.0.1:0")
+        server.start()
+        self.addCleanup(server.stop, 0)
+
+        handle = register_workload(
+            f"127.0.0.1:{port}", job_id="async-job", workload=engine
+        )
+        self.addCleanup(handle.close)
+        self.assertTrue(agent.registered.wait(timeout=10))
+
+        agent.commands.put(
+            pb2.AgentCommand(command_id="c1", snapshot=pb2.SnapshotCommand())
+        )
+        result = agent.results.get(timeout=10)
+        self.assertTrue(result.ok)
+        self.assertEqual(calls, [("sleep", 1)])
+
+
+class ResolveAdapterTest(unittest.TestCase):
+    def test_requires_workload_or_callbacks(self):
+        with self.assertRaises(ValueError):
+            resolve_adapter(None, None, None)
+
+    def test_rejects_workload_plus_callbacks(self):
+        with self.assertRaises(ValueError):
+            resolve_adapter(RecordingWorkload(), lambda m, t: None, lambda t: None)
+
+    def test_rejects_unknown_workload(self):
+        with self.assertRaises(TypeError):
+            resolve_adapter(object(), None, None)
+
+    def test_callbacks(self):
+        calls = []
+        adapter = resolve_adapter(
+            None,
+            lambda mode, tags: calls.append(("snap", mode, tags)),
+            lambda tags: calls.append(("rest", tags)),
+        )
+        adapter.snapshot(pb2.SUSPEND_MODE_DISCARD, ["weights"])
+        adapter.restore([])
+        self.assertEqual(calls, [("snap", "discard", ["weights"]), ("rest", [])])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pkg/client/python/timeslice/snapshot_agent/__init__.py
+++ b/pkg/client/python/timeslice/snapshot_agent/__init__.py
@@ -1,3 +1,4 @@
 from .client import SnapshotAgentClient
+from .workload import WorkloadHandle, register_workload
 
-__all__ = ["SnapshotAgentClient"]
+__all__ = ["SnapshotAgentClient", "WorkloadHandle", "register_workload"]

--- a/pkg/client/python/timeslice/snapshot_agent/adapters.py
+++ b/pkg/client/python/timeslice/snapshot_agent/adapters.py
@@ -1,0 +1,170 @@
+"""Adapters translating agent commands into workload-specific suspend/resume calls.
+
+Resolution order (see resolve_adapter):
+  1. Explicit callbacks (on_snapshot / on_restore).
+  2. Known engine types recognized by inspection (vLLM).
+  3. The Snapshottable duck-type protocol: any object with snapshot(mode, tags)
+     and restore(tags) methods.
+
+Adapters run inside the workload's process; the agent only decides and
+transports. Engine mechanics (what "suspend" means) stay with the engine.
+"""
+
+import logging
+from typing import Any, Callable, List, Optional
+
+from . import snapshot_agent_pb2
+
+logger = logging.getLogger(__name__)
+
+# Public mode names accepted from Snapshottable attributes and register_workload kwargs.
+_MODE_NAMES = {
+    "offload": snapshot_agent_pb2.SUSPEND_MODE_OFFLOAD,
+    "discard": snapshot_agent_pb2.SUSPEND_MODE_DISCARD,
+}
+
+
+def mode_from_name(name: str) -> int:
+    """Maps a mode name ("offload"/"discard") to the SuspendMode enum."""
+    try:
+        return _MODE_NAMES[name.lower()]
+    except KeyError:
+        raise ValueError(
+            f"unknown suspend mode {name!r}; expected one of {sorted(_MODE_NAMES)}"
+        ) from None
+
+
+def mode_name(mode: int) -> str:
+    """Maps a SuspendMode enum value to its public name."""
+    for name, value in _MODE_NAMES.items():
+        if value == mode:
+            return name
+    return str(mode)
+
+
+class WorkloadAdapter:
+    """Base adapter. Subclasses implement snapshot/restore; either may return
+    an awaitable, which the channel runner resolves."""
+
+    name = "base"
+    supported_modes: List[int] = []
+    default_mode: int = snapshot_agent_pb2.SUSPEND_MODE_UNSPECIFIED
+    tags: List[str] = []
+
+    def snapshot(self, mode: int, tags: List[str]) -> Any:
+        raise NotImplementedError
+
+    def restore(self, tags: List[str]) -> Any:
+        raise NotImplementedError
+
+
+class CallbackAdapter(WorkloadAdapter):
+    """Escape hatch: user-provided callables."""
+
+    name = "callbacks"
+
+    def __init__(self, on_snapshot: Callable[..., Any], on_restore: Callable[..., Any]):
+        self._on_snapshot = on_snapshot
+        self._on_restore = on_restore
+
+    def snapshot(self, mode: int, tags: List[str]) -> Any:
+        return self._on_snapshot(mode_name(mode), tags)
+
+    def restore(self, tags: List[str]) -> Any:
+        return self._on_restore(tags)
+
+
+class SnapshottableAdapter(WorkloadAdapter):
+    """Wraps any object implementing the Snapshottable protocol:
+
+    class MyWorkload:
+        supported_modes = ["offload"]        # optional
+        default_mode = "offload"             # optional
+        def snapshot(self, mode, tags): ...  # mode is "offload"/"discard"
+        def restore(self, tags): ...
+    """
+
+    name = "snapshottable"
+
+    def __init__(self, obj: Any):
+        self._obj = obj
+        declared = getattr(obj, "supported_modes", None)
+        if declared:
+            self.supported_modes = [mode_from_name(m) for m in declared]
+        default = getattr(obj, "default_mode", None)
+        if default:
+            self.default_mode = mode_from_name(default)
+
+    def snapshot(self, mode: int, tags: List[str]) -> Any:
+        return self._obj.snapshot(mode_name(mode), tags)
+
+    def restore(self, tags: List[str]) -> Any:
+        return self._obj.restore(tags)
+
+
+def _is_vllm_engine(obj: Any) -> bool:
+    """Recognizes vLLM engines without importing vllm (it may not be installed
+    here, and if obj is a vLLM engine the app has already imported it)."""
+    cls = type(obj)
+    module = cls.__module__ or ""
+    return module.split(".")[0] == "vllm" and cls.__name__ in (
+        "LLM",
+        "AsyncLLMEngine",
+        "AsyncLLM",
+    )
+
+
+class VLLMAdapter(WorkloadAdapter):
+    """Drives a vLLM engine object through its Python sleep API.
+
+    SuspendMode maps to the sleep level: OFFLOAD -> level 1 (weights backed up
+    in host memory), DISCARD -> level 2 (weights dropped; the app re-provisions
+    them, e.g. RL weight sync). Requires the engine to be constructed with
+    enable_sleep_mode=True.
+    """
+
+    name = "vllm"
+    supported_modes = [
+        snapshot_agent_pb2.SUSPEND_MODE_OFFLOAD,
+        snapshot_agent_pb2.SUSPEND_MODE_DISCARD,
+    ]
+
+    def __init__(self, engine: Any):
+        self._engine = engine
+
+    def snapshot(self, mode: int, tags: List[str]) -> Any:
+        level = 2 if mode == snapshot_agent_pb2.SUSPEND_MODE_DISCARD else 1
+        return self._engine.sleep(level=level)
+
+    def restore(self, tags: List[str]) -> Any:
+        if tags:
+            return self._engine.wake_up(tags=list(tags))
+        return self._engine.wake_up()
+
+
+def resolve_adapter(
+    workload: Optional[Any],
+    on_snapshot: Optional[Callable[..., Any]],
+    on_restore: Optional[Callable[..., Any]],
+) -> WorkloadAdapter:
+    """Picks the adapter for a workload; see module docstring for the order."""
+    if on_snapshot is not None or on_restore is not None:
+        if on_snapshot is None or on_restore is None:
+            raise ValueError("on_snapshot and on_restore must be provided together")
+        if workload is not None:
+            raise ValueError("pass either workload= or callbacks, not both")
+        return CallbackAdapter(on_snapshot, on_restore)
+    if workload is None:
+        raise ValueError(
+            "a workload object or on_snapshot/on_restore callbacks are required"
+        )
+    if _is_vllm_engine(workload):
+        return VLLMAdapter(workload)
+    if callable(getattr(workload, "snapshot", None)) and callable(
+        getattr(workload, "restore", None)
+    ):
+        return SnapshottableAdapter(workload)
+    raise TypeError(
+        f"don't know how to suspend {type(workload).__name__}: not a recognized engine and "
+        "not Snapshottable (snapshot/restore methods); pass on_snapshot=/on_restore= callbacks"
+    )

--- a/pkg/client/python/timeslice/snapshot_agent/workload.py
+++ b/pkg/client/python/timeslice/snapshot_agent/workload.py
@@ -1,0 +1,234 @@
+"""Workload-side of the snapshot-agent workload channel.
+
+register_workload() opens a long-lived WorkloadChannel stream to the
+(node-local) snapshot-agent, registers the job, and services SNAPSHOT/RESTORE
+commands by invoking the resolved adapter in this process. The library owns
+the stream lifecycle: a background daemon thread, command dispatch and acks,
+and reconnect with exponential backoff (re-registering on every reconnect;
+the agent replaces the previous registration).
+"""
+
+import asyncio
+import inspect
+import logging
+import queue
+import random
+import threading
+import time
+from typing import Any, Callable, List, Optional
+
+import grpc
+
+from . import snapshot_agent_pb2, snapshot_agent_pb2_grpc
+from .adapters import mode_from_name, resolve_adapter
+
+logger = logging.getLogger(__name__)
+
+_CLOSE = object()
+
+_INITIAL_BACKOFF_SEC = 0.5
+_MAX_BACKOFF_SEC = 30.0
+# A connection that survived this long resets the backoff.
+_STABLE_CONNECTION_SEC = 5.0
+
+
+class WorkloadHandle:
+    """Handle for a registered workload. close() deregisters by dropping the
+    stream and stops the background thread."""
+
+    def __init__(
+        self,
+        agent: str,
+        register_msg: "snapshot_agent_pb2.RegisterWorkload",
+        adapter: Any,
+        loop: Optional[asyncio.AbstractEventLoop],
+    ):
+        self._agent = agent
+        self._register_msg = register_msg
+        self._adapter = adapter
+        self._loop = loop
+        self._stop = threading.Event()
+        self._call: Optional[Any] = None
+        self._call_lock = threading.Lock()
+        self._thread = threading.Thread(
+            target=self._run,
+            name=f"workload-channel-{register_msg.job_id}",
+            daemon=True,
+        )
+        self._thread.start()
+
+    def close(self, timeout: float = 5.0) -> None:
+        """Stops servicing commands and closes the channel."""
+        self._stop.set()
+        with self._call_lock:
+            if self._call is not None:
+                self._call.cancel()
+        self._thread.join(timeout=timeout)
+
+    # -- background thread --
+
+    def _run(self) -> None:
+        backoff = _INITIAL_BACKOFF_SEC
+        while not self._stop.is_set():
+            started = time.monotonic()
+            try:
+                self._connect_and_serve()
+            except grpc.RpcError as err:
+                if not self._stop.is_set():
+                    logger.warning(
+                        "workload channel for job %s disconnected: %s",
+                        self._register_msg.job_id,
+                        err,
+                    )
+            except Exception:
+                logger.exception(
+                    "workload channel for job %s failed", self._register_msg.job_id
+                )
+            if self._stop.is_set():
+                return
+            if time.monotonic() - started > _STABLE_CONNECTION_SEC:
+                backoff = _INITIAL_BACKOFF_SEC
+            sleep_for = backoff * (0.5 + random.random())  # noqa: S311 - jitter, not crypto
+            backoff = min(backoff * 2, _MAX_BACKOFF_SEC)
+            logger.info(
+                "reconnecting workload channel for job %s in %.1fs",
+                self._register_msg.job_id,
+                sleep_for,
+            )
+            self._stop.wait(sleep_for)
+
+    def _connect_and_serve(self) -> None:
+        sendq: "queue.SimpleQueue" = queue.SimpleQueue()
+
+        def requests():
+            yield snapshot_agent_pb2.WorkloadMessage(register=self._register_msg)
+            while True:
+                item = sendq.get()
+                if item is _CLOSE:
+                    return
+                yield item
+
+        with grpc.insecure_channel(self._agent) as channel:
+            stub = snapshot_agent_pb2_grpc.SnapshotAgentServiceStub(channel)
+            call = stub.WorkloadChannel(requests())
+            with self._call_lock:
+                self._call = call
+            logger.info(
+                "registering workload for job %s with agent %s",
+                self._register_msg.job_id,
+                self._agent,
+            )
+            try:
+                for command in call:
+                    result = self._execute(command)
+                    sendq.put(snapshot_agent_pb2.WorkloadMessage(result=result))
+            finally:
+                with self._call_lock:
+                    self._call = None
+                # Unblock the request generator so grpc's consumer thread exits.
+                sendq.put(_CLOSE)
+
+    # -- command execution --
+
+    def _execute(
+        self, command: "snapshot_agent_pb2.AgentCommand"
+    ) -> "snapshot_agent_pb2.CommandResult":
+        kind = command.WhichOneof("command")
+        logger.info("executing %s command %s", kind, command.command_id)
+        try:
+            if kind == "snapshot":
+                outcome = self._adapter.snapshot(
+                    command.snapshot.mode, list(command.snapshot.tags)
+                )
+            elif kind == "restore":
+                outcome = self._adapter.restore(list(command.restore.tags))
+            else:
+                raise ValueError(f"unknown command type {kind!r}")
+            self._await_if_needed(outcome)
+            return snapshot_agent_pb2.CommandResult(
+                command_id=command.command_id, ok=True
+            )
+        except Exception as err:  # noqa: BLE001 - error is reported to the agent
+            logger.exception("%s command %s failed", kind, command.command_id)
+            return snapshot_agent_pb2.CommandResult(
+                command_id=command.command_id,
+                ok=False,
+                error=f"{type(err).__name__}: {err}",
+            )
+
+    def _await_if_needed(self, outcome: Any) -> None:
+        """Resolves awaitable adapter results. Async engines (e.g. vLLM
+        AsyncLLMEngine) are driven by the app's event loop, captured at
+        registration; their coroutines are scheduled onto it from this
+        thread. Loop-free awaitables run on a private loop."""
+        if not inspect.isawaitable(outcome):
+            return
+        if not inspect.iscoroutine(outcome):
+            coro = _wrap_awaitable(outcome)
+        else:
+            coro = outcome
+        if self._loop is not None:
+            asyncio.run_coroutine_threadsafe(coro, self._loop).result()
+        else:
+            asyncio.run(coro)
+
+
+async def _wrap_awaitable(awaitable: Any) -> Any:
+    return await awaitable
+
+
+def register_workload(
+    agent: str,
+    job_id: str,
+    group: str = "",
+    workload: Optional[Any] = None,
+    on_snapshot: Optional[Callable[..., Any]] = None,
+    on_restore: Optional[Callable[..., Any]] = None,
+    supported_modes: Optional[List[str]] = None,
+    default_mode: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+) -> WorkloadHandle:
+    """Registers this process's workload with the node's snapshot-agent and
+    services suspend/resume commands for it.
+
+    Args:
+        agent: snapshot-agent address, e.g. "127.0.0.1:9001".
+        job_id: job identity; must match the job_id used in Snapshot/Restore
+            requests (in k8s, the timeslice.io/job-id pod label).
+        group: optional group identity.
+        workload: the engine or workload object to suspend. Recognized engines
+            (vLLM LLM/AsyncLLMEngine/AsyncLLM) need nothing else; any object
+            with snapshot(mode, tags)/restore(tags) methods also works.
+        on_snapshot / on_restore: callback escape hatch instead of workload.
+        supported_modes / default_mode: capability overrides ("offload",
+            "discard"); defaults come from the adapter.
+        tags: region tags the workload understands, e.g. ["weights", "kv_cache"].
+
+    Returns:
+        WorkloadHandle; call close() on clean shutdown.
+    """
+    if not job_id:
+        raise ValueError("job_id is required")
+    adapter = resolve_adapter(workload, on_snapshot, on_restore)
+
+    modes = (
+        [mode_from_name(m) for m in supported_modes]
+        if supported_modes
+        else adapter.supported_modes
+    )
+    default = mode_from_name(default_mode) if default_mode else adapter.default_mode
+    capabilities = snapshot_agent_pb2.WorkloadCapabilities(
+        supported_modes=modes,
+        default_mode=default,
+        tags=tags if tags is not None else adapter.tags,
+    )
+    register_msg = snapshot_agent_pb2.RegisterWorkload(
+        job_id=job_id, group=group, capabilities=capabilities
+    )
+
+    try:
+        loop: Optional[asyncio.AbstractEventLoop] = asyncio.get_running_loop()
+    except RuntimeError:
+        loop = None
+
+    return WorkloadHandle(agent, register_msg, adapter, loop)


### PR DESCRIPTION
Design doc: https://docs.google.com/document/d/1QPi1NzlCq2_OXmT2-_bFdGF4eSE__KzkqjHjQKGGEzQ/

## Summary

Workload-side of the app-channel transport (protos #103, agent #102): `register_workload()` registers this process's workload with the node's snapshot-agent over the `WorkloadChannel` stream and services SNAPSHOT/RESTORE commands in-process.

- `register_workload(agent, job_id, group, workload=obj, ...)` returns a `WorkloadHandle`; the library owns the stream on a background daemon thread — command dispatch, `CommandResult` acks (including failure text), and reconnect with exponential backoff, re-registering on every reconnect (the agent replaces the previous stream).
- Adapter resolution: explicit `on_snapshot`/`on_restore` callbacks → recognized engines → the `Snapshottable` duck-type protocol (`snapshot(mode, tags)` / `restore(tags)`, optional `supported_modes`/`default_mode` attributes).
- vLLM adapter (`LLM`/`AsyncLLMEngine`/`AsyncLLM`, recognized without importing vllm): OFFLOAD → `sleep(level=1)`, DISCARD → `sleep(level=2)`, restore → `wake_up(tags)`. Async engine coroutines are scheduled onto the app's event loop, captured at registration.
- Capabilities (`supported_modes`, `default_mode`, `tags`) come from the adapter, overridable via kwargs, and are advertised at registration.

The ruff lint/format drift in `tests/integration/snapshot-agent/agentctl.py` (newer ruff) is fixed in that file's own PR (#100).

## Testing

Unit tests against an in-process gRPC fake agent: registration capabilities, snapshot/restore round trip, failure propagation, reconnect + re-register after stream drop, capability overrides, vLLM adapter mode mapping (sync and async engines), adapter resolution errors. 26 tests pass; ruff check/format clean (CI-equivalent run).

End-to-end with a real engine lands in the next PR (channel integration tests).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Python support for registering workloads with the snapshot agent.
  * Added snapshot and restore command handling with success and error reporting.
  * Added automatic reconnection and workload re-registration.
  * Added adapters for callbacks, custom workloads, and vLLM engines.
  * Added configurable suspend modes, default modes, and tags.
  * Exported workload registration utilities through the public package API.

* **Tests**
  * Added coverage for registration, command handling, failures, reconnects, adapter validation, and vLLM integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->