### PR TITLE
Fix acquire timeout release lock

### DIFF
--- a/pkg/accelerator-orchestrator/server/server.go
+++ b/pkg/accelerator-orchestrator/server/server.go
@@ -89,12 +89,40 @@ func (s *Server) Acquire(ctx context.Context, req *pb.AcquireRequest) (*pb.Acqui
 		select {
 		case <-ctx.Done():
 			slog.InfoContext(ctx, "Acquire context cancelled", "error", ctx.Err())
+			s.cancelLockRequest(ctx, groupID, jobID)
 			return nil, status.FromContextError(ctx.Err()).Err()
 		case <-ticker.C:
 			resp, err, done := s.checkAcquire(ctx, groupID, jobID, startTime)
 			if done {
 				return resp, err
 			}
+		}
+	}
+}
+
+// cancelLockRequest undoes the lock request made by Acquire when the caller
+// stops waiting, so the group is not left locked (or the job queued) for a
+// caller that believes the acquire failed.
+func (s *Server) cancelLockRequest(ctx context.Context, groupID, jobID string) {
+	// The request context is already cancelled; detach so the store updates can proceed.
+	ctx = context.WithoutCancel(ctx)
+
+	// Re-read group to get the latest status and spec from the store
+	group, err := s.groupStore.Get(ctx, groupID)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to get group to cancel lock request", "error", err)
+		return
+	}
+
+	released, err := group.Spec().CancelLockRequest(ctx, jobID)
+	if err != nil {
+		slog.ErrorContext(ctx, "Failed to cancel lock request", "error", err)
+		return
+	}
+	if released {
+		slog.InfoContext(ctx, "Released lock held by cancelled acquire")
+		if s.ctrl != nil {
+			s.ctrl.EnqueueWork(groupID)
 		}
 	}
 }

--- a/pkg/accelerator-orchestrator/server/server_internal_test.go
+++ b/pkg/accelerator-orchestrator/server/server_internal_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/accelerator-orchestrator/store"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/test/bufconn"
 )
@@ -137,21 +136,6 @@ func (m *MockGroupLockStore) Unlock(ctx context.Context, jobID string) error {
 	return nil
 }
 
-// waitFor polls cond until it returns true or the timeout elapses.
-// Used to observe server-side state that is updated asynchronously
-// after the client sees the RPC complete.
-func waitFor(t *testing.T, cond func() bool, msg string) {
-	t.Helper()
-	deadline := time.Now().Add(2 * time.Second)
-	for time.Now().Before(deadline) {
-		if cond() {
-			return
-		}
-		time.Sleep(5 * time.Millisecond)
-	}
-	t.Fatalf("timed out waiting for %s", msg)
-}
-
 func TestServer_Acquire_Whitebox(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -216,9 +200,9 @@ func TestServer_Acquire_Whitebox(t *testing.T) {
 				}
 				// Cancelled acquire must remove job-1 from the waiting queue
 				// without touching job-2's lock.
-				waitFor(t, func() bool {
-					return !g.Spec().GetWaitingJobQueue().Exists("job-1")
-				}, "job-1 to be removed from waiting queue")
+				if g.Spec().GetWaitingJobQueue().Exists("job-1") {
+					t.Errorf("expected job-1 to be removed from waiting queue")
+				}
 				if got := g.Spec().LockingJob(); got != "job-2" {
 					t.Errorf("LockingJob() = %q, want %q", got, "job-2")
 				}
@@ -275,9 +259,9 @@ func TestServer_Acquire_Whitebox(t *testing.T) {
 				if err != nil {
 					t.Fatalf("failed to get group: %v", err)
 				}
-				waitFor(t, func() bool {
-					return g.Spec().LockingJob() == ""
-				}, "lock to be released after cancelled acquire")
+				if got := g.Spec().LockingJob(); got != "" {
+					t.Errorf("LockingJob() = %q, want empty (lock released)", got)
+				}
 			},
 		},
 		{
@@ -361,25 +345,20 @@ func TestServer_Acquire_Whitebox(t *testing.T) {
 			defer cancel()
 			gs, js := tc.setupStores(t, serverCtx)
 
-			srv, mq, cleanup := InitGRPCServer(gs, js)
-			defer cleanup()
+			mq := &MockWorkQueue{}
+			ctrl := controller.NewController(nil, nil, mq, nil, nil)
+			srv := NewServer(ctrl, gs, js)
+			srv.acquirePollInterval = 1 * time.Millisecond
 
 			if tc.hook != nil {
 				tc.hook(t, srv, gs, js, cancel)
 			}
 
-			conn, err := grpc.NewClient(
-				"passthrough:///bufnet",
-				grpc.WithContextDialer(BufDialer),
-				grpc.WithTransportCredentials(insecure.NewCredentials()),
-			)
-			if err != nil {
-				t.Fatalf("Failed to dial bufnet: %v", err)
-			}
-			defer conn.Close()
-			client := pb.NewAcceleratorOrchestratorServiceClient(conn)
-
-			resp, err := client.Acquire(clientCtx, &pb.AcquireRequest{
+			// Call the handler directly (not through gRPC) so that when it
+			// returns, all of its side effects — including lock-request
+			// cleanup on cancellation — have completed and can be asserted
+			// synchronously.
+			resp, err := srv.Acquire(clientCtx, &pb.AcquireRequest{
 				GroupId: tc.groupID,
 				JobId:   tc.jobID,
 			})
@@ -399,15 +378,10 @@ func TestServer_Acquire_Whitebox(t *testing.T) {
 				tc.verify(t, resp, err)
 			}
 
-			// verifyAfter waits for any asynchronous server-side cleanup to
-			// finish, so the enqueue count below is stable when checked.
 			if tc.verifyAfter != nil {
 				tc.verifyAfter(t, gs)
 			}
 
-			waitFor(t, func() bool {
-				return len(mq.GetAdded()) >= tc.wantEnqueues
-			}, "expected number of enqueues")
 			added := mq.GetAdded()
 			if len(added) != tc.wantEnqueues {
 				t.Errorf("expected %d enqueues, got %v", tc.wantEnqueues, added)

--- a/pkg/accelerator-orchestrator/server/server_internal_test.go
+++ b/pkg/accelerator-orchestrator/server/server_internal_test.go
@@ -137,16 +137,32 @@ func (m *MockGroupLockStore) Unlock(ctx context.Context, jobID string) error {
 	return nil
 }
 
+// waitFor polls cond until it returns true or the timeout elapses.
+// Used to observe server-side state that is updated asynchronously
+// after the client sees the RPC complete.
+func waitFor(t *testing.T, cond func() bool, msg string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s", msg)
+}
+
 func TestServer_Acquire_Whitebox(t *testing.T) {
 	tests := []struct {
-		name          string
-		setupStores   func(t *testing.T, ctx context.Context) (GroupStore, JobStore)
-		groupID       string
-		jobID         string
-		expectedCode  codes.Code
-		verify        func(t *testing.T, resp *pb.AcquireResponse, err error)
-		expectEnqueue bool
-		hook          func(t *testing.T, srv *Server, gs GroupStore, js JobStore, cancel context.CancelFunc)
+		name         string
+		setupStores  func(t *testing.T, ctx context.Context) (GroupStore, JobStore)
+		groupID      string
+		jobID        string
+		expectedCode codes.Code
+		verify       func(t *testing.T, resp *pb.AcquireResponse, err error)
+		wantEnqueues int
+		hook         func(t *testing.T, srv *Server, gs GroupStore, js JobStore, cancel context.CancelFunc)
+		verifyAfter  func(t *testing.T, gs GroupStore)
 	}{
 		{
 			name: "block when it has not yet reconciled but another job requesting lock",
@@ -168,10 +184,10 @@ func TestServer_Acquire_Whitebox(t *testing.T) {
 				g.Status().SetLoadedJob("job-1")
 				return gs, store.NewJobStore()
 			},
-			groupID:       "group-1",
-			jobID:         "job-1",        // job-1 tries to acquire, should block because lock is for job-2
-			expectedCode:  codes.Canceled, // We expect Canceled because we will cancel it manually
-			expectEnqueue: true,
+			groupID:      "group-1",
+			jobID:        "job-1",        // job-1 tries to acquire, should block because lock is for job-2
+			expectedCode: codes.Canceled, // We expect Canceled because we will cancel it manually
+			wantEnqueues: 1,
 			hook: func(t *testing.T, srv *Server, gs GroupStore, js JobStore, cancel context.CancelFunc) {
 				t.Helper()
 				tickCalled := make(chan struct{}, 1)
@@ -191,6 +207,77 @@ func TestServer_Acquire_Whitebox(t *testing.T) {
 					}
 					cancel()
 				}()
+			},
+			verifyAfter: func(t *testing.T, gs GroupStore) {
+				t.Helper()
+				g, err := gs.Get(context.Background(), "group-1")
+				if err != nil {
+					t.Fatalf("failed to get group: %v", err)
+				}
+				// Cancelled acquire must remove job-1 from the waiting queue
+				// without touching job-2's lock.
+				waitFor(t, func() bool {
+					return !g.Spec().GetWaitingJobQueue().Exists("job-1")
+				}, "job-1 to be removed from waiting queue")
+				if got := g.Spec().LockingJob(); got != "job-2" {
+					t.Errorf("LockingJob() = %q, want %q", got, "job-2")
+				}
+			},
+		},
+		{
+			name: "release lock when acquire is cancelled after lock granted",
+			setupStores: func(t *testing.T, ctx context.Context) (GroupStore, JobStore) {
+				t.Helper()
+				lockStore := store.NewMemLockStore()
+				// job-1 already holds the lock (promoted while its Acquire was
+				// waiting), but its context has not been loaded yet, so the
+				// acquire keeps blocking.
+				if err := lockStore.Lock(ctx, "group-1", "job-1"); err != nil {
+					t.Fatalf("failed to lock: %v", err)
+				}
+				gs := store.NewGroupStore(lockStore)
+				g, _, err := gs.GetOrCreate(ctx, "group-1")
+				if err != nil {
+					t.Fatalf("failed to create group: %v", err)
+				}
+				g.Status().SetLoadedJob("job-2")
+				return gs, store.NewJobStore()
+			},
+			groupID:      "group-1",
+			jobID:        "job-1",
+			expectedCode: codes.Canceled,
+			// One enqueue from the lock request, one from releasing the lock
+			// so the controller can promote the next waiter.
+			wantEnqueues: 2,
+			hook: func(t *testing.T, srv *Server, gs GroupStore, js JobStore, cancel context.CancelFunc) {
+				t.Helper()
+				tickCalled := make(chan struct{}, 1)
+				origCheck := srv.checkAcquire
+				srv.checkAcquire = func(ctx context.Context, groupID, jobID string, startTime time.Time) (*pb.AcquireResponse, error, bool) {
+					resp, err, done := origCheck(ctx, groupID, jobID, startTime)
+					select {
+					case tickCalled <- struct{}{}:
+					default:
+					}
+					return resp, err, done
+				}
+				// Wait for 5 ticks to be sure it is blocked, then cancel
+				go func() {
+					for i := 0; i < 5; i++ {
+						<-tickCalled
+					}
+					cancel()
+				}()
+			},
+			verifyAfter: func(t *testing.T, gs GroupStore) {
+				t.Helper()
+				g, err := gs.Get(context.Background(), "group-1")
+				if err != nil {
+					t.Fatalf("failed to get group: %v", err)
+				}
+				waitFor(t, func() bool {
+					return g.Spec().LockingJob() == ""
+				}, "lock to be released after cancelled acquire")
 			},
 		},
 		{
@@ -222,10 +309,10 @@ func TestServer_Acquire_Whitebox(t *testing.T) {
 				}
 				return gs, store.NewJobStore()
 			},
-			groupID:       "group-1",
-			jobID:         "job-2", // job-2 tries to acquire, should succeed after job-2 is loaded
-			expectedCode:  codes.OK,
-			expectEnqueue: true,
+			groupID:      "group-1",
+			jobID:        "job-2", // job-2 tries to acquire, should succeed after job-2 is loaded
+			expectedCode: codes.OK,
+			wantEnqueues: 1,
 			hook: func(t *testing.T, srv *Server, gs GroupStore, js JobStore, cancel context.CancelFunc) {
 				t.Helper()
 				mGS, ok := gs.(*MockGroupStore)
@@ -297,17 +384,6 @@ func TestServer_Acquire_Whitebox(t *testing.T) {
 				JobId:   tc.jobID,
 			})
 
-			added := mq.GetAdded()
-			if tc.expectEnqueue {
-				if len(added) != 1 || added[0] != tc.groupID {
-					t.Errorf("expected group %s to be enqueued, got %v", tc.groupID, added)
-				}
-			} else {
-				if len(added) != 0 {
-					t.Errorf("expected no enqueue, got %v", added)
-				}
-			}
-
 			if tc.expectedCode != codes.OK {
 				if err == nil {
 					t.Fatalf("Expected error, got nil")
@@ -319,11 +395,27 @@ func TestServer_Acquire_Whitebox(t *testing.T) {
 				if st.Code() != tc.expectedCode {
 					t.Errorf("Expected code %v, got %v", tc.expectedCode, st.Code())
 				}
-				return
+			} else if tc.verify != nil {
+				tc.verify(t, resp, err)
 			}
 
-			if tc.verify != nil {
-				tc.verify(t, resp, err)
+			// verifyAfter waits for any asynchronous server-side cleanup to
+			// finish, so the enqueue count below is stable when checked.
+			if tc.verifyAfter != nil {
+				tc.verifyAfter(t, gs)
+			}
+
+			waitFor(t, func() bool {
+				return len(mq.GetAdded()) >= tc.wantEnqueues
+			}, "expected number of enqueues")
+			added := mq.GetAdded()
+			if len(added) != tc.wantEnqueues {
+				t.Errorf("expected %d enqueues, got %v", tc.wantEnqueues, added)
+			}
+			for _, id := range added {
+				if id != tc.groupID {
+					t.Errorf("expected only group %s to be enqueued, got %v", tc.groupID, added)
+				}
 			}
 		})
 	}

--- a/pkg/accelerator-orchestrator/store/group.go
+++ b/pkg/accelerator-orchestrator/store/group.go
@@ -269,6 +269,27 @@ func (s *GroupSpec) Yield(ctx context.Context, jobID string) error {
 	// to yield their job if there is a temporary issue locking for next job.
 }
 
+// CancelLockRequest undoes a previous RequestLock for the given job when the
+// caller stops waiting for the lock (e.g. the acquire was cancelled or timed out).
+// If the job is still waiting in the queue it is removed. If the job has already
+// been promoted to be the locking job, the lock is released so the group is not
+// left locked for a job that believes it failed to acquire.
+// Returns true if the lock was released, meaning the next waiter can be promoted.
+func (s *GroupSpec) CancelLockRequest(ctx context.Context, jobID string) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.lockingJob == jobID {
+		if err := s.unlock(ctx, jobID); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	s.queue.Remove(jobID)
+	return false, nil
+}
+
 // RequestLock requests a lock for the given job.
 // If the job already holds the lock, it returns immediately.
 // Otherwise, it enqueues the job in the waiting queue.

--- a/pkg/accelerator-orchestrator/store/group_test.go
+++ b/pkg/accelerator-orchestrator/store/group_test.go
@@ -255,6 +255,86 @@ func TestGroupSpec_Yield(t *testing.T) {
 	}
 }
 
+func TestGroupSpec_CancelLockRequest(t *testing.T) {
+	tests := []struct {
+		name         string
+		initialLock  string
+		queuedJobs   []string
+		cancelJob    string
+		wantReleased bool
+		wantLock     string
+		wantQueue    []string
+	}{
+		{
+			name:         "cancel by lock holder releases lock",
+			initialLock:  "job-1",
+			cancelJob:    "job-1",
+			wantReleased: true,
+			wantLock:     "",
+		},
+		{
+			name:         "cancel by queued job removes it from queue",
+			initialLock:  "job-1",
+			queuedJobs:   []string{"job-2", "job-3"},
+			cancelJob:    "job-2",
+			wantReleased: false,
+			wantLock:     "job-1",
+			wantQueue:    []string{"job-3"},
+		},
+		{
+			name:         "cancel by unknown job is a no-op",
+			initialLock:  "job-1",
+			queuedJobs:   []string{"job-2"},
+			cancelJob:    "job-4",
+			wantReleased: false,
+			wantLock:     "job-1",
+			wantQueue:    []string{"job-2"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			lockStore := store.NewMemLockStore()
+			if tc.initialLock != "" {
+				if err := lockStore.Lock(ctx, "group-1", tc.initialLock); err != nil {
+					t.Fatalf("failed to lock: %v", err)
+				}
+			}
+			wrapped := store.NewGroupLockStoreWrapper(lockStore, "group-1")
+			group, err := store.NewGroup(ctx, "group-1", wrapped)
+			if err != nil {
+				t.Fatalf("failed to create group: %v", err)
+			}
+			spec := group.Spec()
+			for _, jobID := range tc.queuedJobs {
+				spec.RequestLock(jobID)
+			}
+
+			released, err := spec.CancelLockRequest(ctx, tc.cancelJob)
+			if err != nil {
+				t.Fatalf("CancelLockRequest() error = %v", err)
+			}
+			if released != tc.wantReleased {
+				t.Errorf("CancelLockRequest() released = %v, want %v", released, tc.wantReleased)
+			}
+			if spec.LockingJob() != tc.wantLock {
+				t.Errorf("LockingJob() = %q, want %q", spec.LockingJob(), tc.wantLock)
+			}
+
+			queue := spec.GetWaitingJobQueue()
+			if queue.Len() != len(tc.wantQueue) {
+				t.Fatalf("queue len = %d, want %d", queue.Len(), len(tc.wantQueue))
+			}
+			for i, waiting := range queue.List() {
+				if waiting.JobID != tc.wantQueue[i] {
+					t.Errorf("queue[%d] = %q, want %q", i, waiting.JobID, tc.wantQueue[i])
+				}
+			}
+		})
+	}
+}
+
 func TestGroupSpec_TryPromote(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/pkg/accelerator-orchestrator/store/waiting_job_queue.go
+++ b/pkg/accelerator-orchestrator/store/waiting_job_queue.go
@@ -64,6 +64,21 @@ func (q *WaitingJobQueue) Dequeue() (string, bool) {
 	return job.JobID, true
 }
 
+// Remove removes the given job from the queue regardless of its position.
+// Returns true if the job was removed, false if it was not in the queue.
+func (q *WaitingJobQueue) Remove(jobID string) bool {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+
+	elem, ok := q.exist[jobID]
+	if !ok {
+		return false
+	}
+	q.jobs.Remove(elem)
+	delete(q.exist, jobID)
+	return true
+}
+
 // Peek returns the next job from the front of the queue without removing it.
 // Returns the jobID and true if successful, or empty string and false if the queue is empty.
 func (q *WaitingJobQueue) Peek() (string, bool) {

--- a/pkg/accelerator-orchestrator/store/waiting_job_queue_test.go
+++ b/pkg/accelerator-orchestrator/store/waiting_job_queue_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestWaitingJobQueue_BasicAndDuplicates(t *testing.T) {
 	type op struct {
-		action   string // "enqueue", "dequeue", "exists", "len"
+		action   string // "enqueue", "dequeue", "remove", "exists", "len"
 		val      string // input for action
 		wantBool bool   // expected result for enqueue/dequeue/exists
 		wantInt  int    // expected result for len
@@ -38,6 +38,25 @@ func TestWaitingJobQueue_BasicAndDuplicates(t *testing.T) {
 			},
 		},
 		{
+			name: "remove from any position preserves FIFO order",
+			steps: []op{
+				{action: "enqueue", val: "job-a", wantBool: true},
+				{action: "enqueue", val: "job-b", wantBool: true},
+				{action: "enqueue", val: "job-c", wantBool: true},
+				{action: "remove", val: "job-b", wantBool: true},
+				{action: "len", wantInt: 2},
+				{action: "exists", val: "job-b", wantBool: false},
+				{action: "remove", val: "job-b", wantBool: false}, // already removed
+				{action: "remove", val: "job-d", wantBool: false}, // never enqueued
+				{action: "dequeue", wantBool: true, wantVal: "job-a"},
+				{action: "dequeue", wantBool: true, wantVal: "job-c"},
+				{action: "len", wantInt: 0},
+				// removed job can be re-enqueued
+				{action: "enqueue", val: "job-b", wantBool: true},
+				{action: "dequeue", wantBool: true, wantVal: "job-b"},
+			},
+		},
+		{
 			name: "prevent duplicates",
 			steps: []op{
 				{action: "enqueue", val: "job-a", wantBool: true},
@@ -51,27 +70,32 @@ func TestWaitingJobQueue_BasicAndDuplicates(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			queue := store.NewWaitingJobQueue()
-			for i, step := range tc.steps {
+			for stepIdx, step := range tc.steps {
 				switch step.action {
 				case "enqueue":
 					got := queue.Enqueue(step.val)
 					if got != step.wantBool {
-						t.Fatalf("step %d: Enqueue(%q) = %t, want %t", i, step.val, got, step.wantBool)
+						t.Fatalf("step %d: Enqueue(%q) = %t, want %t", stepIdx, step.val, got, step.wantBool)
 					}
 				case "dequeue":
 					gotVal, ok := queue.Dequeue()
 					if ok != step.wantBool || gotVal != step.wantVal {
-						t.Fatalf("step %d: Dequeue() = (%q, %t), want (%q, %t)", i, gotVal, ok, step.wantVal, step.wantBool)
+						t.Fatalf("step %d: Dequeue() = (%q, %t), want (%q, %t)", stepIdx, gotVal, ok, step.wantVal, step.wantBool)
+					}
+				case "remove":
+					got := queue.Remove(step.val)
+					if got != step.wantBool {
+						t.Fatalf("step %d: Remove(%q) = %t, want %t", stepIdx, step.val, got, step.wantBool)
 					}
 				case "exists":
 					got := queue.Exists(step.val)
 					if got != step.wantBool {
-						t.Fatalf("step %d: Exists(%q) = %t, want %t", i, step.val, got, step.wantBool)
+						t.Fatalf("step %d: Exists(%q) = %t, want %t", stepIdx, step.val, got, step.wantBool)
 					}
 				case "len":
 					got := queue.Len()
 					if got != step.wantInt {
-						t.Fatalf("step %d: Len() = %d, want %d", i, got, step.wantInt)
+						t.Fatalf("step %d: Len() = %d, want %d", stepIdx, got, step.wantInt)
 					}
 				}
 			}


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and their purpose -->

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Cancelled accelerator acquisition requests now properly release locks or leave waiting queues, preventing jobs from remaining stuck.
  * Lock ownership is transferred to the next waiting job when appropriate.
  * Waiting jobs can be removed while preserving queue order and allowing later re-enqueueing.

* **Tests**
  * Added coverage for cancellation, lock release, queue removal, and post-cancellation state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->