### PR TITLE
Add default retries for timeslice python client

### DIFF
--- a/pkg/client/python/tests/test_orchestrator.py
+++ b/pkg/client/python/tests/test_orchestrator.py
@@ -69,7 +69,9 @@ class TestTimeSliceOrchestratorClient(unittest.TestCase):
 
     def test_init_custom_channel_options_override(self):
         custom_options = [("grpc.max_receive_message_length", 1024)]
-        client = TimeSliceOrchestratorClient(self.target, channel_options=custom_options)
+        client = TimeSliceOrchestratorClient(
+            self.target, channel_options=custom_options
+        )
         self.mock_insecure_channel.assert_called_with(
             self.target, options=custom_options
         )

--- a/pkg/client/python/tests/test_orchestrator.py
+++ b/pkg/client/python/tests/test_orchestrator.py
@@ -1,10 +1,12 @@
 import datetime
+import json
 import unittest
 from unittest.mock import MagicMock, patch
 
 import grpc
 
 from timeslice import TimeSliceOrchestratorClient
+from timeslice.orchestrator.client import DEFAULT_CHANNEL_OPTIONS
 from timeslice.orchestrator.exceptions import (
     OrchestratorConnectionError,
     OrchestratorTimeoutError,
@@ -44,12 +46,34 @@ class TestTimeSliceOrchestratorClient(unittest.TestCase):
         self.mock_stub_patcher.stop()
 
     def test_init(self):
-        self.mock_insecure_channel.assert_called_once_with(self.target, options=None)
+        self.mock_insecure_channel.assert_called_once_with(
+            self.target, options=DEFAULT_CHANNEL_OPTIONS
+        )
         self.mock_stub_class.assert_called_once_with(
             self.mock_insecure_channel.return_value
         )
         self.assertEqual(self.client.job_id, self.job_id)
         self.assertEqual(self.client.group_id, self.group_id)
+
+    def test_default_retry_status_codes(self):
+        # Verify DEFAULT_CHANNEL_OPTIONS configures retryable status codes
+        self.assertEqual(len(DEFAULT_CHANNEL_OPTIONS), 1)
+        key, service_config_str = DEFAULT_CHANNEL_OPTIONS[0]
+        self.assertEqual(key, "grpc.service_config")
+        config = json.loads(service_config_str)
+        retry_policy = config["methodConfig"][0]["retryPolicy"]
+        self.assertEqual(
+            retry_policy["retryableStatusCodes"],
+            ["UNAVAILABLE", "RESOURCE_EXHAUSTED", "ABORTED", "DEADLINE_EXCEEDED"],
+        )
+
+    def test_init_custom_channel_options_override(self):
+        custom_options = [("grpc.max_receive_message_length", 1024)]
+        client = TimeSliceOrchestratorClient(self.target, channel_options=custom_options)
+        self.mock_insecure_channel.assert_called_with(
+            self.target, options=custom_options
+        )
+        client.close()
 
     def test_acquire_success(self):
         # Mock Acquire response

--- a/pkg/client/python/timeslice/orchestrator/client.py
+++ b/pkg/client/python/timeslice/orchestrator/client.py
@@ -1,4 +1,5 @@
 import contextlib
+import json
 from typing import Any, List, Optional, Tuple
 
 import grpc
@@ -14,6 +15,34 @@ from timeslice.orchestrator.types import (
     SnapshotAgentJobState,
     YieldResult,
 )
+
+DEFAULT_SERVICE_CONFIG = json.dumps(
+    {
+        "methodConfig": [
+            {
+                "name": [
+                    {"service": "timeslice.orchestrator.AcceleratorOrchestratorService"}
+                ],
+                "retryPolicy": {
+                    "maxAttempts": 5,
+                    "initialBackoff": "0.1s",
+                    "maxBackoff": "1s",
+                    "backoffMultiplier": 2.0,
+                    "retryableStatusCodes": [
+                        "UNAVAILABLE",
+                        "RESOURCE_EXHAUSTED",
+                        "ABORTED",
+                        "DEADLINE_EXCEEDED",
+                    ],
+                },
+            }
+        ]
+    }
+)
+
+DEFAULT_CHANNEL_OPTIONS: List[Tuple[str, Any]] = [
+    ("grpc.service_config", DEFAULT_SERVICE_CONFIG),
+]
 
 
 class TimeSliceOrchestratorClient:
@@ -37,6 +66,9 @@ class TimeSliceOrchestratorClient:
         self.target = target
         self.job_id = job_id
         self.group_id = group_id
+
+        if channel_options is None:
+            channel_options = DEFAULT_CHANNEL_OPTIONS
 
         # Initialize insecure channel. (Can be extended to secure if needed in future)
         self._channel = grpc.insecure_channel(target, options=channel_options)


### PR DESCRIPTION
Of interest, the temporary FAUTLED condition on pod cleanup shows up as UNAVAILABLE and therefore is covered by this retry logic.

## What does this PR do?

<!-- Describe the changes and their purpose -->

## Why is this change needed?

For https://github.com/llm-d-incubation/llm-d-rl-time-slicing/issues/96

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added default gRPC retry configuration for orchestrator connections.
  * Improved connection resilience by retrying selected transient service errors.
  * Custom channel options continue to be supported when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->