### PR TITLE
Publish component images and fix Helm chart defaults

### DIFF
--- a/.github/actions/docker-build-and-push/action.yml
+++ b/.github/actions/docker-build-and-push/action.yml
@@ -15,6 +15,10 @@ inputs:
     required: false
     description: Container registry
     default: ghcr.io/llm-d
+  dockerfile:
+    required: false
+    description: Path to the Dockerfile to build
+    default: Dockerfile
   platforms:
     required: false
     description: Target platforms
@@ -45,6 +49,7 @@ runs:
           LATEST_TAG="-t ${{ inputs.registry }}/${{ inputs.image-name }}:latest"
         fi
         docker buildx build \
+          -f ${{ inputs.dockerfile }} \
           --platform ${{ inputs.platforms }} \
           --push \
           --annotation "index:org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}" \

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -2,10 +2,14 @@ name: CI - Release
 
 on:
   push:
-    tags:
-      - 'v*'
-  release:
-    types: [published]
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version tag to publish (e.g. v0.1.0). Leave empty to publish 'latest'."
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -14,35 +18,47 @@ permissions:
 jobs:
   docker-build-and-push:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Single-platform (amd64) for both components: the platform is adopted
+          # as a unit, and the snapshot-agent is x86_64-only today (cuda-checkpoint
+          # binary + CGO build). Revisit both together when an aarch64
+          # cuda-checkpoint is available.
+          - component: acceleratororchestrator
+            dockerfile: docker/acceleratororchestrator/Dockerfile
+            platforms: linux/amd64
+          - component: snapshot-agent
+            dockerfile: docker/snapshot-agent/Dockerfile
+            platforms: linux/amd64
     steps:
       - name: Checkout source
         uses: actions/checkout@v7
 
-      - name: Set project name from repository
-        id: meta
-        run: |
-          repo="${GITHUB_REPOSITORY##*/}"
-          echo "project_name=$repo" >> "$GITHUB_OUTPUT"
-
       - name: Determine tag
         id: tag
         run: |
-          if [[ "${GITHUB_EVENT_NAME}" == "release" ]]; then
-            echo "tag=${GITHUB_REF##refs/tags/}" >> "$GITHUB_OUTPUT"
-            echo "prerelease=${{ github.event.release.prerelease }}" >> "$GITHUB_OUTPUT"
-          elif [[ "${GITHUB_REF}" == refs/tags/* ]]; then
-            echo "tag=${GITHUB_REF##refs/tags/}" >> "$GITHUB_OUTPUT"
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          version="${{ github.event.inputs.version }}"
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${version}" ]]; then
+            # Manual versioned release: publish only the requested tag,
+            # leave 'latest' to main-branch builds.
+            echo "tag=${version}" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
+            # Every main merge (and tag-less manual runs) publishes 'latest'.
             echo "tag=latest" >> "$GITHUB_OUTPUT"
-            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
           fi
         shell: bash
 
       - name: Build and push
         uses: ./.github/actions/docker-build-and-push
         with:
-          image-name: ${{ steps.meta.outputs.project_name }}
+          image-name: ${{ matrix.component }}
+          dockerfile: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platforms }}
+          registry: ghcr.io/${{ github.repository }}
           tag: ${{ steps.tag.outputs.tag }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           prerelease: ${{ steps.tag.outputs.prerelease }}
@@ -50,4 +66,4 @@ jobs:
       - name: Trivy security scan
         uses: ./.github/actions/trivy-scan
         with:
-          image: ghcr.io/llm-d/${{ steps.meta.outputs.project_name }}:${{ steps.tag.outputs.tag }}
+          image: ghcr.io/${{ github.repository }}/${{ matrix.component }}:${{ steps.tag.outputs.tag }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -2,6 +2,8 @@
 
 This is the parent Helm chart that coordinates the deployment of both the **Accelerator Orchestrator** and the **Snapshot Agent**.
 
+Public images are published to `ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/*` by CI: `latest` on every merge to main; versioned tags via a manual workflow run.
+
 ## Directory Structure
 
 *   `Chart.yaml`: Defines the parent chart and its dependencies.

--- a/deploy/acceleratororchestrator/README.md
+++ b/deploy/acceleratororchestrator/README.md
@@ -2,6 +2,8 @@
 
 This directory contains the Helm chart for deploying the Accelerator Orchestrator in a Kubernetes cluster.
 
+Public images are published to `ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/*` by CI: `latest` on every merge to main; versioned tags via a manual workflow run.
+
 ## Prerequisites
 
 *   A Kubernetes cluster.

--- a/deploy/acceleratororchestrator/values.yaml
+++ b/deploy/acceleratororchestrator/values.yaml
@@ -1,8 +1,8 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/llm-d/acceleratororchestrator
-  pullPolicy: IfNotPresent
+  repository: ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/acceleratororchestrator
+  pullPolicy: Always
   tag: "latest"
 
 service:

--- a/deploy/snapshot-agent/README.md
+++ b/deploy/snapshot-agent/README.md
@@ -2,6 +2,8 @@
 
 This directory contains the Helm chart for deploying the Snapshot Agent DaemonSet in a Kubernetes cluster.
 
+Public images are published to `ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/*` by CI: `latest` on every merge to main; versioned tags via a manual workflow run.
+
 ## Prerequisites
 
 *   A Kubernetes cluster with GPU nodes (NVIDIA).
@@ -134,7 +136,7 @@ We use the provided `Makefile` targets to build and push the container image.
     ```
 2.  Run the following make target from the repository root to build and push the image:
     ```bash
-    make image-push-snapshot-agent
+    make snapshot-agent-image-push
     ```
     This will build the image and push it to `your-custom-registry.com/your-project/snapshot-agent:dev-<hash>`.
 

--- a/deploy/snapshot-agent/templates/daemonset.yaml
+++ b/deploy/snapshot-agent/templates/daemonset.yaml
@@ -28,6 +28,7 @@ spec:
       initContainers:
         - name: install-cuda-checkpoint
           image: alpine:latest
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
           command: ["sh", "-c", "apk add --no-cache wget && wget -qO /opt/bin/cuda-checkpoint https://raw.githubusercontent.com/NVIDIA/cuda-checkpoint/main/bin/x86_64_Linux/cuda-checkpoint && chmod +x /opt/bin/cuda-checkpoint && echo 'cuda-checkpoint installed'"]
           volumeMounts:
             - name: bin-dir

--- a/deploy/snapshot-agent/values.yaml
+++ b/deploy/snapshot-agent/values.yaml
@@ -1,8 +1,8 @@
 # Default values for snapshot-agent.
 image:
-  repository: ghcr.io/llm-d/snapshot-agent
-  pullPolicy: IfNotPresent
-  tag: ""
+  repository: ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/snapshot-agent
+  pullPolicy: Always
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/docker/snapshot-agent/Dockerfile
+++ b/docker/snapshot-agent/Dockerfile
@@ -15,12 +15,17 @@ RUN rm -f go.work && \
 # Build the snapshot-agent
 RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w" -o /workspace/snapshot-agent ./cmd/snapshot-agent
 
+# Fetch cuda-checkpoint (pinned to a specific NVIDIA/cuda-checkpoint commit) so the
+# image is self-contained and builds from a fresh clone without a pre-populated bin/
+ADD https://github.com/NVIDIA/cuda-checkpoint/raw/00d5cce84c628088d6caa203fc4af40c1538b6f7/bin/x86_64_Linux/cuda-checkpoint /workspace/bin/cuda-checkpoint
+RUN chmod +x /workspace/bin/cuda-checkpoint
+
 # --- Runtime stage ---
 FROM gcr.io/distroless/base
 
 WORKDIR /
 COPY --from=builder /workspace/snapshot-agent .
-# Copy pre-built binaries (like cuda-checkpoint) from the bin directory
+# Copy bundled binaries (cuda-checkpoint) from the builder's bin directory
 COPY --from=builder /workspace/bin ./bin
 
 


### PR DESCRIPTION
The Helm charts default to `ghcr.io/llm-d/*` images that have never been published, so `helm install` fails at image pull out of the box. The release workflow could not have produced them: it is unmodified repo-template scaffolding that builds the root `Dockerfile` (the `cmd/main.go` placeholder stub) as a single repo-named image, targeting an org this repo's token cannot push to.

Changes:
- **CI publishes both components**: `ci-release.yaml` builds `acceleratororchestrator` and `snapshot-agent` from their own Dockerfiles and pushes to `ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/<component>`. The docker-build-and-push action gains a `dockerfile` input; the Trivy scan now scans the images actually pushed.
- **Release model**: `latest` is published on every merge to main; versioned tags are published via a manual `workflow_dispatch` run with a `version` input (versioned runs do not move `latest`). The template's tag-push/release triggers are removed — note that pushing a `v*` git tag alone no longer publishes images.
- **Images are linux/amd64 only**: the snapshot-agent is x86_64-bound (cuda-checkpoint binary + CGO build), and the platform is adopted as a unit, so the orchestrator matches rather than advertising an arch the stack can't deliver.
- **Hermetic snapshot-agent image**: the Dockerfile fetches cuda-checkpoint pinned to `NVIDIA/cuda-checkpoint@00d5cce` in the builder stage instead of requiring a pre-populated (gitignored) `bin/`, so it builds from a fresh clone. The chart's initContainer mechanism is unchanged.
- **Chart defaults match what CI publishes**: both `values.yaml` point at the new image path with `tag: latest` and `pullPolicy: Always` (explicit on the initContainer too, tied to the same value).
- **Docs**: published-image location noted in the deploy READMEs; fixed the snapshot-agent README's make target (`snapshot-agent-image-push`).

Both component Dockerfiles were build-verified from a clean checkout (no `bin/` preparation), and `helm lint`/`helm template` render the new image references on both subcharts and the parent chart.

Post-merge step (one-time): the first publish creates both ghcr packages **private** by default — an admin must set them to public (Package settings → Change visibility) for anonymous pulls / out-of-the-box `helm install` to work. Visibility persists for all future pushes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Releases can now run automatically after merges to `main` or manually with a specified version.
  * CI publishes Accelerator Orchestrator and Snapshot Agent container images with configurable tags and build settings.
  * Snapshot Agent images now include the CUDA checkpoint utility.

* **Bug Fixes**
  * Deployment configuration now consistently uses the published container images and always retrieves the configured image version.

* **Documentation**
  * Added instructions for published image locations, tags, and updated image publishing commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->