### PR TITLE
snapshot-agent tests: pin engine images and add TEST_NODE override

### DIFF
--- a/tests/integration/snapshot-agent/README.md
+++ b/tests/integration/snapshot-agent/README.md
@@ -66,6 +66,11 @@ This builds from your working directory, so local modifications are included —
 --skip-cleanup       Leave the test-runner pod running for debugging
 ```
 
+Environment: `TEST_NODE=<node-name>` pins the suite to a specific node instead
+of the default pick (first node with a free GPU by requests). Use it when the
+cluster runs workloads that occupy GPUs without requesting them (time-slicing
+experiments), which the default pick cannot see.
+
 ## Exit code
 
 `go test`'s exit code (0 = all passed).

--- a/tests/integration/snapshot-agent/engines.go
+++ b/tests/integration/snapshot-agent/engines.go
@@ -22,7 +22,7 @@ var VLLM = EngineSpec{
 	Port:       8000,
 	PIDPattern: "vllm.entrypoints",
 	BuildPod: func(h *Harness) *corev1.Pod {
-		return enginePod(h, "vllm", "vllm/vllm-openai:latest",
+		return enginePod(h, "vllm", "vllm/vllm-openai:v0.25.1",
 			[]string{"python3", "-m", "vllm.entrypoints.openai.api_server"},
 			[]string{
 				"--model=" + h.Model,
@@ -42,7 +42,7 @@ var SGLang = EngineSpec{
 	Port:       30000,
 	PIDPattern: "sglang.launch_server",
 	BuildPod: func(h *Harness) *corev1.Pod {
-		return enginePod(h, "sglang", "lmsysorg/sglang:latest",
+		return enginePod(h, "sglang", "lmsysorg/sglang:v0.5.15",
 			[]string{"python3", "-m", "sglang.launch_server"},
 			[]string{
 				"--model-path=" + h.Model,

--- a/tests/integration/snapshot-agent/engines.go
+++ b/tests/integration/snapshot-agent/engines.go
@@ -22,7 +22,7 @@ var VLLM = EngineSpec{
 	Port:       8000,
 	PIDPattern: "vllm.entrypoints",
 	BuildPod: func(h *Harness) *corev1.Pod {
-		return enginePod(h, "vllm", "vllm/vllm-openai:v0.25.1",
+		return enginePod(h, "vllm", "vllm/vllm-openai:v0.25.1@sha256:e4f88a835143cd22aee2397a26ec6bb80b3a4a6fe0c882bcbc63822904766089",
 			[]string{"python3", "-m", "vllm.entrypoints.openai.api_server"},
 			[]string{
 				"--model=" + h.Model,
@@ -42,7 +42,7 @@ var SGLang = EngineSpec{
 	Port:       30000,
 	PIDPattern: "sglang.launch_server",
 	BuildPod: func(h *Harness) *corev1.Pod {
-		return enginePod(h, "sglang", "lmsysorg/sglang:v0.5.15",
+		return enginePod(h, "sglang", "lmsysorg/sglang:v0.5.15@sha256:af911a303a12516adf23ab8bb89c8fdf161ec0ceafc278a436fa111f5c118988",
 			[]string{"python3", "-m", "sglang.launch_server"},
 			[]string{
 				"--model-path=" + h.Model,

--- a/tests/integration/snapshot-agent/harness.go
+++ b/tests/integration/snapshot-agent/harness.go
@@ -84,7 +84,13 @@ func NewHarness(t *testing.T, mode string) *Harness {
 	}
 
 	h := &Harness{Client: client, Config: cfg, Image: image, Model: model, Mode: mode}
-	h.Node = h.pickGPUNode(t)
+	// TEST_NODE pins the suite to a specific node (e.g. one known to be
+	// otherwise idle); by default the first node with a free GPU is used.
+	if node := os.Getenv("TEST_NODE"); node != "" {
+		h.Node = node
+	} else {
+		h.Node = h.pickGPUNode(t)
+	}
 	t.Logf("using node %s, image %s, mode %s", h.Node, h.Image, h.Mode)
 
 	h.deployAgent(t)

--- a/tests/integration/snapshot-agent/run.sh
+++ b/tests/integration/snapshot-agent/run.sh
@@ -71,7 +71,7 @@ $K exec test-runner -- sh -c "apt-get update -qq > /dev/null && apt-get install 
 
 log "Running Go test suite in-cluster (this deploys agent + engine pods)..."
 EXIT=0
-$K exec test-runner -- env "AGENT_IMAGE=${IMAGE}" "MODEL=${MODEL}" \
+$K exec test-runner -- env "AGENT_IMAGE=${IMAGE}" "MODEL=${MODEL}" "TEST_NODE=${TEST_NODE:-}" \
   sh -c "cd /workspace && go test -tags=integration -count=1 -v -timeout 40m -run '${RUN_PATTERN}' ./tests/integration/snapshot-agent/" \
   || EXIT=$?
 


### PR DESCRIPTION
## Summary

Follow-up to #100 review:

- Pin the engine images for reproducible suite results: `vllm/vllm-openai:v0.25.1` and `lmsysorg/sglang:v0.5.15` (current releases) instead of `:latest`. Engine versions are now bumped deliberately.
- `TEST_NODE` env override for the harness's node selection: the default pick (first node with a free GPU **by requests**) cannot see workloads that occupy GPUs without requesting them (time-slicing experiments) and can land the suite on a busy node.

## Testing

Full suite rerun with the pinned images on a dedicated H100 node: **9/9 pass** — see the results comment below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added instructions for pinning integration tests to a specific Kubernetes node with `TEST_NODE`.

* **Tests**
  * Added support for selecting a specific test node, while retaining automatic GPU-node selection by default.
  * Updated test runner configuration to pass the node selection option.
  * Pinned vLLM and SGLang test images to specific versioned, digest-verified releases for more consistent test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->