### PR TITLE
Rename OrchestratorClient to TimeSliceOrchestratorClient

### DIFF
--- a/guides/accelerator-orchestrator/README.md
+++ b/guides/accelerator-orchestrator/README.md
@@ -196,12 +196,12 @@ Typically, you configure a central coordinator (such as the RL loop actor in ini
 
 This ordering prevents resource conflicts during the initial startup and initialization phases.
 
-The following Python example demonstrates how to use the `OrchestratorClient` to safely orchestrate the startup and deployment of work pods:
+The following Python example demonstrates how to use the `TimeSliceOrchestratorClient` to safely orchestrate the startup and deployment of work pods:
 
 ```python
-from timeslice import OrchestratorClient
+from timeslice import TimeSliceOrchestratorClient
 
-orchestrator = OrchestratorClient(
+orchestrator = TimeSliceOrchestratorClient(
     target="accelerator-orchestrator.timeslice-system.svc.cluster.local:50051",
     job_id="job-a",
     group_id="group-ab-sampler"
@@ -239,11 +239,11 @@ Typically, you configure the job logic (such as the RL loop actor in the loop) t
 The cleanest developer experience is to wrap your GPU-bound phases in functions decorated with `@on_accelerators`. This automatically acquires the lock when the function starts and yields it when the function returns, allowing other jobs to interleave during CPU-bound phases (like reward computation).
 
 ```python
-from timeslice import OrchestratorClient
+from timeslice import TimeSliceOrchestratorClient
 import time
 
 # Initialize the client. The job_id identifies this workload (e.g., 'job-a')
-orchestrator = OrchestratorClient(target="accelerator-orchestrator.timeslice-system.svc.cluster.local:50051", job_id="job-a")
+orchestrator = TimeSliceOrchestratorClient(target="accelerator-orchestrator.timeslice-system.svc.cluster.local:50051", job_id="job-a")
 
 # Decorate GPU tasks to automatically yield/acquire hardware via the Orchestrator
 @orchestrator.on_accelerators(group_id="group-ab-trainer")

--- a/pkg/client/python/tests/__init__.py
+++ b/pkg/client/python/tests/__init__.py
@@ -1,1 +1,1 @@
-# Unit tests for OrchestratorClient
+# Unit tests for TimeSliceOrchestratorClient

--- a/pkg/client/python/tests/test_orchestrator.py
+++ b/pkg/client/python/tests/test_orchestrator.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import grpc
 
-from timeslice import OrchestratorClient
+from timeslice import TimeSliceOrchestratorClient
 from timeslice.orchestrator.exceptions import (
     OrchestratorConnectionError,
     OrchestratorTimeoutError,
@@ -14,7 +14,7 @@ from timeslice.orchestrator.types import AgentJobState, GroupLockState
 from timeslice.orchestrator._generated import pb2
 
 
-class TestOrchestratorClient(unittest.TestCase):
+class TestTimeSliceOrchestratorClient(unittest.TestCase):
     def setUp(self):
         self.target = "localhost:50051"
         self.job_id = "test-job"
@@ -34,7 +34,9 @@ class TestOrchestratorClient(unittest.TestCase):
         self.mock_stub = MagicMock()
         self.mock_stub_class.return_value = self.mock_stub
 
-        self.client = OrchestratorClient(self.target, self.job_id, self.group_id)
+        self.client = TimeSliceOrchestratorClient(
+            self.target, self.job_id, self.group_id
+        )
 
     def tearDown(self):
         self.client.close()
@@ -211,13 +213,13 @@ class TestOrchestratorClient(unittest.TestCase):
 
     def test_init_optional_args(self):
         # We can create a client with only target
-        client = OrchestratorClient(self.target)
+        client = TimeSliceOrchestratorClient(self.target)
         self.assertIsNone(client.job_id)
         self.assertIsNone(client.group_id)
         client.close()
 
     def test_acquire_missing_args_raises_value_error(self):
-        client = OrchestratorClient(self.target)
+        client = TimeSliceOrchestratorClient(self.target)
 
         # Missing both
         with self.assertRaises(ValueError) as ctx:

--- a/pkg/client/python/timeslice/__init__.py
+++ b/pkg/client/python/timeslice/__init__.py
@@ -1,7 +1,7 @@
 from .snapshot_agent.client import SnapshotAgentClient
-from .orchestrator.client import OrchestratorClient
+from .orchestrator.client import TimeSliceOrchestratorClient
 
 __all__ = [
     "SnapshotAgentClient",
-    "OrchestratorClient",
+    "TimeSliceOrchestratorClient",
 ]

--- a/pkg/client/python/timeslice/orchestrator/README.md
+++ b/pkg/client/python/timeslice/orchestrator/README.md
@@ -1,6 +1,6 @@
 # Accelerator Orchestrator Python Client
 
-The `OrchestratorClient` coordinates access to shared accelerators (GPUs/TPUs) among multiple jobs in a time-slice group. It ensures that only one job has exclusive access to the accelerator at any given time, driving the snapshot/restore cycle automatically behind the scenes.
+The `TimeSliceOrchestratorClient` coordinates access to shared accelerators (GPUs/TPUs) among multiple jobs in a time-slice group. It ensures that only one job has exclusive access to the accelerator at any given time, driving the snapshot/restore cycle automatically behind the scenes.
 
 ## Usage
 
@@ -9,11 +9,11 @@ The `OrchestratorClient` coordinates access to shared accelerators (GPUs/TPUs) a
 You can explicitly control accelerator access using `acquire()` and `release()`. It is highly recommended to use a `try...finally` block to ensure the access is always released.
 
 ```python
-from timeslice import OrchestratorClient
+from timeslice import TimeSliceOrchestratorClient
 from timeslice.orchestrator import OrchestratorError
 
 # Initialize client for a specific job in a shared GPU group
-client = OrchestratorClient(
+client = TimeSliceOrchestratorClient(
     target="orchestrator-service:50051",
     job_id="my-job-123",
     group_id="shared-gpu-group"
@@ -38,9 +38,9 @@ finally:
 A cleaner and safer way to manage accelerator access is using the `on_accelerators()` context manager, which automatically handles acquisition and release. It yields an `AcquireResult` that you can inspect inside the block.
 
 ```python
-from timeslice import OrchestratorClient
+from timeslice import TimeSliceOrchestratorClient
 
-client = OrchestratorClient("orchestrator-service:50051", "my-job", "shared-gpu")
+client = TimeSliceOrchestratorClient("orchestrator-service:50051", "my-job", "shared-gpu")
 
 # Automatically acquires on enter, releases on exit (even if exceptions occur)
 with client.on_accelerators(timeout_sec=30.0) as result:
@@ -53,9 +53,9 @@ with client.on_accelerators(timeout_sec=30.0) as result:
 The `on_accelerators()` method also supports decorator usage out of the box. Exclusive accelerator access is acquired when the decorated function is called and released when it returns.
 
 ```python
-from timeslice import OrchestratorClient
+from timeslice import TimeSliceOrchestratorClient
 
-client = OrchestratorClient("orchestrator-service:50051", "my-job", "shared-gpu")
+client = TimeSliceOrchestratorClient("orchestrator-service:50051", "my-job", "shared-gpu")
 
 @client.on_accelerators(timeout_sec=10.0)
 def run_gpu_kernel():
@@ -71,10 +71,10 @@ run_gpu_kernel()
 The `job_id` and `group_id` are optional on construction. If omitted, they **must** be provided dynamically during the method calls. You can also override the constructor-configured values on a per-call basis.
 
 ```python
-from timeslice import OrchestratorClient
+from timeslice import TimeSliceOrchestratorClient
 
 # Initialize without job_id and group_id
-client = OrchestratorClient(target="orchestrator-service:50051")
+client = TimeSliceOrchestratorClient(target="orchestrator-service:50051")
 
 # Pass them dynamically during acquire/release
 client.acquire(job_id="job-A", group_id="group-A")
@@ -92,11 +92,11 @@ with client.on_accelerators(job_id="job-B", group_id="group-B") as result:
 
 In a typical Reinforcement Learning setup, a single training job might need to coordinate access across two different GPU resource pools: one dedicated to **Sampling** (generating experience rollouts) and another dedicated to **Training** (updating model weights).
 
-Using `OrchestratorClient` as a **decorator** (`@client.on_accelerators()`), we can cleanly bind GPU access management directly to the execution functions. This keeps the orchestration loop in `main()` extremely clean and readable.
+Using `TimeSliceOrchestratorClient` as a **decorator** (`@client.on_accelerators()`), we can cleanly bind GPU access management directly to the execution functions. This keeps the orchestration loop in `main()` extremely clean and readable.
 
 ```python
 import time
-from timeslice import OrchestratorClient
+from timeslice import TimeSliceOrchestratorClient
 
 # Configuration
 ORCHESTRATOR_TARGET = "orchestrator-service:50051"
@@ -109,8 +109,8 @@ SAMPLING_GROUP = "sampling-gpu-pool"
 TRAINING_GROUP = "training-gpu-pool"
 
 # Initialize clients at the module level so they can be used as decorators
-sampler_client = OrchestratorClient(ORCHESTRATOR_TARGET, job_id=RL_JOB_ID, group_id=SAMPLING_GROUP)
-trainer_client = OrchestratorClient(ORCHESTRATOR_TARGET, job_id=RL_JOB_ID, group_id=TRAINING_GROUP)
+sampler_client = TimeSliceOrchestratorClient(ORCHESTRATOR_TARGET, job_id=RL_JOB_ID, group_id=SAMPLING_GROUP)
+trainer_client = TimeSliceOrchestratorClient(ORCHESTRATOR_TARGET, job_id=RL_JOB_ID, group_id=TRAINING_GROUP)
 
 
 # Decorate functions to automatically manage GPU access when they are invoked

--- a/pkg/client/python/timeslice/orchestrator/__init__.py
+++ b/pkg/client/python/timeslice/orchestrator/__init__.py
@@ -1,4 +1,4 @@
-from timeslice.orchestrator.client import OrchestratorClient
+from timeslice.orchestrator.client import TimeSliceOrchestratorClient
 from timeslice.orchestrator.exceptions import (
     OrchestratorError,
     OrchestratorConnectionError,
@@ -17,7 +17,7 @@ from timeslice.orchestrator.types import (
 )
 
 __all__ = [
-    "OrchestratorClient",
+    "TimeSliceOrchestratorClient",
     "OrchestratorError",
     "OrchestratorConnectionError",
     "OrchestratorTimeoutError",

--- a/pkg/client/python/timeslice/orchestrator/client.py
+++ b/pkg/client/python/timeslice/orchestrator/client.py
@@ -16,7 +16,7 @@ from timeslice.orchestrator.types import (
 )
 
 
-class OrchestratorClient:
+class TimeSliceOrchestratorClient:
     """Convenient UX wrapper client for the Accelerator Orchestrator Service."""
 
     def __init__(


### PR DESCRIPTION
Renames the Python client class `OrchestratorClient` to `TimeSliceOrchestratorClient`, updating the client package, tests, and user guides.

Scope is the client class only (as we have code snippets published to a blog post that will come out today) — the Accelerator Orchestrator component name is unchanged for now and will be handled as part of #64.