### PR TITLE
ci: gate changes to tests/integration on integration testing

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,3 +4,4 @@ needs-integration-test:
           - 'pkg/snapshot-agent/**'
           - 'cmd/snapshot-agent/**'
           - 'pkg/client/python/timeslice/snapshot_agent/**'
+          - 'tests/integration/**'


### PR DESCRIPTION
## Summary

Adds `tests/integration/**` to the `needs-integration-test` labeler globs. Changes to the integration test harness itself previously passed the gate without an integration run (surfaced while sweeping open PRs: the channel test PR skated through).

## Testing

Config-only. The labeler run on this PR exercises the change indirectly; the new glob takes effect for PRs opened or updated after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test labeling configuration to recognize changes under the integration test directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->