### PR TITLE
Pin ruff to 0.15.22 to unblock PR CI

### DIFF
--- a/.github/workflows/ci-pr-checks.yaml
+++ b/.github/workflows/ci-pr-checks.yaml
@@ -91,7 +91,9 @@ jobs:
 
       - name: Install ruff
         if: steps.check-python.outputs.has_python == 'true'
-        run: pip install ruff
+        # Pinned so lint results only change when we bump the version, not
+        # when ruff releases (0.16.0 introduced 101 new findings, see #116).
+        run: pip install ruff==0.15.22
 
       - name: Run ruff check
         if: steps.check-python.outputs.has_python == 'true'


### PR DESCRIPTION
ruff 0.16.0 (released 2026-07-23 19:10 UTC) reports 101 new errors in `pkg/client/python`, failing `python-lint-and-test` on every PR regardless of its contents — the workflow installs ruff unpinned, so the linter changed underneath us (e.g. #112 went green→red with no repo changes in between).

This pins ruff to 0.15.22, the last version CI passed on, so lint results only change on a deliberate version bump.

Fixing the 101 findings and unpinning is tracked in #116.

After merge, re-running `python-lint-and-test` on open PRs picks up the pinned workflow via the merge commit — no rebases needed.