### PR TITLE
Release follow-ups: harden version input, drop cuda-checkpoint downloader, fix Makefile paths

### DIFF
--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -38,13 +38,19 @@ jobs:
 
       - name: Determine tag
         id: tag
+        env:
+          # Read via env, not template interpolation, so the input can't be
+          # rendered into Bash source; validated as a Docker tag below.
+          VERSION: ${{ github.event.inputs.version }}
         run: |
-          version="${{ github.event.inputs.version }}"
-          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${version}" ]]; then
+          if [[ -n "${VERSION}" && ! "${VERSION}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+            echo "Invalid image tag: ${VERSION}" >&2
+            exit 1
+          fi
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" && -n "${VERSION}" ]]; then
             # Manual versioned release: publish only the requested tag,
             # leave 'latest' to main-branch builds.
-            echo "tag=${version}" >> "$GITHUB_OUTPUT"
-            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+            printf 'tag=%s\nprerelease=true\n' "${VERSION}" >> "$GITHUB_OUTPUT"
           else
             # Every main merge (and tag-less manual runs) publishes 'latest'.
             echo "tag=latest" >> "$GITHUB_OUTPUT"

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,16 @@
 # Project configuration
-# TODO: Replace {{PROJECT_NAME}} with your project name
 PROJECT_NAME ?= llm-d-rl-time-slicing
-REGISTRY ?= ghcr.io/llm-d
-IMAGE ?= $(REGISTRY)/$(PROJECT_NAME)
+# Matches where CI publishes (ghcr.io/<owner>/<repo>/<component>); override
+# REGISTRY for dev pushes to your own registry.
+REGISTRY ?= ghcr.io/llm-d-incubation
 ORCHESTRATOR_IMAGE ?= $(REGISTRY)/$(PROJECT_NAME)/acceleratororchestrator
 ORCHESTRATOR_DOCKERFILE ?= docker/acceleratororchestrator/Dockerfile
 SNAPSHOT_AGENT_IMAGE ?= $(REGISTRY)/$(PROJECT_NAME)/snapshot-agent
 SNAPSHOT_AGENT_DOCKERFILE ?= docker/snapshot-agent/Dockerfile
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
-PLATFORMS ?= linux/amd64,linux/arm64
+# amd64-only, same as CI: the snapshot-agent needs the x86_64 cuda-checkpoint
+# binary and a CGO build; the platform is adopted as a unit.
+PLATFORMS ?= linux/amd64
 
 # Go configuration
 GOFLAGS ?=
@@ -80,25 +82,6 @@ pre-commit: ## Run pre-commit hooks on all files
 
 ##@ Container
 
-.PHONY: image-build
-image-build: ## Build multi-arch container image (local only)
-	docker buildx build \
-		--platform $(PLATFORMS) \
-		--tag $(IMAGE):$(VERSION) \
-		--tag $(IMAGE):latest \
-		.
-
-.PHONY: image-push
-image-push: ## Build and push multi-arch container image
-	docker buildx build \
-		--platform $(PLATFORMS) \
-		--push \
-		--annotation "index:org.opencontainers.image.source=https://github.com/llm-d/$(PROJECT_NAME)" \
-		--annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
-		--tag $(IMAGE):$(VERSION) \
-		--tag $(IMAGE):latest \
-		.
-
 .PHONY: image-build-orchestrator
 image-build-orchestrator: ## Build acceleratororchestrator container image (local only)
 	docker buildx build \
@@ -113,7 +96,7 @@ image-push-orchestrator: ## Build and push acceleratororchestrator container ima
 	docker buildx build \
 		--platform $(PLATFORMS) \
 		--push \
-		--annotation "index:org.opencontainers.image.source=https://github.com/llm-d/$(PROJECT_NAME)" \
+		--annotation "index:org.opencontainers.image.source=https://github.com/llm-d-incubation/$(PROJECT_NAME)" \
 		--annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
 		--tag $(ORCHESTRATOR_IMAGE):$(VERSION) \
 		--tag $(ORCHESTRATOR_IMAGE):latest \
@@ -134,7 +117,7 @@ snapshot-agent-image-push: ## Build and push snapshot-agent container image
 	docker buildx build \
 		--platform $(PLATFORMS) \
 		--push \
-		--annotation "index:org.opencontainers.image.source=https://github.com/llm-d/$(PROJECT_NAME)" \
+		--annotation "index:org.opencontainers.image.source=https://github.com/llm-d-incubation/$(PROJECT_NAME)" \
 		--annotation "index:org.opencontainers.image.licenses=Apache-2.0" \
 		--tag $(SNAPSHOT_AGENT_IMAGE):$(VERSION) \
 		--tag $(SNAPSHOT_AGENT_IMAGE):latest \

--- a/deploy/snapshot-agent/README.md
+++ b/deploy/snapshot-agent/README.md
@@ -138,7 +138,7 @@ We use the provided `Makefile` targets to build and push the container image.
     ```bash
     make snapshot-agent-image-push
     ```
-    This will build the image and push it to `your-custom-registry.com/your-project/snapshot-agent:dev-<hash>`.
+    This will build the image and push it to `your-custom-registry.com/your-project/llm-d-rl-time-slicing/snapshot-agent:dev-<hash>` (the repo name comes from `PROJECT_NAME`, also overridable).
 
 ### 2. Deploy with your Custom Image
 

--- a/deploy/snapshot-agent/templates/daemonset.yaml
+++ b/deploy/snapshot-agent/templates/daemonset.yaml
@@ -25,14 +25,6 @@ spec:
       serviceAccountName: {{ include "snapshot-agent.serviceAccountName" . }}
       hostNetwork: true
       hostPID: true
-      initContainers:
-        - name: install-cuda-checkpoint
-          image: alpine:latest
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          command: ["sh", "-c", "apk add --no-cache wget && wget -qO /opt/bin/cuda-checkpoint https://raw.githubusercontent.com/NVIDIA/cuda-checkpoint/main/bin/x86_64_Linux/cuda-checkpoint && chmod +x /opt/bin/cuda-checkpoint && echo 'cuda-checkpoint installed'"]
-          volumeMounts:
-            - name: bin-dir
-              mountPath: /opt/bin
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -43,7 +35,7 @@ spec:
             - name: DEPLOYMENT_MODE
               value: "k8s"
             - name: PATH
-              value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/bin
+              value: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
             - name: NODE_NAME
               valueFrom:
                 fieldRef:
@@ -65,8 +57,6 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: bin-dir
-              mountPath: /opt/bin
             {{- if .Values.nvidia.driver.enabled }}
             - name: nvidia-driver
               mountPath: {{ .Values.nvidia.driver.mountPath }}
@@ -77,8 +67,6 @@ spec:
               mountPath: {{ .Values.nvidia.devices.mountPath }}
             {{- end }}
       volumes:
-        - name: bin-dir
-          emptyDir: {}
         {{- if .Values.nvidia.driver.enabled }}
         - name: nvidia-driver
           hostPath:


### PR DESCRIPTION
Follow-ups from #112 review feedback (CodeRabbit + @jessicaochen's Makefile comment):

- **ci-release.yaml**: read the `workflow_dispatch` version input via `env` and validate it as a Docker tag, instead of interpolating it into Bash source (template-injection finding).
- **snapshot-agent DaemonSet**: remove the init container that downloaded `cuda-checkpoint` from NVIDIA's mutable `main` branch at every pod start. The image has bundled a pinned binary at `/bin/cuda-checkpoint` since #112 (which already won PATH resolution); pod startup is now network-free. Drops the `bin-dir` volume and `/opt/bin` from PATH.
- **Makefile**: default `REGISTRY` pointed at `ghcr.io/llm-d` (wrong org, pre-dates #112). Now `ghcr.io/llm-d-incubation`, so `make *-image-push` targets resolve to the same paths CI publishes; `REGISTRY`/`PROJECT_NAME` remain overridable for dev pushes. Source annotations fixed likewise. Removed the legacy single-image `image-build`/`image-push` targets (they built the placeholder root `Dockerfile`). `PLATFORMS` defaults to `linux/amd64`, matching CI (snapshot-agent is x86_64-only today).
- **snapshot-agent README**: corrected the example dev-push image path (it omitted the `PROJECT_NAME` segment).

Verified: `helm template` renders both charts cleanly with no downloader/`opt/bin` remnants; `make -n` dry-runs resolve to the CI-published paths with and without `REGISTRY` override.