### PR TITLE
snapshot-agent: document and streamline standalone installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,8 @@ LDFLAGS ?= -s -w -X main.version=$(VERSION)
 
 # Tools
 GOLANGCI_LINT_VERSION ?= v2.8.0
+# Pinned to the same commit the container images bundle.
+CUDA_CHECKPOINT_COMMIT ?= 00d5cce84c628088d6caa203fc4af40c1538b6f7
 
 .DEFAULT_GOAL := help
 
@@ -33,6 +35,17 @@ help: ## Show this help message
 build: ## Build the Go binary
 	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o bin/$(PROJECT_NAME) ./cmd
 	go build $(GOFLAGS) -ldflags "$(LDFLAGS)" -o bin/snapshot-agent ./cmd/snapshot-agent
+
+.PHONY: cuda-checkpoint
+cuda-checkpoint: bin/cuda-checkpoint ## Fetch the pinned cuda-checkpoint binary into bin/ (x86_64)
+
+bin/cuda-checkpoint:
+	mkdir -p bin
+	curl -fsSL -o bin/cuda-checkpoint https://raw.githubusercontent.com/NVIDIA/cuda-checkpoint/$(CUDA_CHECKPOINT_COMMIT)/bin/x86_64_Linux/cuda-checkpoint
+	chmod +x bin/cuda-checkpoint
+
+.PHONY: standalone
+standalone: build cuda-checkpoint ## Build everything needed to run the agent in standalone mode
 .PHONY: test
 test: ## Run tests with race detection
 	go test -race -count=1 ./...

--- a/guides/snapshot-agent/README.md
+++ b/guides/snapshot-agent/README.md
@@ -20,14 +20,9 @@ Two ways to get the agent onto a GPU host:
 ```bash
 git clone https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git
 cd llm-d-rl-time-slicing
-make build          # produces bin/snapshot-agent (CGO — links against NVML)
-```
-
-The CUDA backend execs the `cuda-checkpoint` binary, which must be on `PATH`:
-```bash
-sudo wget -qO /usr/local/bin/cuda-checkpoint \
-  https://raw.githubusercontent.com/NVIDIA/cuda-checkpoint/00d5cce84c628088d6caa203fc4af40c1538b6f7/bin/x86_64_Linux/cuda-checkpoint
-sudo chmod +x /usr/local/bin/cuda-checkpoint
+make standalone     # bin/snapshot-agent (CGO — links against NVML)
+                    # + bin/cuda-checkpoint (pinned NVIDIA binary the CUDA
+                    #   backend execs; found via PATH)
 ```
 
 **Or run the published container image** (self-contained: agent + `cuda-checkpoint`):
@@ -47,11 +42,11 @@ By default, the agent starts in standalone mode on port `9001`. Run it as root
 (or as the same user as the workloads) — `cuda-checkpoint` toggles the CUDA
 state of other processes:
 ```bash
-sudo ./bin/snapshot-agent
+sudo env PATH="$PWD/bin:$PATH" ./bin/snapshot-agent
 
 # Or explicitly set the port and mode (also settable via the AGENT_PORT and
 # DEPLOYMENT_MODE environment variables):
-sudo ./bin/snapshot-agent -deployment-mode=standalone -port=9001
+sudo env PATH="$PWD/bin:$PATH" ./bin/snapshot-agent -deployment-mode=standalone -port=9001
 ```
 
 ### Triggering a Snapshot (with PIDs)

--- a/guides/snapshot-agent/README.md
+++ b/guides/snapshot-agent/README.md
@@ -33,9 +33,7 @@ docker run -d --name snapshot-agent \
 
 ### Starting the Agent
 
-By default, the agent starts in standalone mode on port `9001`. Run it as root
-(or as the same user as the workloads) — `cuda-checkpoint` toggles the CUDA
-state of other processes:
+By default, the agent starts in standalone mode on port `9001`:
 ```bash
 sudo env PATH="$PWD/bin:$PATH" ./bin/snapshot-agent
 

--- a/guides/snapshot-agent/README.md
+++ b/guides/snapshot-agent/README.md
@@ -20,21 +20,16 @@ Two ways to get the agent onto a GPU host:
 ```bash
 git clone https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git
 cd llm-d-rl-time-slicing
-make standalone     # bin/snapshot-agent (CGO — links against NVML)
-                    # + bin/cuda-checkpoint (pinned NVIDIA binary the CUDA
-                    #   backend execs; found via PATH)
+make standalone
 ```
 
-**Or run the published container image** (self-contained: agent + `cuda-checkpoint`):
+**Or run the published container image:**
 ```bash
 docker run -d --name snapshot-agent \
   --privileged --pid=host --gpus all \
   -p 9001:9001 \
   ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/snapshot-agent:latest
 ```
-
-`--pid=host` is required: standalone mode targets host PIDs, so the agent must
-share the host PID namespace to checkpoint them.
 
 ### Starting the Agent
 

--- a/guides/snapshot-agent/README.md
+++ b/guides/snapshot-agent/README.md
@@ -12,15 +12,46 @@ It can be deployed in two modes:
 
 In standalone mode, you run the `snapshot-agent` binary directly on your host machine (e.g., a GCE VM). Workloads are targeted by specifying their Process IDs (PIDs) directly in the client request.
 
+### Installing
+
+Two ways to get the agent onto a GPU host:
+
+**Build from source** (requires Go and the NVIDIA driver; x86_64 Linux):
+```bash
+git clone https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git
+cd llm-d-rl-time-slicing
+make build          # produces bin/snapshot-agent (CGO — links against NVML)
+```
+
+The CUDA backend execs the `cuda-checkpoint` binary, which must be on `PATH`:
+```bash
+sudo wget -qO /usr/local/bin/cuda-checkpoint \
+  https://raw.githubusercontent.com/NVIDIA/cuda-checkpoint/00d5cce84c628088d6caa203fc4af40c1538b6f7/bin/x86_64_Linux/cuda-checkpoint
+sudo chmod +x /usr/local/bin/cuda-checkpoint
+```
+
+**Or run the published container image** (self-contained: agent + `cuda-checkpoint`):
+```bash
+docker run -d --name snapshot-agent \
+  --privileged --pid=host --gpus all \
+  -p 9001:9001 \
+  ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/snapshot-agent:latest
+```
+
+`--pid=host` is required: standalone mode targets host PIDs, so the agent must
+share the host PID namespace to checkpoint them.
+
 ### Starting the Agent
 
-By default, the agent starts in standalone mode on port `9001`:
+By default, the agent starts in standalone mode on port `9001`. Run it as root
+(or as the same user as the workloads) — `cuda-checkpoint` toggles the CUDA
+state of other processes:
 ```bash
-# Run the binary
-./snapshot-agent-linux
+sudo ./bin/snapshot-agent
 
-# Or explicitly set the port and mode:
-./snapshot-agent-linux -deployment-mode=standalone -port=9001
+# Or explicitly set the port and mode (also settable via the AGENT_PORT and
+# DEPLOYMENT_MODE environment variables):
+sudo ./bin/snapshot-agent -deployment-mode=standalone -port=9001
 ```
 
 ### Triggering a Snapshot (with PIDs)

--- a/guides/snapshot-agent/README.md
+++ b/guides/snapshot-agent/README.md
@@ -37,8 +37,7 @@ By default, the agent starts in standalone mode on port `9001`:
 ```bash
 sudo env PATH="$PWD/bin:$PATH" ./bin/snapshot-agent
 
-# Or explicitly set the port and mode (also settable via the AGENT_PORT and
-# DEPLOYMENT_MODE environment variables):
+# Or explicitly set the port and mode:
 sudo env PATH="$PWD/bin:$PATH" ./bin/snapshot-agent -deployment-mode=standalone -port=9001
 ```
 


### PR DESCRIPTION
## Summary

The standalone section of the guide assumed a prebuilt `./snapshot-agent-linux` binary. This documents and streamlines the install:

- `make standalone`: builds `bin/snapshot-agent` and fetches the pinned `cuda-checkpoint` binary into `bin/` — no manual download; same pinned commit the container images bundle.
- Guide documents both install paths: source via `make standalone`, or the published container image.

## Testing

Docs + a Makefile download target.