### PR TITLE
snapshot-agent: honor AGENT_PORT from the environment

### DIFF
--- a/cmd/snapshot-agent/main.go
+++ b/cmd/snapshot-agent/main.go
@@ -19,6 +19,7 @@ import (
 	"flag"
 	"log/slog"
 	"os"
+	"strconv"
 
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/logging"
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/backends"
@@ -40,6 +41,18 @@ func main() {
 		depMode = envDepMode
 	}
 
+	// AGENT_PORT overrides the flag, mirroring DEPLOYMENT_MODE: the Helm
+	// chart configures the agent through env vars, not flags.
+	listenPort := *port
+	if envPort := os.Getenv("AGENT_PORT"); envPort != "" {
+		p, err := strconv.Atoi(envPort)
+		if err != nil {
+			slog.Error("Invalid AGENT_PORT", "value", envPort, "error", err)
+			os.Exit(1)
+		}
+		listenPort = p
+	}
+
 	if depMode != "standalone" && depMode != "k8s" {
 		slog.Error("Invalid deployment mode, must be 'standalone' or 'k8s'", "mode", depMode)
 		os.Exit(1)
@@ -52,8 +65,8 @@ func main() {
 		backends.BackendAppEndpoint: backends.NewAppEndpointBackend(),
 	}
 
-	slog.InfoContext(ctx, "Starting Snapshot Agent", "port", *port, "deploymentMode", depMode)
-	if err := server.StartServer(ctx, *port, registeredBackends, backends.BackendCuda, depMode); err != nil {
+	slog.InfoContext(ctx, "Starting Snapshot Agent", "port", listenPort, "deploymentMode", depMode)
+	if err := server.StartServer(ctx, listenPort, registeredBackends, backends.BackendCuda, depMode); err != nil {
 		slog.ErrorContext(ctx, "Failed to start server", "error", err)
 		os.Exit(1)
 	}

--- a/guides/snapshot-agent/README.md
+++ b/guides/snapshot-agent/README.md
@@ -37,7 +37,8 @@ By default, the agent starts in standalone mode on port `9001`:
 ```bash
 sudo env PATH="$PWD/bin:$PATH" ./bin/snapshot-agent
 
-# Or explicitly set the port and mode:
+# Or explicitly set the port and mode (also settable via the AGENT_PORT and
+# DEPLOYMENT_MODE environment variables):
 sudo env PATH="$PWD/bin:$PATH" ./bin/snapshot-agent -deployment-mode=standalone -port=9001
 ```
 


### PR DESCRIPTION
## Summary

The Helm chart configures the agent through env vars — it sets `AGENT_PORT` from `.Values.port` — but the binary only read its `-port` flag, so `.Values.port` was silently ignored (the agent always bound 9001). Honor `AGENT_PORT`, mirroring the existing `DEPLOYMENT_MODE` override, and note the env overrides in the standalone guide's start section.

Found by the chart integration tests (#119).

Stacked on #121; retarget to `main` after it merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for overriding the snapshot agent’s listening port via the `AGENT_PORT` environment variable (takes precedence over the `-port` flag).
  * Invalid `AGENT_PORT` values are logged and will stop the service from starting.

* **Documentation**
  * Updated standalone run instructions to clarify how to explicitly set the port and deployment mode, including configuration via `AGENT_PORT` and `DEPLOYMENT_MODE`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->