### PR TITLE
tests: composed orchestrator integration suite against both official charts

### DIFF
--- a/deploy/timesliceorchestrator/templates/deployment.yaml
+++ b/deploy/timesliceorchestrator/templates/deployment.yaml
@@ -20,6 +20,8 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - "--snapshot-agent-port={{ .Values.snapshotAgentPort }}"
           ports:
             - name: grpc
               containerPort: 50051

--- a/deploy/timesliceorchestrator/values.yaml
+++ b/deploy/timesliceorchestrator/values.yaml
@@ -9,6 +9,8 @@ service:
   type: ClusterIP
   port: 50051
 
+snapshotAgentPort: 9001
+
 resources: {}
   # limits:
   #   cpu: 100m

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -14,9 +14,9 @@ Tests snapshot-agent backends in standalone and k8s modes. The Go harness deploy
 
 ### orchestrator (phase: orchestrator)
 
-Composed orchestrator integration suite. Installs BOTH official Helm charts (snapshot-agent + timeslice-orchestrator) on `TEST_NODE` and drives real orchestrator scenarios through the gRPC API. The orchestrator chart is configured with `snapshotAgentPort` matching `CHART_AGENT_PORT` so it commands the suite's own agent.
+Composed orchestrator integration suite. Installs BOTH official Helm charts (snapshot-agent + timeslice-orchestrator) and drives real orchestrator scenarios through the gRPC API. The orchestrator chart is configured with `snapshotAgentPort` matching `CHART_AGENT_PORT` so it commands the suite's own agent.
 
-The suite labels `TEST_NODE` with dedicated integration groups (`integ-samplers`, `integ-trainers`) so scenario workloads do not interfere with unrelated production groups on shared clusters.
+Uses a 2-node topology: `TEST_NODE_SAMPLERS` for the samplers group, `TEST_NODE_TRAINERS` for the trainers group (one GPU per node, separate nodes). `exclusiveLabel` temporarily removes group labels from other nodes so pods land only on the designated test nodes.
 
 ## Layout
 
@@ -70,12 +70,14 @@ so no commit or merge is needed at any layer:
 TEST_NODE=<gpu-node> ./tests/integration/run.sh \
   --build --project <gcp-project>
 
-# orchestrator phase only:
-TEST_NODE=<gpu-node> ./tests/integration/run.sh \
+# orchestrator phase only (2 GPU nodes, one per group):
+TEST_NODE_SAMPLERS=<gpu-node-1> TEST_NODE_TRAINERS=<gpu-node-2> \
+  ./tests/integration/run.sh \
   --build --project <gcp-project> --phase orchestrator
 
-# everything:
-TEST_NODE=<gpu-node> ./tests/integration/run.sh \
+# everything (standalone + k8s on TEST_NODE, orchestrator on the 2-node topology):
+TEST_NODE=<gpu-node> TEST_NODE_SAMPLERS=<gpu-node-1> TEST_NODE_TRAINERS=<gpu-node-2> \
+  ./tests/integration/run.sh \
   --build --project <gcp-project> --phase all
 ```
 
@@ -86,7 +88,8 @@ caches).
 Alternative (pre-built images -- any registry the cluster can pull from):
 
 ```bash
-TEST_NODE=<gpu-node> ./tests/integration/run.sh \
+TEST_NODE=<gpu-node> TEST_NODE_SAMPLERS=<gpu-node-1> TEST_NODE_TRAINERS=<gpu-node-2> \
+  ./tests/integration/run.sh \
   --agent-image gcr.io/<project>/snapshot-agent:dev \
   --orch-image gcr.io/<project>/timesliceorchestrator:dev \
   --phase all
@@ -116,11 +119,15 @@ TEST_NODE=<gpu-node> ./tests/integration/run.sh \
 
 Environment:
 
-- `TEST_NODE=<node-name>` -- required for the k8s and orchestrator phases
+- `TEST_NODE=<node-name>` -- required for the standalone and k8s phases
   (charts are pinned to this node); for the standalone phase it pins the
   suite instead of the default pick (first node with a free GPU). Use the
   pin when the cluster runs workloads that occupy GPUs without requesting
   them (time-slicing experiments), which the default pick cannot see.
+- `TEST_NODE_SAMPLERS=<node-name>` -- required for the orchestrator phase.
+  GPU node for the samplers group (must be different from `TEST_NODE_TRAINERS`).
+- `TEST_NODE_TRAINERS=<node-name>` -- required for the orchestrator phase.
+  GPU node for the trainers group (must be different from `TEST_NODE_SAMPLERS`).
 - `CHART_AGENT_PORT=<port>` -- port for the chart-deployed agent (default
   9002), so the suite can coexist with an unrelated agent on the default
   port (the chart runs on hostNetwork). The orchestrator chart is

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,21 +1,36 @@
 # Integration Tests
 
-End-to-end tests for snapshot-agent backends on real GPU hardware, in k8s and standalone modes, exercising the Helm chart and Makefile deployment paths respectively.
+End-to-end tests for the time-slicing stack on real GPU hardware, exercising the official Helm chart deployment paths.
 
-The test suite is written in Go and runs inside the cluster: `run.sh` deploys a test-runner pod, copies the repo source into it, and executes `go test` there. The Go harness deploys the snapshot-agent and inference engine pods itself — one engine at a time, so a single free GPU is enough.
+The test suite is written in Go and runs inside the cluster: `run.sh` deploys a test-runner pod, copies the repo source into it, and executes `go test` there.
 
-All snapshot/restore calls go through the **Python client** (`timeslice.snapshot_agent`, invoked via `agentctl.py`), so the entire client layer is covered.
+## Suites
 
-- `run.sh` — launcher (build image, install chart fixture, deploy runner, copy source, build `make standalone`, install the Python client, `go test`, cleanup)
-- `runner.yaml` — test-runner pod + RBAC
-- `harness/` — shared framework: in-cluster client, node selection, pod lifecycle, exec/HTTP/VRAM helpers
-- `snapshot-agent/` — the agent suite: `standalone_test.go` / `k8s_test.go`, plus the agent specifics (`harness.go` agent deployment, `engines.go` engine specs, `agentctl.py` — a thin CLI over the Python client that builds `BackendConfig` protos from primitive flags)
+### snapshot-agent (phases: standalone, k8s)
 
-**How the standalone mode for snapshot-agent works:** since the test suite runs inside a GKE cluster, standalone mode is simulated by deploying a privileged pod with `hostPID` and `hostNetwork` on the test node. The `make standalone` artifacts are built in the test runner and copied into this pod, which then runs the agent binary with the same GPU and PID namespace access as a host process. Long-term, standalone tests will run on an actual GPU VM.
+Tests snapshot-agent backends in standalone and k8s modes. The Go harness deploys the snapshot-agent and inference engine pods itself -- one engine at a time, so a single free GPU is enough. All snapshot/restore calls go through the **Python client** (`timeslice.snapshot_agent`, invoked via `agentctl.py`), so the entire client layer is covered.
+
+**How the standalone mode works:** since the test suite runs inside a GKE cluster, standalone mode is simulated by deploying a privileged pod with `hostPID` and `hostNetwork` on the test node. The `make standalone` artifacts are built in the test runner and copied into this pod, which then runs the agent binary with the same GPU and PID namespace access as a host process.
+
+### orchestrator (phase: orchestrator)
+
+Composed orchestrator integration suite. Installs BOTH official Helm charts (snapshot-agent + timeslice-orchestrator) on `TEST_NODE` and drives real orchestrator scenarios through the gRPC API. The orchestrator chart is configured with `snapshotAgentPort` matching `CHART_AGENT_PORT` so it commands the suite's own agent.
+
+The suite labels `TEST_NODE` with dedicated integration groups (`integ-samplers`, `integ-trainers`) so scenario workloads do not interfere with unrelated production groups on shared clusters.
+
+## Layout
+
+- `run.sh` -- launcher (build images, install chart fixtures, deploy runner, copy source, build `make standalone`, install the Python client, `go test`, cleanup)
+- `runner.yaml` -- test-runner pod + RBAC
+- `harness/` -- shared framework: in-cluster client, node selection, pod lifecycle, exec/HTTP/VRAM helpers
+- `snapshot-agent/` -- the agent suite: `standalone_test.go` / `k8s_test.go`, plus the agent specifics (`harness.go` agent deployment, `engines.go` engine specs, `agentctl.py`)
+- `orchestrator/` -- the orchestrator suite: `orchestrator_test.go` / `harness.go`
+- `orchestrator/scenarios/` -- scenario drivers shared by both the simulate tier (unit tests) and the composed suite
+- `orchestrator/simulate/` -- fakes tier: in-process orchestrator with fake K8s, runs on every PR
 
 ## Adding a test
 
-Add a `t.Run(...)` inside the engine group that provides the pods it needs, using the harness helpers:
+**snapshot-agent:** Add a `t.Run(...)` inside the engine group that provides the pods it needs, using the harness helpers:
 
 ```go
 h.WithEngine(t, VLLM, func(t *testing.T, e *Engine) {
@@ -31,75 +46,85 @@ h.WithEngine(t, VLLM, func(t *testing.T, e *Engine) {
 
 A new engine is an `EngineSpec` in `snapshot-agent/engines.go`.
 
+**orchestrator:** Add a scenario to `orchestrator/scenarios/` and call it from the `TestOrchestrator` function in `orchestrator/orchestrator_test.go`.
+
 ## Prerequisites
 
 - A GKE cluster with at least 1 free GPU
 - `gcloud` and `kubectl` on the machine running the tests
   (Go and everything else run inside the cluster)
-- For the k8s phase: a snapshot-agent image built from the official
-  Dockerfile (`--build` does this for you; `cloudbuild-image.yaml` defaults
-  to `docker/snapshot-agent/Dockerfile`). The standalone phase needs no
-  image — it builds the agent from source in the test runner.
+- For the k8s/orchestrator phases: images built from the official
+  Dockerfiles (`--build` does this for you). The standalone phase needs no
+  image -- it builds the agent from source in the test runner.
 - Cloud Build API enabled (`gcloud services enable cloudbuild.googleapis.com`)
   and permission to push to the project's registry; GKE nodes in the same
   project can pull from `gcr.io/<project>` by default.
 
 ## Testing your changes
 
-Everything runs from your working directory — uncommitted changes included —
+Everything runs from your working directory -- uncommitted changes included --
 so no commit or merge is needed at any layer:
 
 ```bash
+# snapshot-agent phases (standalone + k8s):
 TEST_NODE=<gpu-node> ./tests/integration/run.sh \
   --build --project <gcp-project>
+
+# orchestrator phase only:
+TEST_NODE=<gpu-node> ./tests/integration/run.sh \
+  --build --project <gcp-project> --phase orchestrator
+
+# everything:
+TEST_NODE=<gpu-node> ./tests/integration/run.sh \
+  --build --project <gcp-project> --phase all
 ```
 
-`--build` has Cloud Build produce the agent image from the working directory
+`--build` has Cloud Build produce the images from the working directory
 (tagged `integ-<commit>` so repeated runs don't collide with node image
-caches) and runs both phases against it. `run.sh` then copies the local
-workspace into the cluster, so the standalone phase's `make standalone`
-build, the Helm chart (installed from local `deploy/`), the Python client,
-and the test code all come from the workspace too.
+caches).
 
-Alternative (pre-built image — any registry the cluster can pull from):
+Alternative (pre-built images -- any registry the cluster can pull from):
 
 ```bash
-gcloud builds submit --config=cloudbuild-image.yaml \
-  --substitutions=_IMAGE=gcr.io/<project>/snapshot-agent:dev .
-
 TEST_NODE=<gpu-node> ./tests/integration/run.sh \
-  --agent-image gcr.io/<project>/snapshot-agent:dev
+  --agent-image gcr.io/<project>/snapshot-agent:dev \
+  --orch-image gcr.io/<project>/timesliceorchestrator:dev \
+  --phase all
 ```
 
 ## Options
 
 ```text
---agent-image IMAGE  Snapshot-agent image the k8s phase installs via the
-                     official chart (required for k8s/both unless --build)
---build              Build the agent image from the working directory via
-                     Cloud Build (requires --project); explicit
-                     --agent-image overrides
+--agent-image IMAGE  Snapshot-agent image (required for k8s/orchestrator
+                     unless --build)
+--orch-image IMAGE   Orchestrator image (required for orchestrator unless
+                     --build)
+--build              Build images from the working directory via Cloud Build
+                     (requires --project); explicit --agent-image /
+                     --orch-image overrides
 --project PROJECT    GCP project (required with --build for image pushes;
                      also used by gcloud get-credentials with --cluster)
 --cluster CLUSTER    GKE cluster name (optional; omit to use current
                      kubectl context)
 --zone ZONE          GKE cluster zone (optional)
 --model MODEL        Model to load (default: Qwen/Qwen2.5-0.5B)
---phase PHASE        "standalone", "k8s", or "both" (default)
---skip-cleanup       Leave the test-runner pod and chart fixture running
+--phase PHASE        "standalone", "k8s", "orchestrator", "both" (default,
+                     = standalone+k8s), or "all" (= standalone+k8s+orch)
+--skip-cleanup       Leave the test-runner pod and chart fixtures running
                      for debugging
 ```
 
 Environment:
 
-- `TEST_NODE=<node-name>` — required for the k8s phase (the chart is pinned
-  to this node); for the standalone phase it pins the suite instead of the
-  default pick (first node with a free GPU by requests). Use the pin when
-  the cluster runs workloads that occupy GPUs without requesting them
-  (time-slicing experiments), which the default pick cannot see.
-- `CHART_AGENT_PORT=<port>` — port for the chart-deployed agent (default
-  9001), so the suite can coexist with an unrelated agent on the default
-  port (the chart runs on hostNetwork).
+- `TEST_NODE=<node-name>` -- required for the k8s and orchestrator phases
+  (charts are pinned to this node); for the standalone phase it pins the
+  suite instead of the default pick (first node with a free GPU). Use the
+  pin when the cluster runs workloads that occupy GPUs without requesting
+  them (time-slicing experiments), which the default pick cannot see.
+- `CHART_AGENT_PORT=<port>` -- port for the chart-deployed agent (default
+  9002), so the suite can coexist with an unrelated agent on the default
+  port (the chart runs on hostNetwork). The orchestrator chart is
+  configured with the same port via `snapshotAgentPort`.
 
 ## Exit code
 

--- a/tests/integration/harness/harness.go
+++ b/tests/integration/harness/harness.go
@@ -152,16 +152,18 @@ func (c *Cluster) WaitPodReady(t *testing.T, name string, timeout time.Duration)
 }
 
 // WaitPodReadyByLabel waits for a Ready pod matching labelSelector on the
-// given node in the given namespace and returns its IP. It attaches to pods
-// deployed by something other than the suite (e.g. a Helm chart DaemonSet).
+// given node in the given namespace and returns its IP. If node is empty,
+// any node is accepted. It attaches to pods deployed by something other
+// than the suite (e.g. a Helm chart DaemonSet or Deployment).
 func (c *Cluster) WaitPodReadyByLabel(t *testing.T, namespace, labelSelector, node string, timeout time.Duration) string {
 	t.Helper()
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		pods, err := c.Client.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{
-			LabelSelector: labelSelector,
-			FieldSelector: "spec.nodeName=" + node,
-		})
+		opts := metav1.ListOptions{LabelSelector: labelSelector}
+		if node != "" {
+			opts.FieldSelector = "spec.nodeName=" + node
+		}
+		pods, err := c.Client.CoreV1().Pods(namespace).List(context.Background(), opts)
 		if err == nil {
 			for i := range pods.Items {
 				pod := &pods.Items[i]

--- a/tests/integration/orchestrator/harness.go
+++ b/tests/integration/orchestrator/harness.go
@@ -1,0 +1,210 @@
+//go:build integration
+
+// Package orchestrator_test provides the composed orchestrator integration
+// suite harness. It attaches to chart-deployed orchestrator and snapshot-agent
+// instances (installed by run.sh), sets up dedicated integration test groups
+// (integ-samplers, integ-trainers) on TEST_NODE, and provides workload hooks
+// and assertion helpers.
+//
+// Like the snapshot-agent harness, everything runs INSIDE the cluster from
+// the test-runner pod.
+package orchestrator_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/tests/integration/harness"
+)
+
+const (
+	// integSamplers and integTrainers are the group labels the suite applies
+	// to TEST_NODE. The scenario code (scenarios/) hardcodes these group IDs
+	// in its Acquire/Yield calls and node lookups, so they must match.
+	// Safety on shared clusters comes from labeling ONLY TEST_NODE, not from
+	// using distinct group names (the preflight check in run.sh ensures
+	// TEST_NODE is set).
+	integSamplers = "samplers"
+	integTrainers = "trainers"
+
+	// chartNamespace is where the official Helm charts install components.
+	chartNamespace = "timeslice-system"
+
+	orchPodTimeout = 5 * time.Minute
+)
+
+// ComposedHarness manages the composed orchestrator + snapshot-agent test
+// stack. Both components are deployed by run.sh via their official Helm
+// charts; this harness attaches to them and sets up the test environment.
+type ComposedHarness struct {
+	*harness.Cluster
+	Node     string
+	OrchAddr string // host:port of the orchestrator gRPC service
+}
+
+// NewComposedHarness connects to the cluster, attaches to the chart-deployed
+// orchestrator (via its ClusterIP Service) and snapshot-agent, labels
+// TEST_NODE with the integration test groups, and registers cleanup.
+func NewComposedHarness(t *testing.T) *ComposedHarness {
+	t.Helper()
+
+	node := harness.RequiredNode(t)
+	c := harness.NewCluster(t, "default")
+
+	h := &ComposedHarness{
+		Cluster: c,
+		Node:    node,
+	}
+
+	// Resolve the orchestrator Service address. The chart creates a
+	// ClusterIP Service in timeslice-system; run.sh installs it as
+	// "orch-chart-test".
+	orchPort := 50051
+	if p := os.Getenv("ORCH_PORT"); p != "" {
+		port, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid ORCH_PORT %q: %v", p, err)
+		}
+		orchPort = port
+	}
+	h.OrchAddr = fmt.Sprintf("orch-chart-test.%s.svc.cluster.local:%d", chartNamespace, orchPort)
+
+	// Wait for the orchestrator pod to be Ready.
+	orchSelector := "app.kubernetes.io/name=timesliceorchestrator,app.kubernetes.io/instance=orch-chart-test"
+	h.WaitPodReadyByLabel(t, chartNamespace, orchSelector, "", orchPodTimeout)
+	t.Logf("orchestrator chart pod ready, reachable at %s", h.OrchAddr)
+
+	// Wait for the snapshot-agent chart pod to be Ready on TEST_NODE.
+	saSelector := "app.kubernetes.io/name=snapshot-agent,app.kubernetes.io/instance=sa-chart-test"
+	agentIP := h.WaitPodReadyByLabel(t, chartNamespace, saSelector, node, orchPodTimeout)
+	agentPort := 9001
+	if p := os.Getenv("CHART_AGENT_PORT"); p != "" {
+		port, err := strconv.Atoi(p)
+		if err != nil {
+			t.Fatalf("invalid CHART_AGENT_PORT %q: %v", p, err)
+		}
+		agentPort = port
+	}
+	t.Logf("snapshot-agent chart pod ready at %s:%d on %s", agentIP, agentPort, node)
+
+	// Ensure TEST_NODE is the ONLY node with these group labels so the
+	// scheduler pins scenario pods there. Other nodes (e.g. a production
+	// timeslice release) may carry the same labels; temporarily remove
+	// them for the test and restore on cleanup.
+	for _, group := range []string{integSamplers, integTrainers} {
+		h.exclusiveLabel(t, node, group)
+	}
+
+	// Pre-clean: remove any leaked pods from a previous failed run.
+	h.cleanLeakedPods(t)
+
+	return h
+}
+
+// exclusiveLabel ensures TEST_NODE is the ONLY node with the given group
+// label: it removes the label from all other nodes (restoring on cleanup)
+// and adds it to TEST_NODE (removing on cleanup).
+func (h *ComposedHarness) exclusiveLabel(t *testing.T, testNode, group string) {
+	t.Helper()
+	ctx := context.Background()
+	labelKey := fmt.Sprintf("group.timeslice.io/%s", group)
+
+	nodes, err := h.Client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("listing nodes: %v", err)
+	}
+	for i := range nodes.Items {
+		n := &nodes.Items[i]
+		if n.Name == testNode {
+			continue
+		}
+		if n.Labels[labelKey] != "true" {
+			continue
+		}
+		delete(n.Labels, labelKey)
+		if _, err := h.Client.CoreV1().Nodes().Update(ctx, n, metav1.UpdateOptions{}); err != nil {
+			t.Fatalf("removing label %s from node %s: %v", labelKey, n.Name, err)
+		}
+		t.Logf("temporarily removed label %s from node %s", labelKey, n.Name)
+		nodeName := n.Name
+		t.Cleanup(func() {
+			nn, err := h.Client.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+			if err != nil {
+				t.Logf("WARNING: could not restore label %s on %s: %v", labelKey, nodeName, err)
+				return
+			}
+			nn.Labels[labelKey] = "true"
+			if _, err := h.Client.CoreV1().Nodes().Update(ctx, nn, metav1.UpdateOptions{}); err != nil {
+				t.Logf("WARNING: could not restore label %s on %s: %v", labelKey, nodeName, err)
+			} else {
+				t.Logf("restored label %s on node %s", labelKey, nodeName)
+			}
+		})
+	}
+	h.labelNode(t, testNode, group)
+}
+
+// labelNode adds a group.timeslice.io/<group>=true label to the node and
+// registers cleanup to remove it.
+func (h *ComposedHarness) labelNode(t *testing.T, node, group string) {
+	t.Helper()
+	ctx := context.Background()
+	labelKey := fmt.Sprintf("group.timeslice.io/%s", group)
+
+	n, err := h.Client.CoreV1().Nodes().Get(ctx, node, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("getting node %s: %v", node, err)
+	}
+	if n.Labels == nil {
+		n.Labels = make(map[string]string)
+	}
+	n.Labels[labelKey] = "true"
+	if _, err := h.Client.CoreV1().Nodes().Update(ctx, n, metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("labeling node %s with %s: %v", node, labelKey, err)
+	}
+	t.Logf("labeled node %s: %s=true", node, labelKey)
+
+	t.Cleanup(func() {
+		n, err := h.Client.CoreV1().Nodes().Get(ctx, node, metav1.GetOptions{})
+		if err != nil {
+			t.Logf("WARNING: could not get node %s for label cleanup: %v", node, err)
+			return
+		}
+		delete(n.Labels, labelKey)
+		if _, err := h.Client.CoreV1().Nodes().Update(ctx, n, metav1.UpdateOptions{}); err != nil {
+			t.Logf("WARNING: could not remove label %s from node %s: %v", labelKey, node, err)
+		} else {
+			t.Logf("removed label %s from node %s", labelKey, node)
+		}
+	})
+}
+
+// cleanLeakedPods deletes any pods from a previous failed run that carry the
+// timeslice.io/group label in the default namespace.
+func (h *ComposedHarness) cleanLeakedPods(t *testing.T) {
+	t.Helper()
+	ctx := context.Background()
+	for _, group := range []string{integSamplers, integTrainers} {
+		pods, err := h.Client.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
+			LabelSelector: fmt.Sprintf("timeslice.io/group=%s", group),
+		})
+		if err != nil {
+			t.Logf("WARNING: listing leaked pods for group %s: %v", group, err)
+			continue
+		}
+		for i := range pods.Items {
+			name := pods.Items[i].Name
+			if err := h.Client.CoreV1().Pods("default").Delete(ctx, name, metav1.DeleteOptions{}); err != nil {
+				t.Logf("WARNING: deleting leaked pod %s: %v", name, err)
+			} else {
+				t.Logf("cleaned leaked pod %s", name)
+			}
+		}
+	}
+}

--- a/tests/integration/orchestrator/harness.go
+++ b/tests/integration/orchestrator/harness.go
@@ -42,29 +42,44 @@ const (
 // ComposedHarness manages the composed orchestrator + snapshot-agent test
 // stack. Both components are deployed by run.sh via their official Helm
 // charts; this harness attaches to them and sets up the test environment.
+//
+// The canonical topology uses separate nodes for each group (one GPU per
+// node): TEST_NODE_SAMPLERS for the samplers group, TEST_NODE_TRAINERS
+// for the trainers group.
 type ComposedHarness struct {
 	*harness.Cluster
-	Node     string
-	OrchAddr string // host:port of the orchestrator gRPC service
+	SamplerNode string
+	TrainerNode string
+	OrchAddr    string // host:port of the orchestrator gRPC service
 }
 
 // NewComposedHarness connects to the cluster, attaches to the chart-deployed
-// orchestrator (via its ClusterIP Service) and snapshot-agent, labels
-// TEST_NODE with the integration test groups, and registers cleanup.
+// orchestrator (via its ClusterIP Service) and snapshot-agent, labels the
+// group nodes, and registers cleanup.
+//
+// Requires TEST_NODE_SAMPLERS and TEST_NODE_TRAINERS (separate GPU nodes,
+// one per group — the canonical deployment topology).
 func NewComposedHarness(t *testing.T) *ComposedHarness {
 	t.Helper()
 
-	node := harness.RequiredNode(t)
+	samplerNode := os.Getenv("TEST_NODE_SAMPLERS")
+	trainerNode := os.Getenv("TEST_NODE_TRAINERS")
+	if samplerNode == "" || trainerNode == "" {
+		t.Fatal("TEST_NODE_SAMPLERS and TEST_NODE_TRAINERS are required (one GPU node per group)")
+	}
+	if samplerNode == trainerNode {
+		t.Fatal("TEST_NODE_SAMPLERS and TEST_NODE_TRAINERS must be different nodes")
+	}
+
 	c := harness.NewCluster(t, "default")
 
 	h := &ComposedHarness{
-		Cluster: c,
-		Node:    node,
+		Cluster:     c,
+		SamplerNode: samplerNode,
+		TrainerNode: trainerNode,
 	}
 
-	// Resolve the orchestrator Service address. The chart creates a
-	// ClusterIP Service in timeslice-system; run.sh installs it as
-	// "orch-chart-test".
+	// Resolve the orchestrator Service address.
 	orchPort := 50051
 	if p := os.Getenv("ORCH_PORT"); p != "" {
 		port, err := strconv.Atoi(p)
@@ -80,9 +95,8 @@ func NewComposedHarness(t *testing.T) *ComposedHarness {
 	h.WaitPodReadyByLabel(t, chartNamespace, orchSelector, "", orchPodTimeout)
 	t.Logf("orchestrator chart pod ready, reachable at %s", h.OrchAddr)
 
-	// Wait for the snapshot-agent chart pod to be Ready on TEST_NODE.
+	// Wait for snapshot-agent chart pods to be Ready on BOTH group nodes.
 	saSelector := "app.kubernetes.io/name=snapshot-agent,app.kubernetes.io/instance=sa-chart-test"
-	agentIP := h.WaitPodReadyByLabel(t, chartNamespace, saSelector, node, orchPodTimeout)
 	agentPort := 9001
 	if p := os.Getenv("CHART_AGENT_PORT"); p != "" {
 		port, err := strconv.Atoi(p)
@@ -91,15 +105,14 @@ func NewComposedHarness(t *testing.T) *ComposedHarness {
 		}
 		agentPort = port
 	}
-	t.Logf("snapshot-agent chart pod ready at %s:%d on %s", agentIP, agentPort, node)
-
-	// Ensure TEST_NODE is the ONLY node with these group labels so the
-	// scheduler pins scenario pods there. Other nodes (e.g. a production
-	// timeslice release) may carry the same labels; temporarily remove
-	// them for the test and restore on cleanup.
-	for _, group := range []string{integSamplers, integTrainers} {
-		h.exclusiveLabel(t, node, group)
+	for _, node := range []string{samplerNode, trainerNode} {
+		ip := h.WaitPodReadyByLabel(t, chartNamespace, saSelector, node, orchPodTimeout)
+		t.Logf("snapshot-agent chart pod ready at %s:%d on %s", ip, agentPort, node)
 	}
+
+	// Label each group node exclusively.
+	h.exclusiveLabel(t, samplerNode, integSamplers)
+	h.exclusiveLabel(t, trainerNode, integTrainers)
 
 	// Pre-clean: remove any leaked pods from a previous failed run.
 	h.cleanLeakedPods(t)

--- a/tests/integration/orchestrator/orchestrator_test.go
+++ b/tests/integration/orchestrator/orchestrator_test.go
@@ -51,8 +51,8 @@ func TestOrchestrator(t *testing.T) {
 			h.Client,
 			client,
 			t,
-			"vllm",  // sampler template key
-			"vllm",  // trainer template key
+			"",  // sampler template key (default: PyTorch GPU burner)
+			"",  // trainer template key (default: PyTorch GPU burner)
 		)
 		if err != nil {
 			t.Fatalf("SingleRLJob scenario failed: %v", err)
@@ -79,8 +79,8 @@ func TestOrchestrator(t *testing.T) {
 			h.Client,
 			client,
 			t,
-			"vllm",  // sampler template key
-			"vllm",  // trainer template key
+			"",  // sampler template key (default: PyTorch GPU burner)
+			"",  // trainer template key (default: PyTorch GPU burner)
 		)
 		if err != nil {
 			t.Fatalf("QueuedRLJobs scenario failed: %v", err)

--- a/tests/integration/orchestrator/orchestrator_test.go
+++ b/tests/integration/orchestrator/orchestrator_test.go
@@ -1,0 +1,89 @@
+//go:build integration
+
+package orchestrator_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/timeslice-orchestrator/api/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/tests/integration/orchestrator/scenarios"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// TestOrchestrator is the composed orchestrator integration suite. It runs
+// against BOTH official Helm charts deployed by run.sh (snapshot-agent +
+// timeslice-orchestrator) on a real cluster with real GPU workloads.
+//
+// The orchestrator chart is installed with snapshotAgentPort matching
+// CHART_AGENT_PORT so it commands the suite's own agent, not whatever
+// might be running on the default port on a shared node.
+//
+// Scenario workloads deploy pods into dedicated integration test groups
+// (integ-samplers, integ-trainers) labeled only on TEST_NODE.
+func TestOrchestrator(t *testing.T) {
+	if os.Getenv("ORCH_CHART_DEPLOYED") == "" {
+		t.Skip("requires chart-deployed orchestrator (run.sh --phase orchestrator)")
+	}
+
+	h := NewComposedHarness(t)
+
+	t.Run("SingleRLJob", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+
+		conn, err := grpc.NewClient(
+			h.OrchAddr,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err != nil {
+			t.Fatalf("dialing orchestrator at %s: %v", h.OrchAddr, err)
+		}
+		defer conn.Close()
+
+		client := pb.NewTimeSliceOrchestratorServiceClient(conn)
+
+		err = scenarios.RunSingleRLJobScenario(
+			ctx,
+			h.Client,
+			client,
+			t,
+			"vllm",  // sampler template key
+			"vllm",  // trainer template key
+		)
+		if err != nil {
+			t.Fatalf("SingleRLJob scenario failed: %v", err)
+		}
+	})
+
+	t.Run("QueuedRLJobs", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+		defer cancel()
+
+		conn, err := grpc.NewClient(
+			h.OrchAddr,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err != nil {
+			t.Fatalf("dialing orchestrator at %s: %v", h.OrchAddr, err)
+		}
+		defer conn.Close()
+
+		client := pb.NewTimeSliceOrchestratorServiceClient(conn)
+
+		err = scenarios.RunQueuedRLJobsScenario(
+			ctx,
+			h.Client,
+			client,
+			t,
+			"vllm",  // sampler template key
+			"vllm",  // trainer template key
+		)
+		if err != nil {
+			t.Fatalf("QueuedRLJobs scenario failed: %v", err)
+		}
+	})
+}

--- a/tests/integration/orchestrator/scenarios/fake_rl_job.go
+++ b/tests/integration/orchestrator/scenarios/fake_rl_job.go
@@ -418,9 +418,10 @@ func (f *FakeRLJob) cleanupPods(ctx context.Context) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	// 1. Delete Pods
+	// 1. Delete Pods (force-delete so they vanish immediately)
+	zero := int64(0)
 	for _, podName := range f.createdPods {
-		err := f.clientset.CoreV1().Pods("default").Delete(ctx, podName, metav1.DeleteOptions{})
+		err := f.clientset.CoreV1().Pods("default").Delete(ctx, podName, metav1.DeleteOptions{GracePeriodSeconds: &zero})
 		if err != nil {
 			if !k8serrors.IsNotFound(err) {
 				f.t.Errorf("[Job %s] Failed to delete pod %s: %v", f.name, podName, err)

--- a/tests/integration/orchestrator/scenarios/scenarios.go
+++ b/tests/integration/orchestrator/scenarios/scenarios.go
@@ -83,7 +83,7 @@ func RunSingleRLJobScenario(
 	}
 
 	// Verify Post-Cleanup State: All pods created by this job should be deleted
-	err := wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+	err := wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		pods, err := clientset.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
 			LabelSelector: "timeslice.io/job-id=my-rl-job",
 		})
@@ -248,7 +248,7 @@ func RunQueuedRLJobsScenario(
 	}
 
 	// Verify Post-Cleanup State (only pods for these jobs)
-	err = wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+	err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
 		pods, err := clientset.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
 			LabelSelector: "timeslice.io/job-id in (job-a, job-b)",
 		})

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -56,7 +56,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 usage() {
-  echo "Usage: $0 [--agent-image IMAGE] [--orch-image IMAGE] [--build --project PROJECT] [--cluster CLUSTER --zone ZONE] [--model MODEL] [--phase standalone|k8s|orchestrator|all]"
+  echo "Usage: $0 [--agent-image IMAGE] [--orch-image IMAGE] [--build --project PROJECT] [--cluster CLUSTER --zone ZONE] [--model MODEL] [--phase standalone|k8s|both|orchestrator|all]"
   echo ""
   echo "  --cluster/--zone/--project are optional; omit them to use your current kubectl context."
   echo "  --project is required with --build (Cloud Build needs it for the image registry)."

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
-# Launcher for the snapshot-agent integration tests — the single entrypoint
-# (--phase both runs standalone + k8s).
+# Launcher for the integration test suites — the single entrypoint.
 #
 # Phases and their fixtures — each one a REAL install path:
 #   standalone    TestStandalone against the `make standalone` artifacts
 #                 (built in-cluster in the test-runner pod, run from a plain
 #                 Debian base — the chart has no standalone mode)
 #   k8s           TestK8s against the OFFICIAL snapshot-agent Helm chart
-#   both          both of the above
+#   orchestrator  TestOrchestrator against BOTH official Helm charts
+#                 (snapshot-agent + timeslice-orchestrator), driving real
+#                 scenario workloads through the orchestrator's gRPC API
+#   all           all of the above
 #
 # The test suite itself is written in Go (see *_test.go) and runs INSIDE the
-# cluster: this script installs the chart fixture, deploys the test-runner
+# cluster: this script installs the chart fixture(s), deploys the test-runner
 # pod, copies the repo source into it, and executes `go test` there. The Go
 # harness deploys engine pods itself, one engine at a time, so a single free
 # GPU is enough.
@@ -23,6 +25,7 @@ K="${KUBECTL:-kubectl}"
 HELM="${HELM:-helm}"
 
 AGENT_IMAGE=""
+ORCH_IMAGE=""
 PROJECT=""
 CLUSTER=""
 ZONE=""
@@ -32,13 +35,15 @@ BUILD=false
 SKIP_CLEANUP=false
 NEED_STANDALONE=false
 NEED_SA_CHART=false
+NEED_ORCH_CHART=false
 # CHART_AGENT_PORT lets the chart-deployed agent bind a non-default port so
 # the suite can coexist with an unrelated agent on 9001 (hostNetwork).
-CHART_AGENT_PORT="${CHART_AGENT_PORT:-9001}"
+CHART_AGENT_PORT="${CHART_AGENT_PORT:-9002}"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
     --agent-image)  AGENT_IMAGE="$2"; shift 2 ;;
+    --orch-image)   ORCH_IMAGE="$2"; shift 2 ;;
     --build)        BUILD=true; shift ;;
     --project)      PROJECT="$2"; shift 2 ;;
     --cluster)      CLUSTER="$2"; shift 2 ;;
@@ -51,17 +56,20 @@ while [[ $# -gt 0 ]]; do
 done
 
 usage() {
-  echo "Usage: $0 [--agent-image IMAGE | --build --project PROJECT] [--cluster CLUSTER --zone ZONE] [--model MODEL] [--phase standalone|k8s|both]"
+  echo "Usage: $0 [--agent-image IMAGE] [--orch-image IMAGE] [--build --project PROJECT] [--cluster CLUSTER --zone ZONE] [--model MODEL] [--phase standalone|k8s|orchestrator|all]"
   echo ""
   echo "  --cluster/--zone/--project are optional; omit them to use your current kubectl context."
   echo "  --project is required with --build (Cloud Build needs it for the image registry)."
 }
 
 case "$PHASE" in
-  standalone) RUN_PATTERN='^TestStandalone$';         NEED_STANDALONE=true ;;
-  k8s)        RUN_PATTERN='^TestK8s$';                NEED_SA_CHART=true ;;
-  both)       RUN_PATTERN='^(TestStandalone|TestK8s)$'
-              NEED_STANDALONE=true; NEED_SA_CHART=true ;;
+  standalone)   RUN_PATTERN='^TestStandalone$';         NEED_STANDALONE=true ;;
+  k8s)          RUN_PATTERN='^TestK8s$';                NEED_SA_CHART=true ;;
+  both)         RUN_PATTERN='^(TestStandalone|TestK8s)$'
+                NEED_STANDALONE=true; NEED_SA_CHART=true ;;
+  orchestrator) RUN_PATTERN='^TestOrchestrator$';       NEED_SA_CHART=true; NEED_ORCH_CHART=true ;;
+  all)          RUN_PATTERN='^(TestStandalone|TestK8s|TestOrchestrator)$'
+                NEED_STANDALONE=true; NEED_SA_CHART=true; NEED_ORCH_CHART=true ;;
   *) echo "Unknown phase: $PHASE"; usage; exit 1 ;;
 esac
 
@@ -80,12 +88,17 @@ fi
 # The standalone phase needs no image: it builds the agent from source in the
 # test-runner pod (`make standalone`) and runs the artifacts directly.
 if [[ "$NEED_SA_CHART" == "true" && -z "$AGENT_IMAGE" && "$BUILD" != "true" ]]; then
-  echo "Error: --agent-image (or --build) is required for the k8s phase (the snapshot-agent chart installs it)"
+  echo "Error: --agent-image (or --build) is required for the k8s/orchestrator phase (the snapshot-agent chart installs it)"
+  usage
+  exit 1
+fi
+if [[ "$NEED_ORCH_CHART" == "true" && -z "$ORCH_IMAGE" && "$BUILD" != "true" ]]; then
+  echo "Error: --orch-image (or --build) is required for the orchestrator phase (the orchestrator chart installs it)"
   usage
   exit 1
 fi
 if [[ "$NEED_SA_CHART" == "true" && -z "${TEST_NODE:-}" ]]; then
-  echo "Error: TEST_NODE must be set for the k8s phase: the chart is pinned to" \
+  echo "Error: TEST_NODE must be set for the k8s/orchestrator phase: the chart is pinned to" \
        "one node so the suite stays off other workloads on shared clusters"
   exit 1
 fi
@@ -97,6 +110,13 @@ cleanup() {
   log "Cleaning up..."
   $K delete pods -l test-suite=snapshot-agent-integration --force --grace-period=0 2>/dev/null || true
   $K delete -f "${SCRIPT_DIR}/runner.yaml" --force --grace-period=0 2>/dev/null || true
+  if [[ "$NEED_ORCH_CHART" == "true" ]]; then
+    $HELM uninstall orch-chart-test -n timeslice-system 2>/dev/null || true
+    # Remove integration group labels from TEST_NODE (only the ones we added).
+    if [[ -n "${TEST_NODE:-}" ]]; then
+      $K label node "$TEST_NODE" "group.timeslice.io/samplers-" "group.timeslice.io/trainers-" 2>/dev/null || true
+    fi
+  fi
   if [[ "$NEED_SA_CHART" == "true" ]]; then
     $HELM uninstall sa-chart-test -n timeslice-system 2>/dev/null || true
   fi
@@ -147,6 +167,14 @@ if [[ "$BUILD" == "true" && "$NEED_SA_CHART" == "true" && -z "$AGENT_IMAGE" ]]; 
     "$REPO_ROOT"
 fi
 
+if [[ "$BUILD" == "true" && "$NEED_ORCH_CHART" == "true" && -z "$ORCH_IMAGE" ]]; then
+  ORCH_IMAGE="gcr.io/${PROJECT}/timesliceorchestrator:${BUILD_TAG}"
+  log "Building ${ORCH_IMAGE} from the working directory (Cloud Build)..."
+  gcloud builds submit --project "$PROJECT" --config="${REPO_ROOT}/cloudbuild-image.yaml" \
+    --substitutions="_IMAGE=${ORCH_IMAGE},_DOCKERFILE=docker/timesliceorchestrator/Dockerfile" \
+    "$REPO_ROOT"
+fi
+
 if [[ "$NEED_SA_CHART" == "true" ]]; then
   # The chart templates pin their namespace to timeslice-system.
   $K create namespace timeslice-system --dry-run=client -o yaml | $K apply -f -
@@ -162,6 +190,21 @@ if [[ "$NEED_SA_CHART" == "true" ]]; then
   SA_SELECTOR="app.kubernetes.io/name=snapshot-agent,app.kubernetes.io/instance=sa-chart-test"
   log "Waiting for the chart's DaemonSet pod to become Ready on ${TEST_NODE}..."
   wait_chart_pods_ready "$SA_SELECTOR" "$TEST_NODE" || chart_failure "snapshot-agent" "$SA_SELECTOR"
+fi
+
+if [[ "$NEED_ORCH_CHART" == "true" ]]; then
+  $K create namespace timeslice-system --dry-run=client -o yaml | $K apply -f -
+  log "Installing the official orchestrator chart (agent port=${CHART_AGENT_PORT})..."
+  $HELM upgrade --install orch-chart-test "${REPO_ROOT}/deploy/timesliceorchestrator" \
+    -n timeslice-system \
+    --set fullnameOverride=orch-chart-test \
+    --set image.repository="${ORCH_IMAGE%:*}" \
+    --set image.tag="${ORCH_IMAGE##*:}" \
+    --set image.pullPolicy=IfNotPresent \
+    --set snapshotAgentPort="${CHART_AGENT_PORT}"
+  ORCH_SELECTOR="app.kubernetes.io/name=timesliceorchestrator,app.kubernetes.io/instance=orch-chart-test"
+  log "Waiting for the orchestrator Deployment pod to become Ready..."
+  wait_chart_pods_ready "$ORCH_SELECTOR" || chart_failure "orchestrator" "$ORCH_SELECTOR"
 fi
 
 log "Deploying test runner..."
@@ -183,9 +226,12 @@ fi
 log "Running Go test suite in-cluster (this deploys agent + engine pods)..."
 SA_CHART_DEPLOYED=""
 [[ "$NEED_SA_CHART" == "true" ]] && SA_CHART_DEPLOYED=1
+ORCH_CHART_DEPLOYED=""
+[[ "$NEED_ORCH_CHART" == "true" ]] && ORCH_CHART_DEPLOYED=1
 EXIT=0
 $K exec test-runner -- env "MODEL=${MODEL}" "TEST_NODE=${TEST_NODE:-}" \
   "SA_CHART_DEPLOYED=${SA_CHART_DEPLOYED}" \
+  "ORCH_CHART_DEPLOYED=${ORCH_CHART_DEPLOYED}" \
   "CHART_AGENT_PORT=${CHART_AGENT_PORT}" \
   sh -c "cd /workspace && go test -tags=integration -count=1 -v -timeout 40m -run '${RUN_PATTERN}' ./tests/integration/..." \
   || EXIT=$?

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -97,10 +97,17 @@ if [[ "$NEED_ORCH_CHART" == "true" && -z "$ORCH_IMAGE" && "$BUILD" != "true" ]];
   usage
   exit 1
 fi
-if [[ "$NEED_SA_CHART" == "true" && -z "${TEST_NODE:-}" ]]; then
-  echo "Error: TEST_NODE must be set for the k8s/orchestrator phase: the chart is pinned to" \
+if [[ "$NEED_SA_CHART" == "true" && -z "${TEST_NODE:-}" && "$NEED_ORCH_CHART" != "true" ]]; then
+  echo "Error: TEST_NODE must be set for the k8s phase: the chart is pinned to" \
        "one node so the suite stays off other workloads on shared clusters"
   exit 1
+fi
+if [[ "$NEED_ORCH_CHART" == "true" ]]; then
+  if [[ -z "${TEST_NODE_SAMPLERS:-}" || -z "${TEST_NODE_TRAINERS:-}" ]]; then
+    echo "Error: TEST_NODE_SAMPLERS and TEST_NODE_TRAINERS must be set for the orchestrator phase" \
+         "(one GPU node per group — the canonical deployment topology)"
+    exit 1
+  fi
 fi
 
 log() { echo "$(date +%H:%M:%S) $*"; }
@@ -112,9 +119,12 @@ cleanup() {
   $K delete -f "${SCRIPT_DIR}/runner.yaml" --force --grace-period=0 2>/dev/null || true
   if [[ "$NEED_ORCH_CHART" == "true" ]]; then
     $HELM uninstall orch-chart-test -n timeslice-system 2>/dev/null || true
-    # Remove integration group labels from TEST_NODE (only the ones we added).
-    if [[ -n "${TEST_NODE:-}" ]]; then
-      $K label node "$TEST_NODE" "group.timeslice.io/samplers-" "group.timeslice.io/trainers-" 2>/dev/null || true
+    # Remove integration group labels (only the ones we added).
+    if [[ -n "${TEST_NODE_SAMPLERS:-}" ]]; then
+      $K label node "$TEST_NODE_SAMPLERS" "group.timeslice.io/samplers-" 2>/dev/null || true
+    fi
+    if [[ -n "${TEST_NODE_TRAINERS:-}" ]]; then
+      $K label node "$TEST_NODE_TRAINERS" "group.timeslice.io/trainers-" 2>/dev/null || true
     fi
   fi
   if [[ "$NEED_SA_CHART" == "true" ]]; then
@@ -178,18 +188,32 @@ fi
 if [[ "$NEED_SA_CHART" == "true" ]]; then
   # The chart templates pin their namespace to timeslice-system.
   $K create namespace timeslice-system --dry-run=client -o yaml | $K apply -f -
-  log "Installing the official snapshot-agent chart (node ${TEST_NODE}, port ${CHART_AGENT_PORT})..."
-  $HELM upgrade --install sa-chart-test "${REPO_ROOT}/deploy/snapshot-agent" \
-    -n timeslice-system \
-    --set fullnameOverride=sa-chart-test \
-    --set image.repository="${AGENT_IMAGE%:*}" \
-    --set image.tag="${AGENT_IMAGE##*:}" \
-    --set image.pullPolicy=IfNotPresent \
-    --set port="${CHART_AGENT_PORT}" \
-    --set nodeSelector."kubernetes\.io/hostname"="${TEST_NODE}"
-  SA_SELECTOR="app.kubernetes.io/name=snapshot-agent,app.kubernetes.io/instance=sa-chart-test"
-  log "Waiting for the chart's DaemonSet pod to become Ready on ${TEST_NODE}..."
-  wait_chart_pods_ready "$SA_SELECTOR" "$TEST_NODE" || chart_failure "snapshot-agent" "$SA_SELECTOR"
+  SA_HELM_ARGS=(
+    -n timeslice-system
+    --set fullnameOverride=sa-chart-test
+    --set image.repository="${AGENT_IMAGE%:*}"
+    --set image.tag="${AGENT_IMAGE##*:}"
+    --set image.pullPolicy=IfNotPresent
+    --set port="${CHART_AGENT_PORT}"
+  )
+  if [[ "$NEED_ORCH_CHART" == "true" ]]; then
+    # Orchestrator phase: SA DaemonSet must land on both group nodes (no nodeSelector pin).
+    log "Installing the official snapshot-agent chart (both group nodes, port ${CHART_AGENT_PORT})..."
+    $HELM upgrade --install sa-chart-test "${REPO_ROOT}/deploy/snapshot-agent" "${SA_HELM_ARGS[@]}"
+    SA_SELECTOR="app.kubernetes.io/name=snapshot-agent,app.kubernetes.io/instance=sa-chart-test"
+    for NODE in "$TEST_NODE_SAMPLERS" "$TEST_NODE_TRAINERS"; do
+      log "Waiting for the chart's DaemonSet pod to become Ready on ${NODE}..."
+      wait_chart_pods_ready "$SA_SELECTOR" "$NODE" || chart_failure "snapshot-agent" "$SA_SELECTOR"
+    done
+  else
+    # k8s phase: single-node pin.
+    log "Installing the official snapshot-agent chart (node ${TEST_NODE}, port ${CHART_AGENT_PORT})..."
+    $HELM upgrade --install sa-chart-test "${REPO_ROOT}/deploy/snapshot-agent" "${SA_HELM_ARGS[@]}" \
+      --set nodeSelector."kubernetes\.io/hostname"="${TEST_NODE}"
+    SA_SELECTOR="app.kubernetes.io/name=snapshot-agent,app.kubernetes.io/instance=sa-chart-test"
+    log "Waiting for the chart's DaemonSet pod to become Ready on ${TEST_NODE}..."
+    wait_chart_pods_ready "$SA_SELECTOR" "$TEST_NODE" || chart_failure "snapshot-agent" "$SA_SELECTOR"
+  fi
 fi
 
 if [[ "$NEED_ORCH_CHART" == "true" ]]; then
@@ -230,6 +254,8 @@ ORCH_CHART_DEPLOYED=""
 [[ "$NEED_ORCH_CHART" == "true" ]] && ORCH_CHART_DEPLOYED=1
 EXIT=0
 $K exec test-runner -- env "MODEL=${MODEL}" "TEST_NODE=${TEST_NODE:-}" \
+  "TEST_NODE_SAMPLERS=${TEST_NODE_SAMPLERS:-}" \
+  "TEST_NODE_TRAINERS=${TEST_NODE_TRAINERS:-}" \
   "SA_CHART_DEPLOYED=${SA_CHART_DEPLOYED}" \
   "ORCH_CHART_DEPLOYED=${ORCH_CHART_DEPLOYED}" \
   "CHART_AGENT_PORT=${CHART_AGENT_PORT}" \

--- a/tests/integration/runner.yaml
+++ b/tests/integration/runner.yaml
@@ -28,8 +28,9 @@ metadata:
   name: snapshot-agent-test-runner
   namespace: default
 ---
-# Cluster-wide read-only: node discovery and the all-namespaces pod listing
-# used to find a free GPU. Pod CRUD/exec stays namespace-local below.
+# Cluster-wide: node discovery (+ label updates for orchestrator groups),
+# all-namespaces pod listing for free GPU detection. Pod CRUD/exec stays
+# namespace-local below.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -37,7 +38,7 @@ metadata:
 rules:
   - apiGroups: [""]
     resources: ["nodes"]
-    verbs: ["get", "list"]
+    verbs: ["get", "list", "update", "patch"]
   - apiGroups: [""]
     resources: ["pods"]
     verbs: ["get", "list", "watch"]
@@ -70,6 +71,10 @@ rules:
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get"]
+  # Orchestrator scenarios create and clean up DRA ResourceClaims.
+  - apiGroups: ["resource.k8s.io"]
+    resources: ["resourceclaims"]
+    verbs: ["create", "delete", "get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding


### PR DESCRIPTION
## Summary

Adds the composed orchestrator integration suite: real orchestrator scenarios running against BOTH official Helm charts (snapshot-agent + timeslice-orchestrator) deployed on a real cluster with real GPU workloads.

- `--phase orchestrator` installs the snapshot-agent chart (DaemonSet) on `CHART_AGENT_PORT` (default 9002) and the timeslice-orchestrator chart with `snapshotAgentPort` set to the same port, so the orchestrator commands the suite's own agent — not whatever might be running on the default port on a shared node.
- Canonical 2-node topology: `TEST_NODE_SAMPLERS` and `TEST_NODE_TRAINERS` (one GPU per group, separate nodes). `exclusiveLabel` temporarily removes group labels from other nodes so pods land only on the designated test nodes.
- `TestOrchestrator/SingleRLJob`: single job acquires locks, deploys GPU pods, runs 2 sampling/training iterations, cleans up.
- `TestOrchestrator/QueuedRLJobs`: two jobs contend for the same locks — Job B queues behind Job A, both complete 2 iterations.
- The orchestrator chart gains a `snapshotAgentPort` value passed as `--snapshot-agent-port` to the binary.
- Runner RBAC gains node update/patch (for group labeling) and `resourceclaims` create/delete/get/list (for the scenarios' DRA claims).

### Files added

| File | Purpose |
|------|---------|
| `tests/integration/orchestrator/orchestrator_test.go` | `TestOrchestrator` with `SingleRLJob` and `QueuedRLJobs` subtests |
| `tests/integration/orchestrator/harness.go` | `ComposedHarness`: 2-node topology, attaches to chart-deployed orchestrator + agent, exclusive group labeling, pre-cleans leaked pods |

### Files modified

| File | Change |
|------|--------|
| `tests/integration/run.sh` | `--orch-image` flag, `--phase orchestrator` and `all`, 2-node topology (`TEST_NODE_SAMPLERS`/`TEST_NODE_TRAINERS`), orchestrator chart install/cleanup |
| `tests/integration/runner.yaml` | Node update/patch RBAC, ResourceClaims RBAC |
| `tests/integration/README.md` | Orchestrator phase documentation |
| `tests/integration/harness/harness.go` | `WaitPodReadyByLabel` handles empty node |
| `deploy/timesliceorchestrator/values.yaml` | `snapshotAgentPort` value |
| `deploy/timesliceorchestrator/templates/deployment.yaml` | Pass `--snapshot-agent-port` arg |
| `tests/integration/orchestrator/scenarios/fake_rl_job.go` | Force-delete pods on cleanup (`GracePeriodSeconds=0`) |
| `tests/integration/orchestrator/scenarios/scenarios.go` | Increased post-cleanup verification timeout (500ms/10s) |

### Integration test results

2-node L4 topology, PyTorch GPU burner template:

| Test | Result | Duration |
|------|--------|----------|
| `TestOrchestrator/SingleRLJob` | PASS | 25.52s |
| `TestOrchestrator/QueuedRLJobs` | PASS | 115.24s |
| **TestOrchestrator (total)** | **PASS** | **141.52s** |

Cloud Build verification (build + `go vet -tags integration` + unit tests): **SUCCESS**
