### PR TITLE
Add async RL coverage and CUJ use-case matrix

### DIFF
--- a/guides/accelerator-orchestrator/README.md
+++ b/guides/accelerator-orchestrator/README.md
@@ -10,8 +10,12 @@ For a detailed architectural breakdown of this inefficiency and the co-operative
 
 ### Use Cases
 
-1.  **Cooperative RL Job Interleaving:** Interleave independent RL jobs on shared GPU/TPU pools (e.g., Job B samples while Job A trains) to maximize utilization.
-2.  **Multi-tenant Resource Sharing:** Manage fair sharing of accelerator pools across teams/experiments without manual coordination or OOM risks.
+1.  **Cooperative RL Job Interleaving (Sync RL):** Interleave independent RL jobs on shared GPU/TPU pools. In sync RL, the trainer and sampler alternate strictly — Job B trains while Job A generates, then they swap. Both the trainer and sampler pools are time-sliced.
+2.  **Async RL Trainer Sharing:** In async/disaggregated RL, samplers generate continuously while trainers consume batches from a queue. The trainer GPU has idle gaps between batches — time-slicing fills those gaps with another job's training. Only the **trainer pool** is shared; each job gets dedicated sampler GPUs (separate group, no contention).
+3.  **Multi-Tenant RLaaS:** Platforms like open-rl or Tinker serve multiple users fine-tuning models concurrently. Time-slicing lets the platform pack more jobs onto the same GPU fleet without requiring users to manage scheduling.
+4.  **Batch RL Experiment Queues:** Run 4 RL experiments on 2 GPU nodes — the orchestrator queues jobs and swaps them in/out at phase boundaries, maximizing throughput without manual coordination.
+5.  **Dev/Prod GPU Sharing:** Development RL jobs share GPUs with production training during off-peak hours. The orchestrator ensures mutual exclusion and clean context switching.
+6.  **Inference + Training Co-tenancy:** A serving workload (vLLM/SGLang) shares GPUs with an RL training job. When the training job yields during its idle phase, the serving workload resumes.
 
 ### Orchestrator Overview
 
@@ -271,6 +275,47 @@ for epoch in range(10):
     rewards = compute_rewards(trajectories)
     train_phase(policy, rewards)
 ```
+
+#### Pattern C: Async RL — Trainer-Only Time-Slicing
+
+In async or disaggregated RL, sampler GPUs generate rollouts continuously — there is no idle time to reclaim. Only the **trainer GPU** has idle gaps (waiting for the next batch). In this case, only the trainer pool is time-sliced; each job gets its own sampler group with no contention.
+
+```python
+from timeslice import TimeSliceOrchestratorClient
+
+# Trainer pool: shared across jobs (time-sliced)
+trainer_orch = TimeSliceOrchestratorClient(
+    target="accelerator-orchestrator.timeslice-system.svc.cluster.local:50051",
+    job_id="job-a",
+    group_id="shared-trainers"  # Both jobs contend for this group
+)
+
+# Sampler pool: dedicated per job (no contention)
+sampler_orch = TimeSliceOrchestratorClient(
+    target="accelerator-orchestrator.timeslice-system.svc.cluster.local:50051",
+    job_id="job-a",
+    group_id="samplers-job-a"  # Only this job uses this group
+)
+
+@trainer_orch.on_accelerators()
+def train_step(model, batch):
+    return model.update(batch)
+
+@trainer_orch.on_accelerators()
+@sampler_orch.on_accelerators()
+def weight_sync(model):
+    # Weight sync (NCCL broadcast) needs both trainer and sampler GPUs
+    model.broadcast_weights()
+
+# Async loop: sampler generates continuously, trainer consumes from queue
+while True:
+    batch = sample_queue.get()  # Trainer GPU is idle here — other job can train
+    train_step(model, batch)
+    if should_sync_weights():
+        weight_sync(model)
+```
+
+The key difference from sync (Pattern B): the generation function is **not decorated** with `on_accelerators` because the sampler group has no contention — each job has its own group, so acquires return immediately with no context switching.
 
 ---
 

--- a/guides/rl-frameworks/slime/README.md
+++ b/guides/rl-frameworks/slime/README.md
@@ -3,10 +3,14 @@
 This guide provides step-by-step instructions on how to integrate and deploy **Slime** (high-performance RL framework for LLMs) with the **llm-d-rl-time-slicing** platform.
 
 ### Motivation: Maximizing GPU Utilization
-In traditional disaggregated RL setups, GPUs sit idle whenever worker groups wait for another phase to complete (e.g., trainer GPUs idling during rollout generation, or rollout GPUs idling during policy updates). Cooperative time-slicing enables multiple independent Slime jobs to multiplex physical GPU resource pools concurrently. When one job finishes a phase, its GPU context is checkpointed and evicted, allowing another job to immediately utilize the hardware—significantly driving up GPU duty cycle and overall cluster throughput.
+In disaggregated RL setups, GPUs sit idle whenever worker groups wait for another phase to complete. Cooperative time-slicing enables multiple independent Slime jobs to share physical GPU pools — when one job finishes a phase, its GPU context is checkpointed and evicted, allowing another job to immediately utilize the hardware.
 
-For a runnable example, see:
-* **[GRPO Integration Example](sync/README.md)**
+**Sync RL** (`train.py`): Training and generation alternate strictly. Both trainer and sampler GPUs have idle gaps. Time-slicing shares **both pools** — Job B trains while Job A generates, then they swap.
+
+**Async RL** (`train_async.py`): Generation N+1 runs concurrently with training N (pipelined). Sampler GPUs are busy non-stop. Only the **trainer GPU** has idle gaps waiting for the next batch. Time-slicing shares only the trainer pool; each job gets dedicated sampler GPUs (separate group per job, no contention).
+
+For a runnable sync example, see:
+* **[Sync GRPO Integration Example](sync/README.md)**
 
 ---
 


### PR DESCRIPTION
## Summary
- Root README: add use-case matrix (multi-tenant RLaaS, batch experiment queues, dev/prod GPU sharing, inference+training co-tenancy, sync/async RL interleaving)
- Orchestrator guide: expand use cases for async RL, add Pattern C (trainer-only time-slicing with dedicated per-job sampler groups)
- Slime guide: add sync vs async motivation explaining when each pool is time-sliced

3 files changed, 66 insertions.