### PR TITLE
[Snapshot-Agent]: Add feature gates, guard DirectMemoryBackend behind one.

### DIFF
--- a/cmd/snapshot-agent/main.go
+++ b/cmd/snapshot-agent/main.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/logging"
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/backends"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/features"
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/server"
 )
 
@@ -34,6 +35,8 @@ func main() {
 
 	port := flag.Int("port", 9001, "The port to listen on")
 	deploymentMode := flag.String("deployment-mode", "standalone", "Deployment mode ('standalone' or 'k8s')")
+	featureGatesSpec := flag.String("feature-gates", "",
+		"Comma-separated list of Name=bool pairs selecting experimental features, e.g. 'DirectMemoryBackend=true'")
 	flag.Parse()
 
 	depMode := *deploymentMode
@@ -57,6 +60,19 @@ func main() {
 		slog.Error("Invalid deployment mode, must be 'standalone' or 'k8s'", "mode", depMode)
 		os.Exit(1)
 	}
+
+	// FEATURE_GATES overrides the flag, mirroring DEPLOYMENT_MODE and
+	// AGENT_PORT: the Helm chart configures the agent through env vars.
+	gatesSpec := *featureGatesSpec
+	if envGates := os.Getenv("FEATURE_GATES"); envGates != "" {
+		gatesSpec = envGates
+	}
+	featureGates, err := features.Parse(gatesSpec)
+	if err != nil {
+		slog.Error("Invalid feature gates", "value", gatesSpec, "error", err)
+		os.Exit(1)
+	}
+
 	ctx := context.Background()
 
 	// The channel registry is shared between the app-channel backend and the
@@ -69,8 +85,11 @@ func main() {
 		backends.BackendAppChannel:  backends.NewAppChannelBackend(channelRegistry),
 	}
 
-	slog.InfoContext(ctx, "Starting Snapshot Agent", "port", listenPort, "deploymentMode", depMode)
-	if err := server.StartServer(ctx, listenPort, registeredBackends, backends.BackendCuda, depMode, channelRegistry); err != nil {
+	slog.InfoContext(ctx, "Starting Snapshot Agent",
+		"port", listenPort, "deploymentMode", depMode, "featureGates", featureGates.String())
+	err = server.StartServer(
+		ctx, listenPort, registeredBackends, backends.BackendCuda, depMode, channelRegistry, featureGates)
+	if err != nil {
 		slog.ErrorContext(ctx, "Failed to start server", "error", err)
 		os.Exit(1)
 	}

--- a/deploy/snapshot-agent/templates/daemonset.yaml
+++ b/deploy/snapshot-agent/templates/daemonset.yaml
@@ -42,6 +42,17 @@ spec:
                   fieldPath: spec.nodeName
             - name: AGENT_PORT
               value: {{ .Values.port | quote }}
+            {{- if .Values.featureGates }}
+            {{- $gates := list }}
+            {{- range $name, $enabled := .Values.featureGates }}
+            {{- if not (kindIs "bool" $enabled) }}
+            {{- fail (printf "featureGates.%s must be true or false, got %q" $name (toString $enabled)) }}
+            {{- end }}
+            {{- $gates = append $gates (printf "%s=%t" $name $enabled) }}
+            {{- end }}
+            - name: FEATURE_GATES
+              value: {{ join "," $gates | quote }}
+            {{- end }}
             {{- if .Values.nvidia.driver.enabled }}
             - name: LD_LIBRARY_PATH
               value: {{ join ":" .Values.nvidia.driver.libraryPaths }}

--- a/deploy/snapshot-agent/values.yaml
+++ b/deploy/snapshot-agent/values.yaml
@@ -47,6 +47,18 @@ nvidia:
     hostPath: /dev
     mountPath: /dev
 
+# Kubernetes-style feature gates (map of Name: bool), rendered into the
+# agent's FEATURE_GATES env var. Experimental capabilities are off by
+# default; requests selecting a gated backend fail with FAILED_PRECONDITION
+# until its gate is enabled.
+# Known gates:
+#   DirectMemoryBackend — the experimental direct_memory backend (driven by
+#   GPU-CR). Default: false.
+# Example:
+#   featureGates:
+#     DirectMemoryBackend: true
+featureGates: {}
+
 rbac:
   create: true
 

--- a/pkg/snapshot-agent/api/v1alpha1/snapshot_agent.pb.go
+++ b/pkg/snapshot-agent/api/v1alpha1/snapshot_agent.pb.go
@@ -388,6 +388,12 @@ func (x *CudaBackendConfig) GetExplicitTarget() *ProcessTarget {
 }
 
 // Configuration for the Direct Memory (process-level) backend.
+//
+// Experimental: this backend is driven by GPU-CR, which is itself
+// experimental — expect deployment requirements and operational caveats.
+// It is disabled by default: requests selecting it fail with
+// FAILED_PRECONDITION unless the agent runs with
+// --feature-gates=DirectMemoryBackend=true (or the FEATURE_GATES env var).
 type DirectMemoryBackendConfig struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// The target processes to checkpoint/restore.
@@ -673,6 +679,8 @@ type BackendConfig_AppChannel struct {
 }
 
 type BackendConfig_DirectMemory struct {
+	// Experimental: disabled by default behind the DirectMemoryBackend
+	// feature gate; see DirectMemoryBackendConfig.
 	DirectMemory *DirectMemoryBackendConfig `protobuf:"bytes,4,opt,name=direct_memory,json=directMemory,proto3,oneof"`
 }
 

--- a/pkg/snapshot-agent/api/v1alpha1/snapshot_agent.proto
+++ b/pkg/snapshot-agent/api/v1alpha1/snapshot_agent.proto
@@ -51,6 +51,12 @@ message CudaBackendConfig {
 }
 
 // Configuration for the Direct Memory (process-level) backend.
+//
+// Experimental: this backend is driven by GPU-CR, which is itself
+// experimental — expect deployment requirements and operational caveats.
+// It is disabled by default: requests selecting it fail with
+// FAILED_PRECONDITION unless the agent runs with
+// --feature-gates=DirectMemoryBackend=true (or the FEATURE_GATES env var).
 message DirectMemoryBackendConfig {
   // The target processes to checkpoint/restore.
   ProcessTarget explicit_target = 1;
@@ -120,6 +126,8 @@ message BackendConfig {
     CudaBackendConfig cuda = 1;
     AppEndpointConfig app_endpoint = 2;
     AppChannelConfig app_channel = 3;
+    // Experimental: disabled by default behind the DirectMemoryBackend
+    // feature gate; see DirectMemoryBackendConfig.
     DirectMemoryBackendConfig direct_memory = 4;
   }
 }

--- a/pkg/snapshot-agent/features/features.go
+++ b/pkg/snapshot-agent/features/features.go
@@ -1,0 +1,95 @@
+// Package features implements Kubernetes-style feature gates for the
+// snapshot agent: experimental capabilities are explicit per-agent opt-ins
+// selected with --feature-gates=Name=bool,... (or the FEATURE_GATES env
+// var), with alpha gates off by default.
+package features
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Feature is the name of a feature gate.
+type Feature string
+
+// DirectMemoryBackend gates the direct_memory backend. It is driven by
+// GPU-CR, which is itself experimental and carries deployment requirements
+// and operational caveats.
+const DirectMemoryBackend Feature = "DirectMemoryBackend"
+
+// defaults registers every known gate and its default state. Alpha gates
+// default to false; flipping a default here is the promotion path
+// (alpha → beta → GA), as in Kubernetes. Adding a gate is one const plus
+// one entry here.
+var defaults = map[Feature]bool{
+	DirectMemoryBackend: false,
+}
+
+// Gates holds the explicitly configured gate values. The zero value (nil)
+// is valid and yields every gate's default — callers that don't care pass
+// nil.
+type Gates map[Feature]bool
+
+// Parse parses a comma-separated list of Name=bool pairs, tolerating
+// whitespace around names, values, and separators. An empty spec yields
+// the defaults. Unknown gate names and non-boolean values are errors so
+// that a typo never runs silently ignored. A gate repeated within the
+// spec takes its last value, matching Kubernetes --feature-gates
+// behavior.
+func Parse(spec string) (Gates, error) {
+	gates := Gates{}
+	if strings.TrimSpace(spec) == "" {
+		return gates, nil
+	}
+	for _, pair := range strings.Split(spec, ",") {
+		pair = strings.TrimSpace(pair)
+		if pair == "" {
+			continue
+		}
+		name, value, found := strings.Cut(pair, "=")
+		if !found {
+			return nil, fmt.Errorf("invalid feature gate %q: must be Name=bool", pair)
+		}
+		feature := Feature(strings.TrimSpace(name))
+		if _, known := defaults[feature]; !known {
+			return nil, fmt.Errorf("unknown feature gate %q; known gates: %s", strings.TrimSpace(name), knownGates())
+		}
+		enabled, err := strconv.ParseBool(strings.TrimSpace(value))
+		if err != nil {
+			return nil, fmt.Errorf("invalid value %q for feature gate %q: must be a boolean", strings.TrimSpace(value), feature)
+		}
+		gates[feature] = enabled
+	}
+	return gates, nil
+}
+
+// Enabled reports whether the gate is on: the explicitly configured value
+// if set, else the registry default.
+func (g Gates) Enabled(f Feature) bool {
+	if enabled, ok := g[f]; ok {
+		return enabled
+	}
+	return defaults[f]
+}
+
+// String returns every known gate with its effective value as a sorted,
+// comma-separated Name=bool list, for startup logging.
+func (g Gates) String() string {
+	pairs := make([]string, 0, len(defaults))
+	for feature := range defaults {
+		pairs = append(pairs, fmt.Sprintf("%s=%t", feature, g.Enabled(feature)))
+	}
+	sort.Strings(pairs)
+	return strings.Join(pairs, ",")
+}
+
+func knownGates() string {
+	names := make([]string, 0, len(defaults))
+	for feature := range defaults {
+		names = append(names, string(feature))
+	}
+	sort.Strings(names)
+	return strings.Join(names, ", ")
+}

--- a/pkg/snapshot-agent/features/features_internal_test.go
+++ b/pkg/snapshot-agent/features/features_internal_test.go
@@ -1,0 +1,191 @@
+package features
+
+import (
+	"strings"
+	"testing"
+)
+
+// testGate is a second gate registered for the duration of a test so that
+// multi-gate parsing and independence can be exercised even while only one
+// real gate exists.
+const testGate Feature = "TestGate"
+
+// withGate registers an extra gate in the shared defaults registry for the
+// duration of a test.
+func withGate(t *testing.T, name Feature, defaultValue bool) {
+	t.Helper()
+	defaults[name] = defaultValue
+	t.Cleanup(func() { delete(defaults, name) })
+}
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name string
+		spec string
+		// want is the exact raw map Parse must return: asserting on the
+		// parsed entries (not just Enabled, which falls back to defaults)
+		// catches a pair being silently dropped.
+		want    map[Feature]bool
+		wantErr []string
+	}{
+		{
+			name: "empty spec yields no explicit gates",
+			spec: "",
+			want: map[Feature]bool{},
+		},
+		{
+			name: "whitespace-only spec yields no explicit gates",
+			spec: "   ",
+			want: map[Feature]bool{},
+		},
+		{
+			name: "single gate",
+			spec: "DirectMemoryBackend=true",
+			want: map[Feature]bool{DirectMemoryBackend: true},
+		},
+		{
+			name: "multiple gates with spaces",
+			spec: "DirectMemoryBackend=true, TestGate=false",
+			want: map[Feature]bool{DirectMemoryBackend: true, testGate: false},
+		},
+		{
+			name: "whitespace around name and value tolerated",
+			spec: " DirectMemoryBackend = true ",
+			want: map[Feature]bool{DirectMemoryBackend: true},
+		},
+		{
+			name: "explicit false",
+			spec: "DirectMemoryBackend=false",
+			want: map[Feature]bool{DirectMemoryBackend: false},
+		},
+		{
+			name: "duplicate gate takes the last value, as in Kubernetes",
+			spec: "DirectMemoryBackend=false,DirectMemoryBackend=true",
+			want: map[Feature]bool{DirectMemoryBackend: true},
+		},
+		{
+			name: "trailing comma tolerated",
+			spec: "DirectMemoryBackend=true,",
+			want: map[Feature]bool{DirectMemoryBackend: true},
+		},
+		{
+			name: "unknown gate rejected, error lists known gates",
+			spec: "NoSuchGate=true",
+			wantErr: []string{
+				"unknown feature gate",
+				string(DirectMemoryBackend),
+			},
+		},
+		{
+			name:    "missing = rejected",
+			spec:    "DirectMemoryBackend",
+			wantErr: []string{"must be Name=bool"},
+		},
+		{
+			name:    "non-bool value rejected",
+			spec:    "DirectMemoryBackend=yes",
+			wantErr: []string{"must be a boolean"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withGate(t, testGate, false)
+
+			gates, err := Parse(tc.spec)
+			if len(tc.wantErr) > 0 {
+				if err == nil {
+					t.Fatalf("Expected error containing %q, got nil", tc.wantErr)
+				}
+				for _, want := range tc.wantErr {
+					if !strings.Contains(err.Error(), want) {
+						t.Errorf("Expected error containing %q, got: %v", want, err)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Expected success, got error: %v", err)
+			}
+			if len(gates) != len(tc.want) {
+				t.Errorf("Parse(%q) = %v, want %v", tc.spec, gates, tc.want)
+			}
+			for feature, want := range tc.want {
+				got, ok := gates[feature]
+				if !ok {
+					t.Errorf("Parse(%q) dropped gate %s", tc.spec, feature)
+					continue
+				}
+				if got != want {
+					t.Errorf("Parse(%q)[%s] = %t, want %t", tc.spec, feature, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestGates_Enabled(t *testing.T) {
+	withGate(t, testGate, true)
+
+	tests := []struct {
+		name    string
+		gates   Gates
+		feature Feature
+		want    bool
+	}{
+		{
+			name:    "nil gates fall back to default off",
+			gates:   nil,
+			feature: DirectMemoryBackend,
+			want:    false,
+		},
+		{
+			name:    "nil gates fall back to default on",
+			gates:   nil,
+			feature: testGate,
+			want:    true,
+		},
+		{
+			name:    "explicit value overrides default",
+			gates:   Gates{DirectMemoryBackend: true},
+			feature: DirectMemoryBackend,
+			want:    true,
+		},
+		{
+			name:    "explicit false overrides default on",
+			gates:   Gates{testGate: false},
+			feature: testGate,
+			want:    false,
+		},
+		{
+			name:    "setting one gate leaves others at their default",
+			gates:   Gates{testGate: false},
+			feature: DirectMemoryBackend,
+			want:    false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.gates.Enabled(tc.feature); got != tc.want {
+				t.Errorf("Enabled(%s) = %t, want %t", tc.feature, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestGates_String(t *testing.T) {
+	// "AAA" sorts before DirectMemoryBackend, so a sorted String() must
+	// list it first even though it was registered last.
+	withGate(t, "AAATestGate", false)
+
+	got := Gates{DirectMemoryBackend: true}.String()
+	want := "AAATestGate=false,DirectMemoryBackend=true"
+	if got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+
+	if got := Gates(nil).String(); !strings.Contains(got, "DirectMemoryBackend=false") {
+		t.Errorf("nil Gates String() should show defaults, got %q", got)
+	}
+}

--- a/pkg/snapshot-agent/server/server.go
+++ b/pkg/snapshot-agent/server/server.go
@@ -11,6 +11,7 @@ import (
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/logging"
 	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/backends"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/features"
 	sm "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/state-machine"
 	podutils "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/utils"
 	"google.golang.org/grpc"
@@ -28,16 +29,20 @@ type Server struct {
 	defaultBackend  backends.BackendType
 	deploymentMode  string
 	channelRegistry *backends.ChannelRegistry
+	featureGates    features.Gates
 }
 
 // NewServer creates a new Server instance. channelRegistry is shared with
 // the app-channel backend so workloads registered through the
-// WorkloadChannel RPC are reachable by Snapshot/Restore.
+// WorkloadChannel RPC are reachable by Snapshot/Restore. featureGates
+// selects which experimental capabilities are enabled; nil means every
+// gate at its default (experimental capabilities off).
 func NewServer(
 	backendMap map[backends.BackendType]backends.Backend,
 	defaultBackend backends.BackendType,
 	deploymentMode string,
 	channelRegistry *backends.ChannelRegistry,
+	featureGates features.Gates,
 ) *Server {
 	return &Server{
 		state:           sm.NewStateManager(),
@@ -45,7 +50,22 @@ func NewServer(
 		defaultBackend:  defaultBackend,
 		deploymentMode:  deploymentMode,
 		channelRegistry: channelRegistry,
+		featureGates:    featureGates,
 	}
+}
+
+// checkFeatureGates rejects configs that select an experimental backend
+// whose feature gate is off. It runs before backend routing so a gated
+// config never silently falls through to another backend.
+func (s *Server) checkFeatureGates(config *pb.BackendConfig) error {
+	if config.GetDirectMemory() != nil && !s.featureGates.Enabled(features.DirectMemoryBackend) {
+		return status.Errorf(codes.FailedPrecondition,
+			"the direct_memory backend is experimental (driven by GPU-CR, which carries deployment "+
+				"requirements and operational caveats) and is disabled by default; restart the agent "+
+				"with --feature-gates=%s=true (or the FEATURE_GATES env var) to enable it",
+			features.DirectMemoryBackend)
+	}
+	return nil
 }
 
 // Snapshot triggers an asynchronous snapshot of the accelerator context for a job.
@@ -53,6 +73,10 @@ func (s *Server) Snapshot(ctx context.Context, req *pb.SnapshotRequest) (*pb.Sna
 	ctx = logging.WithServerMethod(ctx, "Snapshot")
 	ctx = logging.WithJobID(ctx, req.GetJobId())
 	ctx = logging.WithGroupID(ctx, req.GetGroup())
+
+	if err := s.checkFeatureGates(req.GetBackendConfig()); err != nil {
+		return nil, err
+	}
 
 	backendType := s.getSnapshotBackendType(req.GetBackendConfig())
 	slog.InfoContext(ctx, "Snapshot called", "backend", backendType)
@@ -94,6 +118,9 @@ func (s *Server) getSnapshotBackendType(config *pb.BackendConfig) backends.Backe
 	if config.GetAppChannel() != nil {
 		return backends.BackendAppChannel
 	}
+	// NOTE: direct_memory is not routed yet and falls through to the
+	// default backend. It is unreachable unless the DirectMemoryBackend
+	// feature gate is enabled (checkFeatureGates runs before routing).
 	return s.defaultBackend
 }
 
@@ -247,6 +274,10 @@ func (s *Server) Restore(ctx context.Context, req *pb.RestoreRequest) (*pb.Resto
 	ctx = logging.WithJobID(ctx, req.GetJobId())
 	ctx = logging.WithGroupID(ctx, req.GetGroup())
 
+	if err := s.checkFeatureGates(req.GetBackendConfig()); err != nil {
+		return nil, err
+	}
+
 	backendType := s.getSnapshotBackendType(req.GetBackendConfig())
 	slog.InfoContext(ctx, "Restore called", "backend", backendType)
 
@@ -362,7 +393,8 @@ func (h *HealthServer) Watch(req *grpc_health_v1.HealthCheckRequest, stream grpc
 	return status.Errorf(codes.Unimplemented, "method Watch not implemented")
 }
 
-// StartServer starts the gRPC server on the specified port.
+// StartServer starts the gRPC server on the specified port. featureGates
+// may be nil, which leaves every gate at its default.
 func StartServer(
 	ctx context.Context,
 	port int,
@@ -370,6 +402,7 @@ func StartServer(
 	defaultBackend backends.BackendType,
 	deploymentMode string,
 	channelRegistry *backends.ChannelRegistry,
+	featureGates features.Gates,
 ) error {
 	lc := net.ListenConfig{}
 	lis, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", port))
@@ -384,7 +417,7 @@ func StartServer(
 	}
 
 	// 2. Create Server (which creates StateManager internally)
-	srv := NewServer(backendMap, defaultBackend, deploymentMode, channelRegistry)
+	srv := NewServer(backendMap, defaultBackend, deploymentMode, channelRegistry, featureGates)
 
 	// 3. Start the Watcher internally
 	watcher, err := NewWatcher(k8sClient, srv.state)

--- a/pkg/snapshot-agent/server/server_feature_gates_internal_test.go
+++ b/pkg/snapshot-agent/server/server_feature_gates_internal_test.go
@@ -1,0 +1,258 @@
+package server
+
+import (
+	"context"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/backends"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/features"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+)
+
+func directMemoryConfig() *pb.BackendConfig {
+	return &pb.BackendConfig{
+		Backend: &pb.BackendConfig_DirectMemory{
+			DirectMemory: &pb.DirectMemoryBackendConfig{
+				ExplicitTarget: &pb.ProcessTarget{Pids: []int32{123}},
+			},
+		},
+	}
+}
+
+func TestServer_CheckFeatureGates(t *testing.T) {
+	tests := []struct {
+		name     string
+		gates    features.Gates
+		config   *pb.BackendConfig
+		wantCode codes.Code
+	}{
+		{
+			name:     "nil config passes with nil gates",
+			gates:    nil,
+			config:   nil,
+			wantCode: codes.OK,
+		},
+		{
+			name:  "non-gated config passes with nil gates",
+			gates: nil,
+			config: &pb.BackendConfig{
+				Backend: &pb.BackendConfig_Cuda{Cuda: &pb.CudaBackendConfig{}},
+			},
+			wantCode: codes.OK,
+		},
+		{
+			name:     "gated config rejected by default",
+			gates:    nil,
+			config:   directMemoryConfig(),
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name:     "gated config rejected with explicit false",
+			gates:    features.Gates{features.DirectMemoryBackend: false},
+			config:   directMemoryConfig(),
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name:     "gated config passes with its gate enabled",
+			gates:    features.Gates{features.DirectMemoryBackend: true},
+			config:   directMemoryConfig(),
+			wantCode: codes.OK,
+		},
+		{
+			name:  "enabling the gate does not affect non-gated configs",
+			gates: features.Gates{features.DirectMemoryBackend: true},
+			config: &pb.BackendConfig{
+				Backend: &pb.BackendConfig_Cuda{Cuda: &pb.CudaBackendConfig{}},
+			},
+			wantCode: codes.OK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := NewServer(nil, backends.BackendNoop, "standalone", backends.NewChannelRegistry(), tc.gates)
+
+			err := srv.checkFeatureGates(tc.config)
+			if status.Code(err) != tc.wantCode {
+				t.Fatalf("checkFeatureGates() = %v, want code %v", err, tc.wantCode)
+			}
+			if tc.wantCode == codes.FailedPrecondition {
+				if !strings.Contains(err.Error(), string(features.DirectMemoryBackend)) {
+					t.Errorf("Expected error to name the gate, got: %v", err)
+				}
+				if !strings.Contains(err.Error(), "--feature-gates") {
+					t.Errorf("Expected error to name the --feature-gates flag, got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+// newFeatureGateTestServer starts a standalone-mode server whose default
+// backend is noop, so a gated request that passes the gate check completes
+// against the noop backend.
+//
+//nolint:nonamedreturns // Conflict between gocritic's unnamedResult and nonamedreturns
+func newFeatureGateTestServer(
+	t *testing.T,
+	gates features.Gates,
+) (client pb.SnapshotAgentServiceClient, srv *Server, cleanup func()) {
+	t.Helper()
+
+	noopBackend := backends.NewNoopBackend()
+	backendsMap := map[backends.BackendType]backends.Backend{
+		backends.BackendNoop: noopBackend,
+	}
+
+	lisLocal := bufconn.Listen(bufSize)
+	s := grpc.NewServer()
+	srv = NewServer(backendsMap, backends.BackendNoop, "standalone", backends.NewChannelRegistry(), gates)
+	pb.RegisterSnapshotAgentServiceServer(s, srv)
+	go func() {
+		if err := s.Serve(lisLocal); err != nil {
+			return
+		}
+	}()
+
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lisLocal.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("Failed to dial: %v", err)
+	}
+
+	cleanup = func() {
+		conn.Close()
+		s.GracefulStop()
+	}
+	return pb.NewSnapshotAgentServiceClient(conn), srv, cleanup
+}
+
+// registerRunningJob puts a fresh job into the RUNNING state so a snapshot
+// request against it is accepted by the state machine.
+func registerRunningJob(t *testing.T, srv *Server, jobID string) {
+	t.Helper()
+	srv.state.RegisterJob(jobID, "")
+	if err := srv.state.TransitionToRunning(jobID, []int{123}); err != nil {
+		t.Fatalf("Failed to transition job to RUNNING: %v", err)
+	}
+}
+
+// snapshotUntilSaved snapshots a RUNNING job with a direct_memory config
+// and waits for the noop backend to complete so the job reaches SAVED and
+// a subsequent Restore is accepted. Requires the DirectMemoryBackend gate
+// to be enabled on the server.
+func snapshotUntilSaved(
+	t *testing.T,
+	ctx context.Context,
+	client pb.SnapshotAgentServiceClient,
+	srv *Server,
+	jobID string,
+) {
+	t.Helper()
+	if _, err := client.Snapshot(ctx, &pb.SnapshotRequest{
+		JobId:         jobID,
+		BackendConfig: directMemoryConfig(),
+	}); err != nil {
+		t.Fatalf("Snapshot during setup: %v", err)
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		for _, js := range srv.state.GetJobStatus() {
+			if js.JobId == jobID && js.State == pb.JobState_JOB_STATE_SAVED {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("Timeout waiting for job %s to become SAVED", jobID)
+}
+
+func TestServer_FeatureGates_RPCEnforcement(t *testing.T) {
+	enabled := features.Gates{features.DirectMemoryBackend: true}
+
+	tests := []struct {
+		name  string
+		gates features.Gates
+		// restore selects the RPC under test: Restore when true,
+		// Snapshot otherwise.
+		restore bool
+		// jobState is the state the job is brought into before the RPC.
+		// UNSPECIFIED means no setup: rejection happens before backend
+		// routing and the state machine, so no job needs to exist.
+		jobState pb.JobState
+		wantCode codes.Code
+	}{
+		{
+			name:     "Snapshot rejected by default",
+			gates:    nil,
+			restore:  false,
+			jobState: pb.JobState_JOB_STATE_UNSPECIFIED,
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name:     "Restore rejected by default",
+			gates:    nil,
+			restore:  true,
+			jobState: pb.JobState_JOB_STATE_UNSPECIFIED,
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name:     "Snapshot allowed when enabled",
+			gates:    enabled,
+			restore:  false,
+			jobState: pb.JobState_JOB_STATE_RUNNING,
+			wantCode: codes.OK,
+		},
+		{
+			name:     "Restore allowed when enabled",
+			gates:    enabled,
+			restore:  true,
+			jobState: pb.JobState_JOB_STATE_SAVED,
+			wantCode: codes.OK,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client, srv, cleanup := newFeatureGateTestServer(t, tc.gates)
+			defer cleanup()
+			ctx := context.Background()
+			jobID := "gated-job"
+
+			switch tc.jobState {
+			case pb.JobState_JOB_STATE_RUNNING:
+				registerRunningJob(t, srv, jobID)
+			case pb.JobState_JOB_STATE_SAVED:
+				registerRunningJob(t, srv, jobID)
+				snapshotUntilSaved(t, ctx, client, srv, jobID)
+			}
+
+			var err error
+			if tc.restore {
+				_, err = client.Restore(ctx, &pb.RestoreRequest{
+					JobId:         jobID,
+					BackendConfig: directMemoryConfig(),
+				})
+			} else {
+				_, err = client.Snapshot(ctx, &pb.SnapshotRequest{
+					JobId:         jobID,
+					BackendConfig: directMemoryConfig(),
+				})
+			}
+			if status.Code(err) != tc.wantCode {
+				t.Errorf("Expected code %v, got: %v", tc.wantCode, err)
+			}
+		})
+	}
+}

--- a/pkg/snapshot-agent/server/server_internal_test.go
+++ b/pkg/snapshot-agent/server/server_internal_test.go
@@ -64,7 +64,7 @@ func initGRPCServer() {
 	// Default to BackendCuda (matching production) so that requests without a
 	// BackendConfig take the k8s CUDA discovery path; the registered
 	// implementation is still the noop backend.
-	testServer = NewServer(backendsMap, backends.BackendCuda, "k8s", backends.NewChannelRegistry())
+	testServer = NewServer(backendsMap, backends.BackendCuda, "k8s", backends.NewChannelRegistry(), nil)
 	pb.RegisterSnapshotAgentServiceServer(s, testServer)
 	grpc_health_v1.RegisterHealthServer(s, NewHealthServer(backendsMap, backends.BackendNoop))
 	go func() {
@@ -469,7 +469,7 @@ func newModeTestServer(
 
 	lisLocal := bufconn.Listen(bufSize)
 	s := grpc.NewServer()
-	srv := NewServer(backendsMap, defaultBackend, mode, backends.NewChannelRegistry())
+	srv := NewServer(backendsMap, defaultBackend, mode, backends.NewChannelRegistry(), nil)
 	pb.RegisterSnapshotAgentServiceServer(s, srv)
 	go func() {
 		if err := s.Serve(lisLocal); err != nil {
@@ -577,7 +577,7 @@ func TestServer_Snapshot_StandaloneMode(t *testing.T) {
 		backends.BackendCuda: noopBackend,
 	}
 	// enable standalone mode
-	standaloneServer := NewServer(backendsMap, backends.BackendNoop, "standalone", backends.NewChannelRegistry())
+	standaloneServer := NewServer(backendsMap, backends.BackendNoop, "standalone", backends.NewChannelRegistry(), nil)
 	pb.RegisterSnapshotAgentServiceServer(s, standaloneServer)
 	go func() {
 		if err := s.Serve(lisDev); err != nil {
@@ -689,7 +689,7 @@ func TestServer_Snapshot_StandaloneMode_BackendValidation(t *testing.T) {
 	backendsMap := map[backends.BackendType]backends.Backend{
 		backends.BackendCuda: backends.NewCudaCheckpoint(),
 	}
-	standaloneServer := NewServer(backendsMap, backends.BackendCuda, "standalone", backends.NewChannelRegistry())
+	standaloneServer := NewServer(backendsMap, backends.BackendCuda, "standalone", backends.NewChannelRegistry(), nil)
 	pb.RegisterSnapshotAgentServiceServer(s, standaloneServer)
 	go func() {
 		if err := s.Serve(lisDev); err != nil {

--- a/pkg/snapshot-agent/server/workload_channel_internal_test.go
+++ b/pkg/snapshot-agent/server/workload_channel_internal_test.go
@@ -26,7 +26,7 @@ func newChannelTestServer(t *testing.T) (*Server, *backends.ChannelRegistry, pb.
 	backendsMap := map[backends.BackendType]backends.Backend{
 		backends.BackendAppChannel: backends.NewAppChannelBackend(registry),
 	}
-	srv := NewServer(backendsMap, backends.BackendAppChannel, "k8s", registry)
+	srv := NewServer(backendsMap, backends.BackendAppChannel, "k8s", registry, nil)
 	pb.RegisterSnapshotAgentServiceServer(s, srv)
 	go func() {
 		if err := s.Serve(lisChan); err != nil {


### PR DESCRIPTION


## What does this PR do?
  Adds Kubernetes-style feature gates to the snapshot agent (--feature-gates=Name=bool,... or the FEATURE_GATES env var) and puts the experimental
  direct_memory backend behind the first gate, DirectMemoryBackend.

  - Gates are off by default. Snapshot and Restore reject a direct_memory config with FAILED_PRECONDITION unless the gate is enabled; the error says how to
  enable it.
  - Unknown gate names or non-boolean values fail agent startup.
  - The Helm chart gets a featureGates values map; default deployments are unchanged.
  - The proto marks direct_memory as experimental (comments-only regen).
  - Adding a future gate is one constant plus one registry entry.
<!-- Describe the changes and their purpose -->

## Why is this change needed?
Certain backends (such as DirectMemoryBackendConfig) rely on tools which are in a research experimental state. This means that the backend isn't currently production ready, and requires a lot of friction to use. We want to make this explicit for users so that they acknowledge these limitations when using the backend. 
<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable feature gates for experimental snapshot-agent backends.
  - Added support for enabling the Direct Memory backend through deployment settings, command-line options, or environment variables.
  - Direct Memory backend is disabled by default and now reports a clear error when unavailable.

- **Bug Fixes**
  - Invalid or unknown feature-gate values are detected during startup or deployment configuration.
  - Snapshot and restore operations now consistently enforce feature-gate settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->