### PR TITLE
snapshot-agent: fix deadlock between StateManager locks

### DIFF
--- a/pkg/snapshot-agent/state-machine/state-manager.go
+++ b/pkg/snapshot-agent/state-machine/state-manager.go
@@ -44,7 +44,10 @@ type Operation struct {
 type StateManager struct {
 	jobs       map[string]*Job
 	operations map[string]*Operation
-	mu         sync.RWMutex
+
+	// mu guards jobs and operations.
+	// Lock order: mu → Job.mu. The reverse order deadlocks.
+	mu sync.RWMutex
 }
 
 // NewStateManager creates a new StateManager instance.
@@ -80,8 +83,8 @@ func (sm *StateManager) RegisterJob(jobID, group string) {
 // StartSnapshot initiates a snapshot operation if the job state allows it.
 func (sm *StateManager) StartSnapshot(jobID, group string, worker func() error) (string, error) {
 	sm.mu.Lock()
+	defer sm.mu.Unlock()
 	job := sm.getOrCreateJob(jobID, group)
-	sm.mu.Unlock()
 
 	job.mu.Lock()
 	defer job.mu.Unlock()
@@ -105,9 +108,7 @@ func (sm *StateManager) StartSnapshot(jobID, group string, worker func() error) 
 		StartedAt: time.Now(),
 	}
 
-	sm.mu.Lock()
 	sm.operations[opID] = op
-	sm.mu.Unlock()
 
 	// Update job state to TRANSITIONING
 	job.State = pb.JobState_JOB_STATE_TRANSITIONING
@@ -140,8 +141,8 @@ func (sm *StateManager) StartSnapshot(jobID, group string, worker func() error) 
 // StartRestore initiates a restore operation if the job state allows it.
 func (sm *StateManager) StartRestore(jobID, group string, worker func() error) (string, error) {
 	sm.mu.Lock()
+	defer sm.mu.Unlock()
 	job := sm.getOrCreateJob(jobID, group)
-	sm.mu.Unlock()
 
 	job.mu.Lock()
 	defer job.mu.Unlock()
@@ -170,9 +171,7 @@ func (sm *StateManager) StartRestore(jobID, group string, worker func() error) (
 		StartedAt: time.Now(),
 	}
 
-	sm.mu.Lock()
 	sm.operations[opID] = op
-	sm.mu.Unlock()
 
 	// Update job state to TRANSITIONING
 	job.State = pb.JobState_JOB_STATE_TRANSITIONING
@@ -235,9 +234,8 @@ func (sm *StateManager) GetJobStatus() []*pb.JobStatus {
 // UpdateJobPIDs updates the PIDs associated with a job.
 func (sm *StateManager) UpdateJobPIDs(jobID string, pids []int) {
 	sm.mu.Lock()
-	defer sm.mu.Unlock()
-
 	job, ok := sm.jobs[jobID]
+	sm.mu.Unlock()
 	if !ok {
 		return
 	}
@@ -250,9 +248,8 @@ func (sm *StateManager) UpdateJobPIDs(jobID string, pids []int) {
 // GetJobPIDs returns the PIDs associated with a job.
 func (sm *StateManager) GetJobPIDs(jobID string) ([]int, error) {
 	sm.mu.RLock()
-	defer sm.mu.RUnlock()
-
 	job, ok := sm.jobs[jobID]
+	sm.mu.RUnlock()
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "job %s not found", jobID)
 	}
@@ -274,7 +271,6 @@ func (sm *StateManager) TransitionToRunning(jobID string, pids []int) error {
 	sm.mu.Lock()
 	job, ok := sm.jobs[jobID]
 	sm.mu.Unlock()
-
 	if !ok {
 		return status.Errorf(codes.NotFound, "job %s not found", jobID)
 	}


### PR DESCRIPTION
## What does this PR do?

<!-- Describe the changes and their purpose -->

## Why is this change needed?
**Fixing the AB-BA Deadlock in StateManager**

StartSnapshot / StartRestore acquire locks in the order job.mu → sm.mu, while GetJobStatus / UpdateJobPIDs / GetJobPIDs acquire them in the reverse order sm.mu → job.mu — a classic AB-BA deadlock.

The Watcher polls GetJobStatus every second. When that overlaps with a concurrent Snapshot/Restore RPC on the same job, the two goroutines end up waiting on each other indefinitely. Because sm.mu is never released, all subsequent gRPC calls on the agent become blocked, and the only way to recover is to restart the process.

**Fix**
Unify the lock ordering to sm.mu → job.mu. Allow job.mu to be acquired without holding sm.mu, but do not allow sm.mu.Lock to be called while job.mu is held.


<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot and restore operation handling to ensure locks are released safely.
  * Prevented potential lock-ordering issues when updating or retrieving job process information.

* **Documentation**
  * Added documentation clarifying lock usage and ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->