### PR TITLE
chart: render nodeSelector, affinity, and tolerations in the orchestrator Deployment

### DIFF
--- a/deploy/timesliceorchestrator/templates/deployment.yaml
+++ b/deploy/timesliceorchestrator/templates/deployment.yaml
@@ -31,3 +31,15 @@ spec:
               protocol: TCP
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
The timesliceorchestrator subchart declares `nodeSelector`, `tolerations`, and `affinity` in values.yaml, but the Deployment template never rendered them, so setting them had no effect and the orchestrator could land on any node (observed: scheduled onto GPU workload nodes on shared clusters). This renders all three with the standard helm blocks; empty values render nothing, so default output is unchanged. The snapshot-agent DaemonSet already renders these.

Validation: `helm template` verified (values set → blocks rendered; defaults → no scheduling fields emitted); validated live on GKE, where the orchestrator landed on the intended CPU pool via values alone.