### PR TITLE
Add verl fully-async time-slicing guide

### DIFF
--- a/guides/rl-frameworks/README.md
+++ b/guides/rl-frameworks/README.md
@@ -1,6 +1,6 @@
 # Framework Integration Guide
 
-Pre-packaged time-slicing integrations are available for supported frameworks — see [Slime](slime/). If your framework is already supported, use the pre-packaged integration instead of following this guide.
+Pre-packaged time-slicing integrations are available for supported frameworks — see [Slime](slime/) and [verl](verl/). If your framework is already supported, use the pre-packaged integration instead of following this guide.
 
 This guide is for **framework owners and developers** who want to build a time-slicing integration for a framework that doesn't have one yet.
 

--- a/guides/rl-frameworks/verl/README.md
+++ b/guides/rl-frameworks/verl/README.md
@@ -1,0 +1,270 @@
+# Time-Slicing Integration Guide for verl Workloads
+
+This guide provides step-by-step instructions on how to time-slice any two **verl** (Volcano Engine Reinforcement Learning framework) async RL workloads with the **llm-d-rl-time-slicing** platform using the pre-packaged `llm-d-timeslice-verl` integration (`pkg/integrations/verl/`). A complete two-job runnable is provided as an [example](examples/fully-async/README.md); the sections below are the generic walkthrough it instantiates.
+
+### Motivation: Maximizing GPU Utilization
+
+In verl's **fully-async** recipe (`fully_async_policy`), rollout generation runs continuously while the trainer sits idle whenever it waits for the next batch of samples — in our reference runs that idle fraction was ~55–70% of wall-clock. Cooperative time-slicing backfills those valleys: multiple jobs' trainers share one physical GPU pool, and the platform checkpoints the idle trainer's GPU state to host RAM (`cuda-checkpoint`) at every handoff. Rollout engines keep dedicated GPUs and never stop generating: while a job's trainer is checkpointed off the shared GPU, its rollout engine keeps generating samples into the staleness queue.
+
+This guide covers verl's fully-async trainer (`fully_async_policy`), integrated via the `TimesliceFullyAsyncTrainer` subclass and verl's fully-async lifecycle hooks.
+
+For a runnable example, see:
+
+* **[Fully-Async Example](examples/fully-async/README.md)** — the trainers of two fully-async RL jobs (math RLVR + code RLVR) time-sliced on one GPU, each job with a dedicated rollout GPU
+
+---
+
+## Table of Contents
+1. [Cluster Prerequisites](#1-cluster-prerequisites)
+2. [Deploying the Time-Slicing Platform](#2-deploying-the-time-slicing-platform)
+3. [Integrating with verl](#3-integrating-with-verl)
+4. [Deploying Time-Sliced verl Jobs](#4-deploying-time-sliced-verl-jobs)
+5. [Submitting and Observing Time-Sliced Jobs](#5-submitting-and-observing-time-sliced-jobs)
+6. [General Troubleshooting](#6-general-troubleshooting)
+
+---
+
+## 1. Cluster Prerequisites
+
+Before deploying cooperative time-slicing for verl, ensure your environment meets the following requirements:
+
+* Kubernetes **v1.34** or later (we validated on GKE, COS nodes) with 1-GPU nodes (H100-class recommended). The GPUs used for time-slicing must NOT be in use by anything else.
+* GPU nodes must run **NVIDIA GPU Driver 565 or later**. This is a strict requirement to support **NVIDIA Dynamic Resource Allocation (DRA)**. The NVIDIA DRA driver itself ships with the platform Helm chart (§2).
+* Cluster-admin access; `kubectl`, `helm` (v3), and `git` on your workstation.
+* Nodes can pull from Docker Hub (`verlai/verl` image, ~20 GB) and reach GitHub + HuggingFace from pods (model + dataset download at startup; the model is fetched by HF id per node, no shared volume).
+
+### Node Labeling and Time-Slice Groups
+
+The orchestrator discovers resource pools (*groups*) from node labels. Jobs in the same group take turns holding the group's accelerator lock. The principle is that time-slicing machinery touches ONLY time-sliced nodes: the **trainer node** carries all the time-slicing markers — the group label (drives group discovery), the `timeslice.io/enabled` label (the platform-wide marker for nodes participating in time-slicing — the same convention the slime guide uses; in this recipe that is only the trainer node — and what the platform install in §2 targets snapshot-agent and DRA kubelet-plugin placement at), and the isolation taint (keeps unrelated workloads off the shared GPU; all pod specs in this guide tolerate it) — while **rollout nodes carry nothing timeslice-related**. Set up the trainer node with three commands:
+
+```bash
+kubectl label node <trainer-node> group.timeslice.io/trainers=true --overwrite
+kubectl label node <trainer-node> timeslice.io/enabled=true --overwrite
+kubectl taint node <trainer-node> timeslice.io/shared=true:NoSchedule --overwrite
+```
+
+Do NOT put either label on nodes hosting rollout engines, and do not put `timeslice.io/*` pod labels on rollout pods: only labeled pods on labeled nodes are snapshot candidates, so unlabeled rollout processes are never touched by the platform. Rollout nodes need **no labels or taints at all** — rollout pods request GPUs the ordinary way (§ Shared DRA Resource Claim below), which is GPU access, not time-slicing. Placement follows from three guarantees.
+
+1. Both jobs' head pods co-locate on the trainer node because they consume the SAME shared `ResourceClaim`, and a claim's consumers must run where its device is. (If the trainer node lacks CPU/RAM headroom for the second head pod, that pod goes Pending; see the host-RAM sizing rule below.)
+2. Rollout pods can never land on the trainer node: each rollout pod carries a required node anti-affinity on `group.timeslice.io/trainers`.
+3. The device plugin allocates whole GPUs exclusively, so two rollout pods always land on distinct GPUs; on a 1-GPU-per-node topology that means distinct nodes. On multi-GPU nodes this becomes distinct GPUs, possibly on the same node.
+
+On clusters with GPU nodes beyond the recipe's, rollouts may schedule onto any free GPU node; operators running amid other workloads should scope their GPU pool (e.g. with their own labels/taints).
+
+### Shared DRA Resource Claim
+
+Cooperative time-slicing leverages Kubernetes **Dynamic Resource Allocation (DRA)** so multiple jobs' pods can share physical GPU hardware without scheduler blocking — and without elevated pod permissions: the NVIDIA DRA driver injects the GPU and driver userspace into ordinary pods. The recipe contains exactly ONE `ResourceClaim` — the **shared** trainer claim — because sharing is what only DRA can express: reference it from every job's head pod, and each tenant gets the full, unpartitioned GPU during its turn. Rollout pods request their GPUs the ordinary way (`nvidia.com/gpu: 1` via the device plugin) — they need no claims. (On clusters that manage GPUs purely via DRA, with no device plugin, give each rollout pod its own `ExactCount: 1` claim instead — and since the DRA kubelet plugin must then run on the rollout nodes too, drop or widen the `kubeletPlugin` nodeSelector flag from the §2 install.)
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: shared-trainers-gpu-claim
+  namespace: default
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        allocationMode: ExactCount
+        count: 1
+```
+
+Apply the claim before submitting jobs (the example ships this exact file):
+```bash
+kubectl apply -f guides/rl-frameworks/verl/examples/fully-async/resource-claims.yaml
+```
+
+Verify the orchestrator synced the group after labeling:
+
+```bash
+kubectl -n timeslice-system logs deploy/timeslice-timesliceorchestrator --tail=50 \
+  | grep -i trainers | tail -3
+```
+
+### Host-RAM Sizing Rule
+
+A head pod's memory limit must fit its normal RSS **plus its entire GPU allocation** — the cuda-checkpoint dump of a trainer's full GPU state lands in pod memory. Size trainer-node host RAM to hold the GPU memory footprint of every job whose trainer can be checkpointed there.
+
+---
+
+## 2. Deploying the Time-Slicing Platform
+
+Deploy the core platform components — **TimeSlice Orchestrator** (Deployment: the gRPC lock service) and **Snapshot Agent** (DaemonSet on the time-sliced nodes: performs `cuda-checkpoint` snapshot/restore of a job's GPU state when the orchestrator hands the lock over) — using the parent Helm chart.
+
+### Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git
+cd llm-d-rl-time-slicing
+```
+
+> **Release pin:** the chart is not published to a registry — you install it from the clone. To pin a release, clone the repo at the release tag (`git clone --branch <version> https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git`) so the chart matches the pinned images, and pin the images with `--set timesliceorchestrator.image.tag=<version> --set snapshot-agent.image.tag=<version>` (the chart defaults pull the official `ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/*` images at `latest`). Until the first tagged release is cut, `main` + `latest` is the only option.
+
+### Step 2: Install the Helm Chart
+
+Install into a dedicated namespace (`timeslice-system`), pinning the node-level platform components to `timeslice.io/enabled` nodes:
+
+```bash
+helm dependency update ./deploy
+helm install timeslice ./deploy -n timeslice-system --create-namespace \
+  --set-string "snapshot-agent.nodeSelector.timeslice\.io/enabled=true" \
+  --set-string "nvidia-dra-driver-gpu.kubeletPlugin.nodeSelector.timeslice\.io/enabled=true"
+```
+
+The first flag pins the snapshot agent (a `hostPID` DaemonSet) to `timeslice.io/enabled` nodes — in this recipe, just the trainer node; agents on rollout nodes would perform no work anyway (all prior runs confirmed this). The second flag pins the NVIDIA DRA driver's kubelet plugin — the bundled driver's only node-level component, which publishes `ResourceSlice`s and injects the GPU into claim-consuming pods — to the same nodes: DRA is needed exactly where the shared claim binds, and gating it keeps other GPU nodes free of `ResourceSlice`s advertising their GPUs as claimable.
+
+**Zero-impact principle:** you can share the cluster with non-timeslice workloads with zero impact to them. This install plus the labels + taint in §1 touch only the trainer node — the snapshot agent and the DRA kubelet plugin run only there, and every other node carries no platform components, labels, or taints, so workloads on those nodes are unaffected. The recipe's rollout pods compete for free GPUs like any ordinary workload: standard scheduling, no special machinery.
+
+> If a `timeslice` release already exists, do a clean
+> `helm uninstall timeslice -n timeslice-system` first — `helm install` fails
+> on an existing release name. (Note: uninstalling also
+> removes the bundled NVIDIA DRA driver DaemonSet until you reinstall.)
+
+### Step 3: Verify Platform Health
+
+Verify the orchestrator is Running, and that an agent pod and a `nvidia-dra-driver-gpu-kubelet-plugin` pod run on the trainer node — and only there; no other node should carry either:
+
+```bash
+kubectl -n timeslice-system get pods -o wide
+```
+
+Optionally verify with the `rlts` CLI (requires Go toolchain; from the repo root — the same binary is used to observe lock handoffs while jobs run):
+
+```bash
+go build -o bin/rlts ./cmd/rlts
+./bin/rlts orchestrator list
+```
+
+---
+
+## 3. Integrating with verl
+
+### How It Works
+
+The `llm-d-timeslice-verl` package ships `TimesliceFullyAsyncTrainer`, a subclass of verl's `fully_async_policy` trainer that overrides the trainer's empty `on_*` lifecycle hooks to acquire/release the orchestrator lock at the trainer's natural wait points. It registers under the trainer name `timeslice` (verl's `register_trainer` registry; the package's `verl.plugins` entry point makes `import verl` load the registering module) and is selected with a single hydra override: `async_training.trainer_name=timeslice`. No monkey-patching and no verl source edits in your job — it requires a verl build with the fully-async lifecycle hooks + trainer registry and per-pool placement-group bundle resources (currently the `feat/fully-async-lifecycle-hooks` fork branch, until the commits land upstream).
+
+Lock protocol:
+
+| Trainer lifecycle point | Lock action |
+|---|---|
+| `init_workers` (model load) | ACQUIRE → load → YIELD |
+| initial weight sync (pre-fit) | ACQUIRE → sync → YIELD |
+| a batch of samples is ready | ACQUIRE (this is the resume point) |
+| weight update + param sync done | YIELD |
+
+### Placement-Group Pinning
+
+Pin trainer/rollout placement with Ray **custom resources** — start ray on the head with `--resources='{"trainer_node": 100}'`, on the worker with `--resources='{"rollout_node": 100}'`, and pass verl's per-pool placement-group bundle resources (hydra override `ray_pg_extra_resources={trainer_pool: {trainer_node: 1}, rollout_pool: {rollout_node: 1}}`) so verl's trainer placement group requests `{trainer_node: 1}` and the rollout PG `{rollout_node: 1}`.
+
+### Installing verl (Pinned Fork)
+
+In each job pod (or your job image), clone the [`feat/fully-async-lifecycle-hooks`](https://github.com/aishukamal/verl/tree/feat/fully-async-lifecycle-hooks) branch of `github.com/aishukamal/verl` — upstream `983cb0f24443f87b3d161fad318445130a620b07` + two feature commits (fully-async lifecycle hooks + trainer registry; per-pool PG bundle resources) — and install it with `pip install -e ".[gpu]"`. This is a temporary fork until the commits land upstream; once they do, point the install at mainline verl instead (the example manifests parameterize this as the `VERL_REPO`/`VERL_REF` pod envs).
+
+### Installing the `llm-d-timeslice-verl` Package
+
+Install the timeslice client and the integration package in every job pod (or bake them into your job image):
+
+```bash
+# Install the timeslice client library
+pip install "git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/client/python"
+
+# Install the llm-d-timeslice-verl trainer package
+pip install --no-cache-dir --no-deps "llm-d-timeslice-verl @ git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/integrations/verl"
+```
+
+> **Why `--no-deps`?** The package declares no dependencies of its own — the timeslice client it uses is installed separately (above), so there is nothing for pip to resolve.
+
+### Usage
+
+Every time-sliced verl job must carry this contract:
+
+* **Hydra overrides** on the verl launch command:
+  * `async_training.trainer_name=timeslice` — selects the registered timeslice trainer.
+  * `"ray_pg_extra_resources={trainer_pool: {trainer_node: 1}, rollout_pool: {rollout_node: 1}}"` — pins the placement groups (see [Placement-Group Pinning](#placement-group-pinning)).
+  * `trainer.save_freq=-1` — checkpoint saving is disabled under time-slicing: a save RPCs the FSDP worker, which may be checkpointed off the GPU at that moment. The timeslice trainer vetoes saves (with a warning) if this is left `> 0`. Note the consequence: time-sliced runs write no training checkpoints.
+  * `+actor_rollout_ref.rollout.checkpoint_engine.engine_kwargs.nccl.rebuild_group=true` — tears down and rebuilds the trainer↔rollout weight-sync NCCL communicator around each sync, so no communicator exists outside lock-held windows.
+  * `async_training.trigger_parameter_sync_step=1` — yield the GPU once per training step; larger values hold the lock across sample-queue waits.
+  * `async_training.use_dynamic_resource_scheduling=false` and `async_training.use_trainer_do_validate=false` — keep dynamic rescheduling and validation off the time-sliced trainer GPU (both would touch the GPU outside the lock protocol).
+* **`ray start` custom resources**: head `--resources='{"trainer_node": 100}'`, rollout worker `--resources='{"rollout_node": 100}'`.
+* **Environment variables** (set as container-level env vars on both pods, kept identical — the trainer driver actor is a CPU-only Ray actor that can be scheduled on either Ray node and inherits the raylet's env):
+  * `TIMESLICE_FULLY_ASYNC=1` — activates the hooks (they are inert without it).
+  * `TIMESLICE_JOB_ID` — unique per job; must equal the head pod's `timeslice.io/job-id` label.
+  * `TIMESLICE_GROUP` — the group whose lock the trainer takes (e.g. `trainers`).
+  * `TIMESLICE_ORCH_ADDR` — orchestrator gRPC address (`timeslice-timesliceorchestrator.timeslice-system.svc:50051`).
+* **Pod labels** on the head pod ONLY (the trainer is the sole time-sliced process; rollout pods stay unlabeled): `timeslice.io/job-id: <job id>` and `timeslice.io/group: <group>` — the exact keys the platform selects snapshot candidates on.
+* **NCCL environment**: set `NCCL_CUMEM_ENABLE=0` and `NCCL_NVLS_ENABLE=0` on every job pod (the example manifests set both) — precautionary settings around cuda-checkpoint; keep them as set.
+
+---
+
+## 4. Deploying Time-Sliced verl Jobs
+
+Deploy each job as a **2-node Ray cluster**:
+
+* **Head pod** — runs the verl driver + FSDP trainer. Schedule it on the shared, group-labeled trainer node (`nodeSelector: group.timeslice.io/trainers: "true"`), reference the **shared** trainer `ResourceClaim` (the same claim in every job's head pod), and carry the `timeslice.io/job-id` + `timeslice.io/group` pod labels.
+* **Rollout pod** — runs the vLLM rollout engine as a ray worker. Request its GPU the ordinary way (`resources.limits: nvidia.com/gpu: "1"` — the device plugin, no claim), and keep it off the trainer node (whose GPU is claim-managed) with a required node anti-affinity on `group.timeslice.io/trainers` (`operator: DoesNotExist`): it can then land on any GPU node except the trainer node, and since the device plugin allocates whole GPUs exclusively, rollout pods always get distinct GPUs. Leave it unlabeled (no `timeslice.io/*` labels).
+* **Headless Service** — pointing at the head pod, so the rollout pod can resolve the ray head address.
+* **Tolerations** — give both pods tolerations for the GPU-node taints they must land on (the example tolerates `nvidia.com/gpu` and `timeslice.io/shared=true:NoSchedule`).
+
+A complete two-job runnable is provided in [examples/fully-async/](examples/fully-async/).
+
+---
+
+## 5. Submitting and Observing Time-Sliced Jobs
+
+### Step 1: Submit Multiple Jobs
+
+Apply two (or more) independent verl jobs with unique `TIMESLICE_JOB_ID` values and the same `TIMESLICE_GROUP`:
+
+```bash
+kubectl apply -f <job-a>.yaml
+kubectl apply -f <job-b>.yaml
+```
+
+### Step 2: Port-Forward the Orchestrator
+
+```bash
+kubectl port-forward svc/timeslice-timesliceorchestrator 50051:50051 -n timeslice-system
+```
+
+### Step 3: Observe Time-Slicing via the CLI
+
+Watch the shared trainer pool with the `rlts` CLI (built in §2):
+
+```bash
+watch -n 0.5 ./bin/rlts orchestrator status trainers
+```
+
+**Expected output:** the `Active Job` and `Locking Job` alternate between the jobs' `TIMESLICE_JOB_ID`s. While one job's trainer holds the GPU, the other shows up in the `Waiter Queue Depth`. The rollout engines never appear here — they take no locks.
+
+### Step 4: Observe Context Switches in the Logs
+
+The integration package logs every acquire/release into the head pod's log:
+
+```bash
+kubectl logs <head-pod> --tail=2000 | grep -E "ACQUIRE|RELEASE" | tail -5
+# [timeslice] job=<job id> ACQUIRE group=trainers waited=232000ms context_restored=True
+# [timeslice] job=<job id> RELEASE group=trainers pending_waiters=1 snapshot_deferred=False
+```
+
+Snapshot/restore operations appear in the log of the snapshot-agent pod on the shared trainer node:
+
+```bash
+kubectl -n timeslice-system logs <agent-pod-on-trainer-node> --tail=100 | grep -i "cuda-checkpoint"
+```
+
+---
+
+## 6. General Troubleshooting
+
+For failures specific to the runnable demo's topology and manifests, see the [example's troubleshooting section](examples/fully-async/README.md#8-troubleshooting).
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Trainer placement group lands on the rollout node (or rollout work on the trainer node) | PG pinning not active — `--resources` missing on a `ray start` line, or the `ray_pg_extra_resources` hydra override is missing/typo'd, or the verl build lacks the feature | Verify both `ray start` lines carry `--resources`, keep the `ray_pg_extra_resources={trainer_pool: ...}` override in the head launch script intact, and use the pinned verl branch (§3); check `ray status` custom resources |
+| Rollout throughput collapses when the other job trains; agent log shows cuda-checkpoint activity on a ROLLOUT node | A rollout pod carries `timeslice.io/*` labels, or a rollout node is labeled into the group | Rollout pods/nodes must stay unlabeled — only head pods and the trainer node (§1). A rollout node must never show cuda-checkpoint activity |
+| `Found multiple active Ray instances` warning on a shared node | Ray's `address='auto'` discovery found more than one GCS — a driver can join the wrong ray cluster when two jobs' head pods share the trainer node | `export RAY_ADDRESS="$(hostname -i):6379"` right after `ray start --head` (the example manifests do) — keep that line if you edit |
+| Hydra error `Key 'use_trainer_do_validate' is not in struct trainer` | Wrong config key path | These flags live under `async_training.*`, not `trainer.*` (the example manifests are correct) |
+| `save_freq` / checkpoint-save-skipped warning in log | Checkpoint saving would RPC a possibly-frozen worker | By design: the timeslice trainer vetoes saves when `save_freq > 0`; keep `trainer.save_freq=-1` |
+| Steps complete but one job's staleness queue near `staleness_threshold × batch` | Very asymmetric job speeds | Raise `async_training.staleness_threshold` (we use 8) or budget shorter runs; queue overflow drops samples |

--- a/guides/rl-frameworks/verl/examples/fully-async/README.md
+++ b/guides/rl-frameworks/verl/examples/fully-async/README.md
@@ -1,0 +1,368 @@
+# Time-Slicing the Trainers of Two verl Fully-Async RL Jobs on One GPU
+
+This guide runs **two independent verl `fully_async_policy` RL training
+jobs** and time-slices **their trainers on a single shared GPU** through the
+llm-d-rl-time-slicing platform. Each job keeps a dedicated 1-GPU node for its vLLM rollout engine;
+the two FSDP trainers take turns on a third, shared 1-GPU node. The platform
+checkpoints the idle trainer's GPU memory to host RAM (`cuda-checkpoint`) at
+every handoff — no verl source changes, no manual coordination between the
+jobs.
+
+> This demo instantiates the generic step-by-step walkthrough in the
+> **[verl integration guide](../../README.md)** for two concrete jobs. How
+> the integration works (the `TimesliceFullyAsyncTrainer` subclass, lock
+> protocol, placement-group pinning), the platform install, node-labeling
+> concept, and the `llm-d-timeslice-verl` package install are covered there —
+> this README covers only what is specific to this two-job demo.
+
+**Measured results** (2× DeepSeek-R1-Distill-Qwen-1.5B, GRPO, H100s — one math
+job + one code job, ~2.5 h window):
+
+| Metric | Solo baseline | Time-sliced (2 jobs) |
+|---|---|---|
+| Shared trainer GPU duty cycle | 41.6% | **86.6% (2.08×)** |
+| Training steps completed | 10 | **22 (13 + 9)** |
+| Median step time | 627 s | 554 s (A) / 570 s (B) |
+| Median swap cost | — | 21 s snapshot + 9 s restore |
+
+The two jobs in this guide are real, distinct workloads:
+
+- **Job A — math RLVR**: DAPO-Math-17k, rule-based answer matching.
+- **Job B — code RLVR**: Eurus-2 code split, rewards from live in-pod
+  execution of each problem's test cases (`prime_code`).
+
+Both use GRPO on DeepSeek-R1-Distill-Qwen-1.5B (MIT-licensed, ungated — no
+HuggingFace token needed).
+
+---
+
+## 1. Architecture
+
+```
+   three 1-GPU nodes (we use GKE a3-highgpu-1g, 1× H100 each)
+
+  ROLLOUT NODE A            ROLLOUT NODE B            TRAINER NODE (SHARED)
+  ┌──────────────────┐      ┌──────────────────┐      ┌───────────────────────┐
+  │ job-a-rollout    │      │ job-b-rollout    │      │ job-a-head  job-b-head│
+  │ vLLM, always on  │      │ vLLM, always on  │      │ trainer A ⇄ trainer B │
+  │ (ray worker)     │      │ (ray worker)     │      │ alternating via       │
+  └────────┬─────────┘      └────────┬─────────┘      │ cuda-checkpoint C/R   │
+           │ ray (job A)             │ ray (job B)    └──────────┬────────────┘
+           │                         │                           │ snapshot/restore
+           ▼                         ▼                           │ (snapshot agent
+  ┌──────────────────┐      ┌──────────────────┐                 │  DaemonSet)
+  │ job-a-head       │      │ job-b-head       │◀────────────────┘
+  │ ray head + verl  │      │ ray head + verl  │
+  │ driver + plugin  │      │ driver + plugin  │
+  └────────┬─────────┘      └────────┬─────────┘
+           │ gRPC lock               │ gRPC lock
+           └────────────┬────────────┘
+                        ▼
+             ┌─────────────────────┐
+             │ TimeSlice           │
+             │ Orchestrator        │
+             │ (group lock)        │
+             └─────────────────────┘
+```
+
+Each job is a **2-node Ray cluster**: a head pod on the shared trainer node
+(runs the verl driver + FSDP trainer) and a rollout pod on a dedicated node
+(runs the vLLM rollout engine). Trainer/rollout placement is pinned exactly
+as described in the integration guide's
+[placement-group pinning section](../../README.md#placement-group-pinning) —
+the head starts ray with `--resources='{"trainer_node": 100}'`, the worker
+with `--resources='{"rollout_node": 100}'`, and both manifests carry the
+`ray_pg_extra_resources={trainer_pool: {trainer_node: 1}, rollout_pool:
+{rollout_node: 1}}` hydra override.
+
+The platform pieces at work — the **TimeSlice Orchestrator** (group lock),
+the **Snapshot Agent** DaemonSet (cuda-checkpoint snapshot/restore at each
+handoff), and the **`llm-d-timeslice-verl` integration package** (installed inside
+each pod, selected via `async_training.trainer_name=timeslice`) — are
+described in the [integration guide](../../README.md#3-integrating-with-verl).
+In this topology, only the **head pods** carry the `timeslice.io/*` labels the
+platform selects on; the rollout pods are unlabeled and live on other nodes,
+so rollout processes are never touched. While a job's trainer is checkpointed
+off the shared GPU, its rollout node keeps generating samples into the
+staleness queue.
+
+## 2. Prerequisites
+
+Cluster-wide prerequisites (workstation tools, image/network reachability,
+node labeling, host-RAM sizing rule) are in the
+[integration guide §1](../../README.md#1-cluster-prerequisites). Specific to
+this demo:
+
+- **Three 1-GPU nodes** (H100-class recommended; the reference shape is GKE
+  `a3-highgpu-1g`, 26 vCPU / 234 Gi each): one shared trainer node + one
+  dedicated rollout node per job. The GPUs must NOT be in use by anything
+  else.
+- No HuggingFace token required (model and datasets are ungated).
+- Host RAM on the trainer node: the two head pods request 80 Gi each
+  (110 Gi limit) — for this 1.5 B model the trainer's shared-GPU footprint
+  reaches ~50 GB, and the cuda-checkpoint dump lands in pod memory (see the
+  [host-RAM sizing rule](../../README.md#host-ram-sizing-rule)).
+
+**Version pins used throughout** (change nothing on the first run) — the verl
+fork branch, platform images, and `llm-d-timeslice-verl` package install are pinned
+in the [integration guide](../../README.md) (§2–3); demo-specific pins:
+
+| Component | Pin |
+|---|---|
+| Job container image | `verlai/verl:vllm020.dev2` |
+| Model | `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B` (HF id, downloaded per node) |
+
+Files in this guide directory:
+
+| File | What it is |
+|---|---|
+| `resource-claims.yaml` | The single DRA `ResourceClaim`, shared by both head pods (rollout pods request GPUs via the ordinary device plugin instead) |
+| `job-a-math.yaml` | Job A (math RLVR): ConfigMap + head pod + rollout pod + headless Service |
+| `job-b-code.yaml` | Job B (code RLVR): ConfigMap + head pod + rollout pod + headless Service |
+
+## 3. Step 1 — Install the time-slicing platform
+
+Follow the [integration guide §2](../../README.md#2-deploying-the-time-slicing-platform)
+(including the clean-uninstall note if you previously installed the platform
+and the verify step):
+
+```bash
+git clone https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git
+cd llm-d-rl-time-slicing
+
+helm dependency update ./deploy
+helm install timeslice ./deploy -n timeslice-system --create-namespace \
+  --set-string "snapshot-agent.nodeSelector.timeslice\.io/enabled=true" \
+  --set-string "nvidia-dra-driver-gpu.kubeletPlugin.nodeSelector.timeslice\.io/enabled=true"
+```
+
+The first `--set-string` pins the snapshot agent to `timeslice.io/enabled`
+nodes; the second pins the NVIDIA DRA driver's kubelet plugin to the same
+nodes. Both pods appear on the trainer node (and only there) as soon as you
+apply the labels in the next step — the two rollout nodes carry no platform
+components at all. The chart defaults pull the
+official platform images at `latest`; see the integration guide's
+release-pin note for pinning a tagged release once one is cut.
+
+No snapshot-device filter is needed in this topology: every node has exactly
+one GPU, and only the labeled head pods on the trainer node are snapshot
+candidates.
+
+## 4. Step 2 — Apply the DRA resource claim, then label the trainer node
+
+First create the recipe's single DRA `ResourceClaim` — the **shared** claim
+referenced by BOTH head pods (that is what lets the two trainers co-locate
+on the one shared GPU, each holding the full, unpartitioned GPU during its
+turn; the rollout pods request their GPUs via the ordinary device plugin
+instead — see the integration guide's
+[Shared DRA Resource Claim](../../README.md#shared-dra-resource-claim)
+section):
+
+```bash
+kubectl apply -f resource-claims.yaml
+```
+
+Only the **trainer node** (shared by both jobs' head pods) needs setup — it
+carries all the time-slicing markers, while the rollout nodes carry nothing
+timeslice-related. Label it into the `trainers` group (see the
+[labeling concept](../../README.md#node-labeling-and-time-slice-groups);
+no other node may carry it — the label drives group discovery), mark it
+`timeslice.io/enabled` (the platform-wide marker for nodes participating in
+time-slicing — here, only the trainer node — which the §3 install targets
+snapshot-agent and DRA kubelet-plugin placement at), and taint it to keep
+unrelated workloads off the shared GPU (the example pods already carry the
+matching toleration):
+
+```bash
+kubectl label node <trainer-node> group.timeslice.io/trainers=true --overwrite
+kubectl label node <trainer-node> timeslice.io/enabled=true --overwrite
+kubectl taint node <trainer-node> timeslice.io/shared=true:NoSchedule --overwrite
+```
+
+The rollout nodes need no labels or taints. Placement follows from three
+guarantees (detailed in the
+[labeling concept](../../README.md#node-labeling-and-time-slice-groups)):
+both head pods co-locate on the trainer node because they consume the same
+shared claim, and a claim's consumers must run where its device is (if the
+trainer node lacks CPU/RAM headroom, the second head pod goes Pending; see
+the host-RAM sizing rule); rollout pods can never land on the trainer node
+(required anti-affinity); and the two rollout pods always get distinct GPUs
+because the device plugin allocates whole GPUs exclusively, which on this
+1-GPU-per-node topology means distinct nodes (on multi-GPU nodes it means
+distinct GPUs, possibly on the same node). On clusters with GPU nodes beyond
+this recipe's three, rollouts may schedule onto any free GPU node; operators
+running amid other workloads should scope their GPU pool (e.g. with their
+own labels/taints).
+
+Verify the platform sees the group (the orchestrator group-sync check is in
+the
+[integration guide §1](../../README.md#node-labeling-and-time-slice-groups)),
+and grab the agent pod on the trainer node — you'll grep its logs in §6:
+
+```bash
+# a snapshot-agent pod runs on the trainer node (and only there):
+AGENT_POD=$(kubectl -n timeslice-system get pods -l app.kubernetes.io/name=snapshot-agent \
+  --field-selector spec.nodeName=<trainer-node> -o jsonpath='{.items[0].metadata.name}')
+echo "$AGENT_POD"
+
+# the DRA kubelet-plugin pod is likewise on the trainer node, and only there:
+kubectl -n timeslice-system get pods -l nvidia-dra-driver-gpu-component=kubelet-plugin -o wide
+```
+
+## 5. Step 3 — Launch the two jobs
+
+At startup the job pods pip-install the `llm-d-timeslice-verl` package (and
+the timeslice client) straight from the repo — commands and details in the
+[integration guide §3](../../README.md#installing-the-llm-d-timeslice-verl-package)
+— and each pod clones and installs the
+[pinned verl fork branch](../../README.md#installing-verl-pinned-fork)
+(once the commits land upstream, point the `VERL_REPO`/`VERL_REF` pod
+envs at mainline verl instead).
+
+Launch:
+
+```bash
+# Training budget: default 5400 s (~90 min) per job — edit the RUN_SECONDS
+# env in each yaml to change it.
+kubectl apply -f job-a-math.yaml
+kubectl apply -f job-b-code.yaml
+```
+
+Placement needs no per-rollout node labels: the head pods land on the
+`group.timeslice.io/trainers` node (their shared claim binds there), and
+each rollout pod lands on any GPU node except the trainer node (required
+anti-affinity) with an ordinary device-plugin GPU (`nvidia.com/gpu: 1` —
+the device plugin allocates whole GPUs exclusively, so the two rollouts
+always get distinct GPUs). Neither path needs elevated pod permissions.
+
+Each job creates 4 objects in namespace `default`: a ConfigMap, a head pod
+(`job-a-head` / `job-b-head`, on the trainer node), a rollout pod
+(`job-a-rollout` / `job-b-rollout`, on its dedicated node) and a headless
+Service the rollout pod uses to find the ray head. Startup takes **20–45
+minutes** before the first training step (much less when the image and HF
+caches are warm on the nodes): every pod installs verl from the pinned
+branch and the integration package; **both pods prepare the dataset locally** (the
+`FullyAsyncRollouter` actor runs on the rollout pod and reads the parquet
+there — no shared volume, same seed ⇒ identical files); the head waits (up
+to 40 min) for its rollout pod to join the ray cluster and downloads the
+model by HF id. This is all logged; slow ≠ stuck (see §6 for what to
+expect when).
+
+## 6. Step 4 — Watch it work
+
+```bash
+kubectl logs job-a-head --tail=30        # never use -f in scripts; poll instead
+kubectl logs job-a-rollout --tail=10
+```
+
+The sequence you should see per job (grep-able markers):
+
+1. `Phase 1: install verl` (both pods, ~20 min) → head: `Phase 2b: wait for
+   the rollout pod to join` (a progress line every 20 s poll) → `Phase 3:
+   prepare dataset`.
+2. `[timeslice] job=job-a-trainer ACQUIRE group=trainers waited=...ms` — first
+   acquisition (model load onto the shared GPU). Grep for `"ACQUIRE"`; note
+   the job scripts run under `set -x`, so echoed lines appear twice (once
+   with a `+` trace prefix).
+3. Alternation, visible in both job logs and the agent's:
+
+```bash
+# lock handoffs: the integration package logs every acquire/release
+# ([timeslice] ... ACQUIRE/RELEASE lines, forwarded into the head pod's log):
+kubectl logs job-a-head --tail=2000 | grep -E "ACQUIRE|RELEASE" | tail -5
+# [timeslice] job=job-a-trainer ACQUIRE group=trainers waited=232000ms context_restored=True
+# [timeslice] job=job-a-trainer RELEASE group=trainers pending_waiters=1 snapshot_deferred=False
+
+# snapshot/restore operations on the shared trainer GPU:
+kubectl -n timeslice-system logs "$AGENT_POD" --tail=100 | grep -i "cuda-checkpoint"
+```
+
+### Observe time-slicing via the `rlts` CLI
+
+You can also watch the orchestrator's group state directly. Port-forward the
+orchestrator gRPC service:
+
+```bash
+kubectl port-forward svc/timeslice-timesliceorchestrator 50051:50051 -n timeslice-system
+```
+
+Then watch the shared `trainers` pool with the `rlts` CLI (built in the
+integration guide's platform-verify step:
+`go build -o bin/rlts ./cmd/rlts` from the repo root):
+
+```bash
+watch -n 0.5 ./bin/rlts orchestrator status trainers
+```
+
+**Expected output:** the `Active Job` and `Locking Job` alternate between
+`job-a-trainer` and `job-b-trainer`. While one job's trainer holds the GPU,
+the other shows up in the `Waiter Queue Depth` (depth = 1). The rollout
+engines never appear here — they take no locks.
+
+Healthy steady state (after ~2 warm-up steps): demand-driven A↔B alternation
+(mostly A→B→A→B; a job takes back-to-back bursts when the other's sample
+queue isn't ready yet — that backfill is the point, not a fault);
+`waited=` on ACQUIRE ≈ the other job's training burst (2–6 min for this
+model); snapshots 12–35 s, restores 5–14 s;
+`count/dropped_stale_samples` stays 0 in the verl stat lines (the key
+appears periodically — check its value, not the line count).
+
+The run ends when `RUN_SECONDS` expires (`timeout` sends INT — the log line
+`Training stopped by planned ... timeout (expected end state)` is success, and
+the head pod stays alive 2 h for result collection).
+
+## 7. Step 5 — Collect results
+
+```bash
+for POD in job-a-head job-b-head; do
+  mkdir -p "results/$POD"
+  kubectl cp "$POD:/workspace/results/train.log" "results/$POD/train.log" || true
+done
+```
+
+- `train.log` — full verl output (steps, rewards, timing breakdown, and the
+  `[timeslice]` ACQUIRE/RELEASE lock-handoff lines; head pod).
+
+## 8. Troubleshooting
+
+General failures — unpinned placement groups,
+ray `address='auto'` cross-talk, hydra key
+paths, the `save_freq` veto, staleness-queue overflow — are covered in the
+[integration guide §6](../../README.md#6-general-troubleshooting). The rows
+below are specific to this demo's manifests and topology:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Head log stuck at `Phase 2b: wait for the rollout pod to join` past 40 min, then `FATAL: rollout pod did not join` | Rollout pod Pending/crashed, or it can't resolve the headless Service (`<job>-head.default.svc.cluster.local:6379`) | `kubectl get pod job-a-rollout; kubectl logs job-a-rollout --tail=50`; both pods and the Service must come from the same rendered manifest |
+| Head pod Pending forever | Trainer node lacks free CPU/RAM for the second 8-CPU/80 Gi head request | The two head pods need ~17 CPU / 161 Gi on the trainer node (a3-highgpu-1g: 26 vCPU / 234 Gi) |
+| Node reclaimed mid-run (spot/preemptible) | — | Results live in the pods (emptyDir): collect every ~10 min on spot capacity, or use on-demand nodes |
+
+## 9. Adapting to your workload
+
+Swap either job's model/data with three overrides in its manifest (and keep
+everything under "Required" comments intact):
+
+- `actor_rollout_ref.model.path` — any HF model id (fits on one GPU;
+  TP > 1 is not yet supported by the snapshot path)
+- `data_prep.py` + `data.train_files`/`val_files` — your dataset in verl
+  RLHFDataset format
+- `trainer.experiment_name`
+
+Rules of thumb when scaling up: snapshot time grows with allocated trainer
+memory (~13 s at 3 GB → ~35 s at 50 GB on H100 + PCIe host RAM); swap overhead
+is amortized by your step time (keep bursts ≥ 10× swap cost);
+`async_training.trigger_parameter_sync_step=1` yields once per step — raise it
+to trade staleness for fewer swaps.
+
+## 10. Teardown
+
+```bash
+kubectl delete pod job-a-head job-a-rollout job-b-head job-b-rollout --ignore-not-found
+kubectl delete service job-a-head job-b-head --ignore-not-found
+kubectl delete configmap ts-job-a ts-job-b --ignore-not-found
+kubectl delete -f resource-claims.yaml --ignore-not-found
+helm uninstall timeslice -n timeslice-system
+kubectl label node <trainer-node> group.timeslice.io/trainers- || true
+kubectl label node <trainer-node> timeslice.io/enabled- || true
+kubectl taint node <trainer-node> timeslice.io/shared- || true
+```

--- a/guides/rl-frameworks/verl/examples/fully-async/job-a-math.yaml
+++ b/guides/rl-frameworks/verl/examples/fully-async/job-a-math.yaml
@@ -1,0 +1,588 @@
+# Job A (math RLVR) for the two-RL-jobs time-slicing guide — disaggregated
+# 1-GPU-per-node shape. DAPO-Math-17k, verl fully_async_policy, GRPO,
+# R1-Distill-Qwen-1.5B.
+# Training budget: edit the RUN_SECONDS env below (default 5400 s ~= 90 min).
+#
+# Topology: each job is a 2-node Ray cluster. Placement needs no per-rollout
+# node labels:
+#   job-a-head    on the SHARED 1-GPU trainer node (label
+#                 group.timeslice.io/trainers=true; hosts job-a-head AND
+#                 job-b-head): ray head, FSDP trainer (time-sliced with job B)
+#   job-a-rollout on any GPU node except the trainer node (required
+#                 anti-affinity on group.timeslice.io/trainers); its GPU is
+#                 an ordinary device-plugin request (nvidia.com/gpu: 1), and
+#                 the device plugin allocates whole GPUs exclusively, so the
+#                 two jobs' rollouts land on distinct GPUs: ray worker, vLLM
+#                 rollout engine (always on)
+# Placement is pinned by Ray CUSTOM RESOURCES, not GPU masks: the head starts
+# ray with --resources='{"trainer_node": 100}', the worker with
+# --resources='{"rollout_node": 100}', and verl's per-pool placement-group
+# bundle resources (hydra override ray_pg_extra_resources={trainer_pool:
+# {trainer_node: 1}, rollout_pool: {rollout_node: 1}}) make verl's trainer
+# placement group request {trainer_node: 1} and the rollout PG
+# {rollout_node: 1}.
+#
+# GPU access: the shared trainer GPU is the recipe's ONLY DRA ResourceClaim
+# (see resource-claims.yaml) — both jobs' head pods reference the SAME
+# shared-trainers-gpu-claim, which is what lets them co-locate on the one
+# shared trainer GPU without scheduler blocking (each holds the full,
+# unpartitioned GPU during its turn); the NVIDIA DRA driver injects the GPU
+# + driver userspace into the container. The rollout pods request their
+# GPUs the ordinary way (nvidia.com/gpu: 1 via the device plugin). Neither
+# path needs elevated pod permissions. Each node has exactly ONE GPU, so
+# there is nothing to mask — every process sees cuda:0.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ts-job-a
+  namespace: default
+data:
+  data_prep.py: |
+    #!/usr/bin/env python3
+    """Prepare DAPO-Math-17k subsets for the async long-CoT experiment.
+
+    Source: HF dataset BytedTsinghua-SIA/DAPO-Math-17k (data/dapo-math-17k.parquet),
+    which is ALREADY in verl RLHFDataset format:
+      - data_source = "math_dapo"  -> default reward routing hits
+        verl.utils.reward_score.math_dapo.compute_score (Answer: <ans> extraction,
+        matching the instruction baked into every prompt)
+      - prompt = [{"role": "user", "content": "...Remember to put your answer on its
+        own line after \"Answer:\"..."}]
+      - reward_model = {"style": "rule", "ground_truth": "<answer string>"}
+
+    We only subsample (512 train / 64 val, disjoint) and sanity-check the schema.
+    No agent_name column -> single_turn_agent (default), single-turn long CoT.
+    """
+
+    import argparse
+    import os
+
+    import pandas as pd
+    from huggingface_hub import hf_hub_download
+
+
+    def main():
+        ap = argparse.ArgumentParser()
+        ap.add_argument("--repo_id", default="BytedTsinghua-SIA/DAPO-Math-17k")
+        ap.add_argument("--filename", default="data/dapo-math-17k.parquet")
+        ap.add_argument("--out_dir", default="/workspace/data/dapo_math")
+        ap.add_argument("--train_size", type=int, default=512)
+        ap.add_argument("--val_size", type=int, default=64)
+        ap.add_argument("--seed", type=int, default=17)
+        args = ap.parse_args()
+
+        local = hf_hub_download(repo_id=args.repo_id, filename=args.filename, repo_type="dataset")
+        df = pd.read_parquet(local)
+        print(f"loaded {len(df)} rows, columns: {list(df.columns)}")
+
+        # ---- schema sanity checks (fail fast, before burning GPU time) ----
+        row = df.iloc[0]
+        prompt = row["prompt"]
+        assert row["data_source"] == "math_dapo", f"unexpected data_source {row['data_source']!r}"
+        p0 = prompt[0] if not isinstance(prompt, dict) else prompt
+        p0 = dict(p0)
+        assert p0.get("role") == "user" and isinstance(p0.get("content"), str), f"bad prompt row: {p0}"
+        assert "Answer:" in p0["content"], "prompt lacks the Answer: instruction the reward fn expects"
+        rm = dict(row["reward_model"])
+        gt = rm.get("ground_truth")
+        assert isinstance(gt, str) and gt, f"bad ground_truth: {gt!r}"
+        print("schema OK; sample prompt (first 400 chars):")
+        print(p0["content"][:400])
+        print("sample ground_truth:", gt[:100])
+
+        # Deduplicate on prompt text so train/val are truly distinct problems.
+        df = df.assign(_ptext=df["prompt"].map(lambda p: dict(list(p)[0])["content"]))
+        df = df.drop_duplicates("_ptext").drop(columns="_ptext").reset_index(drop=True)
+        print(f"{len(df)} unique problems after dedup")
+
+        n = args.train_size + args.val_size
+        sub = df.sample(n=min(n, len(df)), random_state=args.seed).reset_index(drop=True)
+        train = sub.iloc[: args.train_size]
+        val = sub.iloc[args.train_size : args.train_size + args.val_size]
+
+        os.makedirs(args.out_dir, exist_ok=True)
+        train.to_parquet(os.path.join(args.out_dir, "train.parquet"), index=False)
+        val.to_parquet(os.path.join(args.out_dir, "val.parquet"), index=False)
+        print(f"wrote {len(train)} train / {len(val)} val -> {args.out_dir}")
+
+
+    if __name__ == "__main__":
+        main()
+
+  install_common.sh: |
+    #!/usr/bin/env bash
+    # Phase 1 installs, identical on head and rollout pods (sourced).
+    # verl with fully-async lifecycle hooks + trainer registry and per-pool
+    # PG bundle resources, installed directly from the fork branch
+    # (override via VERL_REPO/VERL_REF pod env).
+    VERL_REPO="${VERL_REPO:-https://github.com/aishukamal/verl.git}"
+    VERL_REF="${VERL_REF:-feat/fully-async-lifecycle-hooks}"
+
+    echo "=== Phase 1: install verl @ $VERL_REPO $VERL_REF ==="
+    pip install datasets TransferQueue 2>&1 | tail -5
+    git clone --filter=blob:none "$VERL_REPO" /workspace/verl-src
+    cd /workspace/verl-src
+    # A branch from a fresh clone exists only as a remote ref, and git's
+    # create-tracking-branch DWIM conflicts with --detach; try the remote
+    # ref first, then fall back for SHA/tag refs.
+    git checkout --detach "origin/$VERL_REF" 2>/dev/null || git checkout --detach "$VERL_REF"
+    git rev-parse HEAD | tee "$RESULTS_DIR/verl_commit"
+    pip install -e ".[gpu]" 2>&1 | tail -10
+    cd /workspace
+    pip install cupy-cuda12x 2>&1 | tail -3
+    python3 -c "import verl; print('verl version:', verl.__version__)"
+    python3 -c "import transfer_queue; print('transfer_queue OK')"
+
+    echo "=== Phase 1b: install timeslice lock client + verl plugin wrapper ==="
+    pip install "git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/client/python" 2>&1 | tail -3
+    # The client's generated stubs need grpcio>=1.81 and protobuf gencode
+    # 7.35; the image ships grpcio 1.80.0 / protobuf 6.33.6. Upgrade both
+    # before the import check below.
+    pip install "grpcio>=1.81.0" "protobuf>=7.35.0" 2>&1 | tail -2
+    # Install the timeslice-verl integration package (lock protocol via
+    # verl's fully-async lifecycle hooks). It ships TimesliceFullyAsyncTrainer,
+    # a FullyAsyncTrainer subclass registered under the trainer name
+    # "timeslice" (selected by the async_training.trainer_name=timeslice hydra
+    # override in run_head.sh); installing it registers a `verl.plugins` entry
+    # point, so `import verl` loads the registering module in every process.
+    # The hooks are inert unless TIMESLICE_FULLY_ASYNC=1 is set.
+    # Placement-group pinning comes from
+    # verl's own ray_pg_extra_resources config (see the hydra overrides in
+    # run_head.sh).
+    # --no-deps: the timeslice client is already installed above and the
+    # package declares no other dependencies.
+    pip install --no-cache-dir --no-deps "llm-d-timeslice-verl @ git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/integrations/verl" 2>&1 | tail -3
+    python3 <<'CHK'
+    import importlib.metadata as md
+    eps = list(md.entry_points(group="verl.plugins"))
+    assert any(ep.name == "timeslice" for ep in eps), f"verl.plugins entry point missing: {eps}"
+    import verl  # noqa: F401 - loads verl.plugins entries -> registers the timeslice trainer
+    from verl.experimental.fully_async_policy.fully_async_trainer import get_trainer_cls
+    from timeslice_verl.trainer import TimesliceFullyAsyncTrainer
+    assert get_trainer_cls("timeslice") is TimesliceFullyAsyncTrainer, "timeslice trainer not registered"
+    try:
+        from timeslice import OrchestratorClient  # noqa: F401
+    except ImportError:  # newer client versions export TimeSliceOrchestratorClient instead (same API)
+        from timeslice import TimeSliceOrchestratorClient as OrchestratorClient
+    print("timeslice trainer install OK; registered as:", get_trainer_cls("timeslice").__name__)
+    CHK
+
+  run_head.sh: |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+
+    # On ANY exit, kill background children so the stdout pipe to tee is
+    # released and the container surfaces the real exit status.
+    trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+
+    RESULTS_DIR="/workspace/results"
+    MODEL_ID="deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"   # HF id; cached per node under HF_HOME
+    TRAIN_FILE="/workspace/data/dapo_math/train.parquet"
+    VAL_FILE="/workspace/data/dapo_math/val.parquet"
+    # RUN_SECS mirrors the pod env RUN_SECONDS, with a script-side default.
+    RUN_SECS="${RUN_SECONDS:-5400}"
+    RAY_WAIT_BUDGET_S=2400     # 40 min: the rollout pod's installs take ~20 min
+
+    mkdir -p "$RESULTS_DIR"
+
+    echo "=== Phase 0: verify GPU visibility (DRA-injected) ==="
+    # The NVIDIA DRA driver injects the GPU + driver userspace via the pod's
+    # ResourceClaim — no PATH/LD_LIBRARY_PATH setup or elevated permissions needed.
+    # 1-GPU-per-node topology: exactly ONE GPU must be visible. No masks, no
+    # CUDA_VISIBLE_DEVICES — the node's only GPU is cuda:0 for every process.
+    NVIS=$(nvidia-smi -L | wc -l)
+    nvidia-smi -L
+    if [ "$NVIS" != 1 ]; then
+        echo "FATAL: expected exactly 1 visible GPU on the trainer node, got $NVIS"; exit 96
+    fi
+
+    source /workspace/scripts/install_common.sh
+
+    echo "=== Phase 2: start ray head (trainer_node custom resource pins the trainer PG here) ==="
+    # NOTE: --resources takes JSON with DOUBLE quotes; keep the single-quote wrapper.
+    ray start --head --port=6379 --num-gpus=1 --resources='{"trainer_node": 100}'
+    # Two jobs' head pods share the trainer node: never rely on
+    # ray.init(address='auto') discovery — pin every in-pod ray.init to OUR
+    # head explicitly.
+    export RAY_ADDRESS="$(hostname -i):6379"
+
+    echo "=== Phase 2b: wait for the rollout pod to join (budget ${RAY_WAIT_BUDGET_S}s) ==="
+    DEADLINE=$(( $(date +%s) + RAY_WAIT_BUDGET_S ))
+    until timeout 60 python3 -c "
+    import sys
+    import ray
+    ray.init(address='auto', log_to_driver=False)
+    gpus = sum(n['Resources'].get('GPU', 0) for n in ray.nodes() if n['Alive'])
+    print('ray cluster GPUs visible:', gpus, flush=True)
+    sys.exit(0 if gpus >= 2 else 1)
+    "; do
+        if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+            echo "FATAL: rollout pod did not join the ray cluster within ${RAY_WAIT_BUDGET_S}s"
+            ray status || true
+            exit 95
+        fi
+        echo "still waiting for the rollout pod to join (its installs take ~20 min); next poll in 20s — $(date)"
+        sleep 20
+    done
+    ray status
+
+    echo "=== Phase 3: prepare dataset (512 DAPO-Math-17k prompts) ==="
+    python3 /workspace/scripts/data_prep.py --out_dir /workspace/data/dapo_math \
+        --train_size 512 --val_size 64
+
+    echo "=== Phase 3b: chat-template sanity check (forced <think> must be active) ==="
+    python3 << 'TMPLCHECK'
+    import pandas as pd
+    from transformers import AutoTokenizer
+    tok = AutoTokenizer.from_pretrained("deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B")
+    df = pd.read_parquet("/workspace/data/dapo_math/train.parquet")
+    msgs = [dict(m) for m in df.iloc[0]["prompt"]]
+    rendered = tok.apply_chat_template(msgs, add_generation_prompt=True, tokenize=False)
+    print("RENDERED PROMPT TAIL:", rendered[-200:])
+    assert rendered.rstrip().endswith("<think>"), "chat template does not force <think> - CoT premise broken"
+    ntok = len(tok.apply_chat_template(msgs, add_generation_prompt=True))
+    print(f"prompt tokens: {ntok}")
+    assert ntok < 2048, f"prompt longer than max_prompt_length: {ntok}"
+    print("Chat template check OK")
+    TMPLCHECK
+
+    echo "=== Phase 4: fully-async long-CoT training ==="
+    echo "  Model: DeepSeek-R1-Distill-Qwen-1.5B | Dataset: DAPO-Math-17k (512 prompts)"
+    echo "  lr=${ACTOR_LR:-1e-6} exp=${EXP_NAME:-unnamed} staleness=${STALENESS_THRESHOLD:-8}"
+    echo "  timeslice: job=${TIMESLICE_JOB_ID:-?} group=${TIMESLICE_GROUP:-?} orch=${TIMESLICE_ORCH_ADDR:-?}"
+    nvidia-smi
+
+    export PYTHONUNBUFFERED=1
+    export HYDRA_FULL_ERROR=1
+
+    TOTAL_ROLLOUT_STEPS=65536   # >> trainer consumption; None-sentinel must not fire
+
+    run_training() {
+        # timeout bounds the experiment; exit 124 (timeout) is the EXPECTED end state.
+        timeout --signal=INT --kill-after=120 "$RUN_SECS" \
+        python3 -m verl.experimental.fully_async_policy.fully_async_main \
+            data.train_files="$TRAIN_FILE" \
+            data.val_files="$VAL_FILE" \
+            data.prompt_key=prompt \
+            data.truncation=left \
+            data.max_prompt_length=2048 \
+            data.max_response_length=16384 \
+            data.train_batch_size=0 \
+            data.gen_batch_size=1 \
+            data.return_raw_chat=True \
+            actor_rollout_ref.model.path="$MODEL_ID" \
+            actor_rollout_ref.model.use_remove_padding=True \
+            actor_rollout_ref.model.enable_gradient_checkpointing=True \
+            actor_rollout_ref.hybrid_engine=False \
+            actor_rollout_ref.actor.strategy=fsdp \
+            actor_rollout_ref.actor.ppo_mini_batch_size=64 \
+            actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+            actor_rollout_ref.actor.use_kl_loss=False \
+            actor_rollout_ref.actor.kl_loss_coef=0.0 \
+            actor_rollout_ref.actor.entropy_coeff=0 \
+            actor_rollout_ref.actor.grad_clip=1.0 \
+            actor_rollout_ref.actor.loss_agg_mode=token-mean \
+            actor_rollout_ref.actor.use_dynamic_bsz=True \
+            actor_rollout_ref.actor.ppo_max_token_len_per_gpu=36864 \
+            actor_rollout_ref.actor.optim.lr="${ACTOR_LR:-1e-6}" \
+            actor_rollout_ref.actor.optim.lr_warmup_steps=-1 \
+            actor_rollout_ref.actor.fsdp_config.param_offload=False \
+            actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+            actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True \
+            actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=36864 \
+            actor_rollout_ref.rollout.name=vllm \
+            actor_rollout_ref.rollout.mode=async \
+            actor_rollout_ref.rollout.n=8 \
+            actor_rollout_ref.rollout.calculate_log_probs=True \
+            actor_rollout_ref.rollout.checkpoint_engine.backend=nccl \
+            +actor_rollout_ref.rollout.checkpoint_engine.engine_kwargs.nccl.rebuild_group=True \
+            actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+            actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+            actor_rollout_ref.rollout.max_model_len=18432 \
+            actor_rollout_ref.rollout.max_num_batched_tokens=18432 \
+            actor_rollout_ref.rollout.enable_chunked_prefill=True \
+            actor_rollout_ref.rollout.temperature=1.0 \
+            actor_rollout_ref.rollout.top_p=1.0 \
+            actor_rollout_ref.rollout.top_k=-1 \
+            algorithm.adv_estimator=grpo \
+            algorithm.use_kl_in_reward=False \
+            algorithm.kl_ctrl.kl_coef=0.0 \
+            trainer.logger="['console']" \
+            trainer.val_before_train=False \
+            trainer.save_freq=-1 \
+            trainer.resume_mode=disable \
+            trainer.nnodes=1 \
+            trainer.n_gpus_per_node=1 \
+            trainer.total_epochs=10 \
+            trainer.test_freq=-1 \
+            trainer.project_name=timeslice-demo \
+            trainer.experiment_name="${EXP_NAME:-two-jobs-math-a}" \
+            trainer.default_local_dir="$RESULTS_DIR/ckpts" \
+            rollout.nnodes=1 \
+            rollout.n_gpus_per_node=1 \
+            rollout.total_rollout_steps="$TOTAL_ROLLOUT_STEPS" \
+            async_training.staleness_threshold="${STALENESS_THRESHOLD:-8}" \
+            async_training.trainer_name=timeslice \
+            async_training.trigger_parameter_sync_step=1 \
+            async_training.use_dynamic_resource_scheduling=False \
+            async_training.use_trainer_do_validate=False \
+            "ray_pg_extra_resources={trainer_pool: {trainer_node: 1}, rollout_pool: {rollout_node: 1}}" \
+            2>&1 | tee "$RESULTS_DIR/train.log"
+        return "${PIPESTATUS[0]}"
+    }
+
+    set +e
+    run_training
+    TRAIN_RC=$?
+    set -e
+    if [ "$TRAIN_RC" = "124" ]; then
+        echo "Training stopped by planned ${RUN_SECS}s timeout (expected end state)"
+    elif [ "$TRAIN_RC" != "0" ]; then
+        echo "WARNING: training exited rc=$TRAIN_RC before planned timeout"
+    fi
+
+    echo "=== Keeping pod alive for result collection ==="
+    sleep 7200
+
+  run_rollout.sh: |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+
+    trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+
+    RESULTS_DIR="/workspace/results"
+    RAY_HEAD_ADDR="job-a-head.default.svc.cluster.local:6379"
+
+    mkdir -p "$RESULTS_DIR"
+
+    echo "=== Phase 0: verify GPU visibility (device-plugin) ==="
+    NVIS=$(nvidia-smi -L | wc -l)
+    nvidia-smi -L
+    if [ "$NVIS" != 1 ]; then
+        echo "FATAL: expected exactly 1 visible GPU on the rollout node, got $NVIS"; exit 96
+    fi
+
+    source /workspace/scripts/install_common.sh
+
+    # verl's FullyAsyncRollouter actor runs on
+    # THIS pod (rollout PG pinning) and loads the train/val parquet itself;
+    # there is no shared volume, so the dataset must be prepared here too
+    # (same seed as the head -> identical files).
+    echo "=== Phase 1e: prepare dataset locally (FullyAsyncRollouter reads it on THIS pod) ==="
+    python3 /workspace/scripts/data_prep.py --out_dir /workspace/data/dapo_math \
+        --train_size 512 --val_size 64
+
+    echo "=== Phase 2: join the ray cluster ==="
+    # Join loop: the head pod may still be installing (its ray head comes up
+    # ~20 min after apply). ray start fails fast while the head is
+    # unreachable; --block keeps this script attached to the raylet once
+    # joined. The rollout_node custom resource pins the rollout PG here.
+    # NOTE: --resources takes JSON with DOUBLE quotes; keep the single-quote wrapper.
+    set +e
+    while true; do
+        ray start --block --address="$RAY_HEAD_ADDR" --num-gpus=1 --resources='{"rollout_node": 100}'
+        RC=$?
+        echo "ray start exited rc=$RC (head not up yet, or head gone); retrying in 15s — $(date)"
+        ray stop --force >/dev/null 2>&1 || true
+        sleep 15
+    done
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: job-a-head
+  namespace: default
+  labels:
+    app: job-a-head
+    # Exact keys the platform selects on (pod-utils.go JobIDLabel/GroupLabel,
+    # orchestrator kubernetes.go JobLabelKey/PodLabelKey). ONLY the head pod
+    # carries them: the trainer is the sole time-sliced (snapshotted) process.
+    timeslice.io/job-id: job-a-trainer
+    timeslice.io/group: trainers
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    group.timeslice.io/trainers: "true"
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: timeslice.io/shared
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+  resourceClaims:
+  - name: accelerator
+    resourceClaimName: shared-trainers-gpu-claim   # SAME claim as job-b-head
+  containers:
+  - name: head
+    image: verlai/verl:vllm020.dev2
+    env:
+    - name: VLLM_USE_V1
+      value: "1"
+    - name: STALENESS_THRESHOLD
+      value: "8"
+    - name: RUN_SECONDS
+      value: "5400"
+    - name: HF_HOME
+      value: "/workspace/hf"         # model + dataset cache, per node (no shared volume)
+    # Precautionary NCCL settings around cuda-checkpoint; keep as set.
+    - name: NCCL_CUMEM_ENABLE
+      value: "0"
+    - name: NCCL_NVLS_ENABLE
+      value: "0"
+    - name: ACTOR_LR
+      value: "1e-6"
+    - name: EXP_NAME
+      value: "two-jobs-math-a"
+    # --- timeslice trainer (timeslice_verl, pip install from repo) ---
+    - name: TIMESLICE_FULLY_ASYNC
+      value: "1"
+    - name: TIMESLICE_JOB_ID
+      value: "job-a-trainer"         # must equal the timeslice.io/job-id label
+    - name: TIMESLICE_ORCH_ADDR
+      value: "timeslice-timesliceorchestrator.timeslice-system.svc:50051"
+    - name: TIMESLICE_GROUP
+      value: "trainers"
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      set -euo pipefail
+      echo "=== time-slicing guide: job A (math RLVR) — HEAD (trainer node) ==="
+      echo "Node: $(hostname)"
+      echo "Date: $(date)"
+      bash /workspace/scripts/run_head.sh 2>&1 | tee /workspace/results/experiment.log
+    ports:
+    - containerPort: 6379            # ray GCS (behind headless Service job-a-head)
+    - containerPort: 8265            # ray dashboard (optional)
+    resources:
+      requests:
+        cpu: "8"
+        memory: "80Gi"
+      limits:
+        memory: "110Gi"              # two head pods must fit one a3-highgpu-1g (26 vCPU / 234 Gi)
+      claims:
+      - name: accelerator
+    volumeMounts:
+    - name: scripts
+      mountPath: /workspace/scripts
+    - name: results
+      mountPath: /workspace/results
+    - name: dshm
+      mountPath: /dev/shm
+  volumes:
+  - name: scripts
+    configMap:
+      name: ts-job-a
+      defaultMode: 0755
+  - name: results
+    emptyDir: {}
+  - name: dshm
+    emptyDir:
+      medium: Memory
+      sizeLimit: 16Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: job-a-rollout
+  namespace: default
+  labels:
+    app: job-a-rollout
+    # NO timeslice.io labels: this pod must NEVER be selected for snapshot —
+    # the rollout engine keeps generating while the trainer is checkpointed.
+spec:
+  restartPolicy: Never
+  # Placement: any GPU node except the trainer node. The GPU comes from the
+  # ordinary device plugin (nvidia.com/gpu below); the anti-affinity keeps
+  # this pod off the trainer node, whose GPU is claim-managed.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: group.timeslice.io/trainers
+            operator: DoesNotExist
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: timeslice.io/shared
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+  containers:
+  - name: rollout
+    image: verlai/verl:vllm020.dev2
+    env:
+    - name: VLLM_USE_V1
+      value: "1"
+    - name: HF_HOME
+      value: "/workspace/hf"         # model downloads land here, per node
+    - name: NCCL_CUMEM_ENABLE
+      value: "0"
+    - name: NCCL_NVLS_ENABLE
+      value: "0"
+    # The trainer driver actor (the registered timeslice trainer subclass)
+    # is a CPU-only Ray actor that can be scheduled on either Ray node and
+    # inherits the raylet's env, not the driver's - keep the timeslice env
+    # identical on both pods.
+    - name: TIMESLICE_FULLY_ASYNC
+      value: "1"
+    - name: TIMESLICE_JOB_ID
+      value: "job-a-trainer"
+    - name: TIMESLICE_ORCH_ADDR
+      value: "timeslice-timesliceorchestrator.timeslice-system.svc:50051"
+    - name: TIMESLICE_GROUP
+      value: "trainers"
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      set -euo pipefail
+      echo "=== time-slicing guide: job A (math RLVR) — ROLLOUT (dedicated node) ==="
+      echo "Node: $(hostname)"
+      echo "Date: $(date)"
+      bash /workspace/scripts/run_rollout.sh 2>&1 | tee /workspace/results/experiment.log
+    resources:
+      requests:
+        cpu: "16"
+        memory: "120Gi"
+      limits:
+        nvidia.com/gpu: "1"          # ordinary device-plugin GPU (no claim)
+    volumeMounts:
+    - name: scripts
+      mountPath: /workspace/scripts
+    - name: results
+      mountPath: /workspace/results
+    - name: dshm
+      mountPath: /dev/shm
+  volumes:
+  - name: scripts
+    configMap:
+      name: ts-job-a
+      defaultMode: 0755
+  - name: results
+    emptyDir: {}
+  - name: dshm
+    emptyDir:
+      medium: Memory
+      sizeLimit: 32Gi
+---
+# Headless Service: stable DNS for the ray head; the rollout pod joins via
+# job-a-head.default.svc.cluster.local:6379.
+apiVersion: v1
+kind: Service
+metadata:
+  name: job-a-head
+  namespace: default
+spec:
+  clusterIP: None
+  selector:
+    app: job-a-head
+  ports:
+  - name: ray-gcs
+    port: 6379
+    targetPort: 6379
+  - name: ray-dashboard
+    port: 8265
+    targetPort: 8265

--- a/guides/rl-frameworks/verl/examples/fully-async/job-b-code.yaml
+++ b/guides/rl-frameworks/verl/examples/fully-async/job-b-code.yaml
@@ -1,0 +1,753 @@
+# Job B (code RLVR) for the two-RL-jobs time-slicing guide — disaggregated
+# 1-GPU-per-node shape. Eurus-2 code split with prime_code reward (live
+# in-pod test execution), verl fully_async_policy, GRPO, R1-Distill-Qwen-1.5B.
+# Training budget: edit the RUN_SECONDS env below (default 5400 s ~= 90 min).
+#
+# Topology: each job is a 2-node Ray cluster. Placement needs no per-rollout
+# node labels:
+#   job-b-head    on the SHARED 1-GPU trainer node (label
+#                 group.timeslice.io/trainers=true; hosts job-a-head AND
+#                 job-b-head): ray head, FSDP trainer (time-sliced with job A)
+#   job-b-rollout on any GPU node except the trainer node (required
+#                 anti-affinity on group.timeslice.io/trainers); its GPU is
+#                 an ordinary device-plugin request (nvidia.com/gpu: 1), and
+#                 the device plugin allocates whole GPUs exclusively, so the
+#                 two jobs' rollouts land on distinct GPUs: ray worker, vLLM
+#                 rollout engine (always on)
+# Placement is pinned by Ray CUSTOM RESOURCES, not GPU masks: the head starts
+# ray with --resources='{"trainer_node": 100}', the worker with
+# --resources='{"rollout_node": 100}', and verl's per-pool placement-group
+# bundle resources (hydra override ray_pg_extra_resources={trainer_pool:
+# {trainer_node: 1}, rollout_pool: {rollout_node: 1}}) make verl's trainer
+# placement group request {trainer_node: 1} and the rollout PG
+# {rollout_node: 1}.
+#
+# GPU access: the shared trainer GPU is the recipe's ONLY DRA ResourceClaim
+# (see resource-claims.yaml) — both jobs' head pods reference the SAME
+# shared-trainers-gpu-claim, which is what lets them co-locate on the one
+# shared trainer GPU without scheduler blocking (each holds the full,
+# unpartitioned GPU during its turn); the NVIDIA DRA driver injects the GPU
+# + driver userspace into the container. The rollout pods request their
+# GPUs the ordinary way (nvidia.com/gpu: 1 via the device plugin). Neither
+# path needs elevated pod permissions. Each node has exactly ONE GPU, so
+# there is nothing to mask — every process sees cuda:0.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ts-job-b
+  namespace: default
+data:
+  data_prep.py: |
+    #!/usr/bin/env python3
+    """Prepare the Eurus-2-RL-Data CODE subset for the async code-RLVR experiment.
+
+    Source: HF dataset PRIME-RL/Eurus-2-RL-Data (train.parquet), ALREADY in verl
+    RLHFDataset format:
+      - data_source in {codecontests, apps, codeforces, taco} -> default reward routing
+        hits verl.utils.reward_score.prime_code.compute_score (local in-pod test-case
+        execution; extracts the LAST ```python fenced block)
+      - prompt = [{system (Eurus action protocol)}, {user: problem + "Write Python code
+        ... ```python ... ``` at the end"}]
+      - reward_model = {"style": "rule", "ground_truth": '{"inputs": [...], "outputs": [...]}'}
+
+    Transformations (documented in NOTES.md):
+      1. keep only ability == "code" rows with a data_source that routes to prime_code
+      2. DROP the Eurus system message (R1-Distill guidance: no system prompt; the
+         reward-relevant ```python instruction lives in the user message, kept verbatim)
+      3. truncate test suites to first 8 in/out pairs (bounds worst-case reward latency),
+         preserving fn_name; drop rows with unusable/oversized ground truth
+      4. filter to prompts <= --max_prompt_tokens under the actual chat template
+      5. subsample 512 train / 64 val, disjoint, dedup'd on user text
+    """
+
+    import argparse
+    import json
+    import os
+
+    import pandas as pd
+    from huggingface_hub import hf_hub_download
+
+    CODE_SOURCES = {"codecontests", "apps", "codeforces", "taco"}
+
+
+    def truncate_ground_truth(gt_str, max_tests, max_bytes):
+        """Return truncated JSON ground truth, or None if the row is unusable."""
+        try:
+            gt = json.loads(gt_str)
+        except Exception:
+            return None
+        if not isinstance(gt, dict):
+            return None
+        ins, outs = gt.get("inputs"), gt.get("outputs")
+        if not isinstance(ins, list) or not isinstance(outs, list):
+            return None
+        n = min(len(ins), len(outs), max_tests)
+        if n < 1:
+            return None
+        new_gt = {"inputs": ins[:n], "outputs": outs[:n]}
+        if gt.get("fn_name"):
+            new_gt["fn_name"] = gt["fn_name"]
+        try:
+            s = json.dumps(new_gt)
+        except Exception:
+            return None
+        if len(s) > max_bytes:
+            return None
+        return s
+
+
+    def main():
+        ap = argparse.ArgumentParser()
+        ap.add_argument("--repo_id", default="PRIME-RL/Eurus-2-RL-Data")
+        ap.add_argument("--filename", default="train.parquet")
+        ap.add_argument("--tokenizer", required=True)
+        ap.add_argument("--out_dir", default="/workspace/data/eurus_code")
+        ap.add_argument("--train_size", type=int, default=512)
+        ap.add_argument("--val_size", type=int, default=64)
+        ap.add_argument("--max_tests", type=int, default=8)
+        ap.add_argument("--max_gt_bytes", type=int, default=200000)
+        ap.add_argument("--max_prompt_tokens", type=int, default=1900)
+        ap.add_argument("--candidates", type=int, default=3000)
+        ap.add_argument("--seed", type=int, default=17)
+        args = ap.parse_args()
+
+        local = hf_hub_download(repo_id=args.repo_id, filename=args.filename, repo_type="dataset")
+        df = pd.read_parquet(local)
+        print(f"loaded {len(df)} rows, columns: {list(df.columns)}")
+
+        df = df[df["ability"] == "code"].reset_index(drop=True)
+        print(f"{len(df)} code rows; data_source counts:\n{df['data_source'].value_counts()}")
+        df = df[df["data_source"].isin(CODE_SOURCES)].reset_index(drop=True)
+        print(f"{len(df)} rows with prime_code-routable data_source")
+
+        # ---- rebuild rows: user-only prompt + truncated ground truth ----
+        rows = []
+        n_bad_gt, n_bad_prompt = 0, 0
+        for _, r in df.iterrows():
+            msgs = [dict(m) for m in r["prompt"]]
+            user = [m for m in msgs if m.get("role") == "user"]
+            if len(user) != 1 or "```python" not in user[0].get("content", ""):
+                n_bad_prompt += 1
+                continue
+            gt = truncate_ground_truth(dict(r["reward_model"])["ground_truth"], args.max_tests, args.max_gt_bytes)
+            if gt is None:
+                n_bad_gt += 1
+                continue
+            rows.append(
+                {
+                    "data_source": r["data_source"],
+                    "prompt": [{"role": "user", "content": user[0]["content"]}],
+                    "ability": "code",
+                    "reward_model": {"style": "rule", "ground_truth": gt},
+                    "extra_info": dict(r["extra_info"]) if r["extra_info"] is not None else {},
+                    "_ptext": user[0]["content"],
+                }
+            )
+        print(f"kept {len(rows)} rows (dropped {n_bad_prompt} bad-prompt, {n_bad_gt} bad-ground-truth)")
+
+        out = pd.DataFrame(rows).drop_duplicates("_ptext").reset_index(drop=True)
+        print(f"{len(out)} unique problems after dedup")
+
+        # cheap char prefilter, then exact token filter on a sampled candidate pool
+        out = out[out["_ptext"].str.len() <= 7000].reset_index(drop=True)
+        print(f"{len(out)} rows after 7000-char prefilter")
+        cand = out.sample(n=min(args.candidates, len(out)), random_state=args.seed).reset_index(drop=True)
+
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained(args.tokenizer)
+        keep_idx, tok_lens = [], []
+        for i, r in cand.iterrows():
+            ntok = len(tok.apply_chat_template(list(r["prompt"]), add_generation_prompt=True))
+            if ntok <= args.max_prompt_tokens:
+                keep_idx.append(i)
+                tok_lens.append(ntok)
+        cand = cand.loc[keep_idx].reset_index(drop=True)
+        print(
+            f"{len(cand)} candidates <= {args.max_prompt_tokens} prompt tokens "
+            f"(mean {sum(tok_lens) / max(len(tok_lens), 1):.0f})"
+        )
+
+        n = args.train_size + args.val_size
+        assert len(cand) >= n, f"only {len(cand)} candidates for {n} needed"
+        sub = cand.sample(n=n, random_state=args.seed + 1).reset_index(drop=True)
+        train = sub.iloc[: args.train_size].drop(columns="_ptext")
+        val = sub.iloc[args.train_size : n].drop(columns="_ptext")
+
+        # ---- final schema sanity checks (fail fast, before burning GPU time) ----
+        row = train.iloc[0]
+        assert row["data_source"] in CODE_SOURCES
+        p0 = dict(row["prompt"][0])
+        assert p0["role"] == "user" and "```python" in p0["content"]
+        gt = json.loads(dict(row["reward_model"])["ground_truth"])
+        assert len(gt["inputs"]) >= 1 and len(gt["inputs"]) == len(gt["outputs"])
+        ntests = [len(json.loads(dict(rm)["ground_truth"])["inputs"]) for rm in train["reward_model"]]
+        n_fn = sum(1 for rm in train["reward_model"] if "fn_name" in json.loads(dict(rm)["ground_truth"]))
+        print(f"tests/problem: mean {sum(ntests) / len(ntests):.1f} max {max(ntests)}; call-based (fn_name): {n_fn}")
+        print("sample prompt (first 400 chars):")
+        print(p0["content"][:400])
+        print("sample prompt (last 200 chars):")
+        print(p0["content"][-200:])
+        print("sample ground_truth (first 200 chars):", dict(row["reward_model"])["ground_truth"][:200])
+
+        os.makedirs(args.out_dir, exist_ok=True)
+        train.to_parquet(os.path.join(args.out_dir, "train.parquet"), index=False)
+        val.to_parquet(os.path.join(args.out_dir, "val.parquet"), index=False)
+        print(f"wrote {len(train)} train / {len(val)} val -> {args.out_dir}")
+
+
+    if __name__ == "__main__":
+        main()
+
+  install_common.sh: |
+    #!/usr/bin/env bash
+    # Phase 1 installs, identical on head and rollout pods (sourced). The
+    # prime_code reward deps + smoke test run on BOTH pods: reward scoring
+    # executes wherever Ray places the reward workers.
+    # verl with fully-async lifecycle hooks + trainer registry and per-pool
+    # PG bundle resources, installed directly from the fork branch
+    # (override via VERL_REPO/VERL_REF pod env).
+    VERL_REPO="${VERL_REPO:-https://github.com/aishukamal/verl.git}"
+    VERL_REF="${VERL_REF:-feat/fully-async-lifecycle-hooks}"
+
+    echo "=== Phase 1: install verl @ $VERL_REPO $VERL_REF ==="
+    pip install datasets TransferQueue 2>&1 | tail -5
+    git clone --filter=blob:none "$VERL_REPO" /workspace/verl-src
+    cd /workspace/verl-src
+    # A branch from a fresh clone exists only as a remote ref, and git's
+    # create-tracking-branch DWIM conflicts with --detach; try the remote
+    # ref first, then fall back for SHA/tag refs.
+    git checkout --detach "origin/$VERL_REF" 2>/dev/null || git checkout --detach "$VERL_REF"
+    git rev-parse HEAD | tee "$RESULTS_DIR/verl_commit"
+    pip install -e ".[gpu]" 2>&1 | tail -10
+    cd /workspace
+    pip install cupy-cuda12x 2>&1 | tail -3
+    python3 -c "import verl; print('verl version:', verl.__version__)"
+    python3 -c "import transfer_queue; print('transfer_queue OK')"
+
+    echo "=== Phase 1b: install timeslice lock client + verl plugin wrapper ==="
+    pip install "git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/client/python" 2>&1 | tail -3
+    # The client's generated stubs need grpcio>=1.81 and protobuf gencode
+    # 7.35; the image ships grpcio 1.80.0 / protobuf 6.33.6. Upgrade both
+    # before the import check below.
+    pip install "grpcio>=1.81.0" "protobuf>=7.35.0" 2>&1 | tail -2
+    # Install the timeslice-verl integration package (lock protocol via
+    # verl's fully-async lifecycle hooks). It ships TimesliceFullyAsyncTrainer,
+    # a FullyAsyncTrainer subclass registered under the trainer name
+    # "timeslice" (selected by the async_training.trainer_name=timeslice hydra
+    # override in run_head.sh); installing it registers a `verl.plugins` entry
+    # point, so `import verl` loads the registering module in every process.
+    # The hooks are inert unless TIMESLICE_FULLY_ASYNC=1 is set.
+    # Placement-group pinning comes from
+    # verl's own ray_pg_extra_resources config (see the hydra overrides in
+    # run_head.sh).
+    # --no-deps: the timeslice client is already installed above and the
+    # package declares no other dependencies.
+    pip install --no-cache-dir --no-deps "llm-d-timeslice-verl @ git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/integrations/verl" 2>&1 | tail -3
+    python3 <<'CHK'
+    import importlib.metadata as md
+    eps = list(md.entry_points(group="verl.plugins"))
+    assert any(ep.name == "timeslice" for ep in eps), f"verl.plugins entry point missing: {eps}"
+    import verl  # noqa: F401 - loads verl.plugins entries -> registers the timeslice trainer
+    from verl.experimental.fully_async_policy.fully_async_trainer import get_trainer_cls
+    from timeslice_verl.trainer import TimesliceFullyAsyncTrainer
+    assert get_trainer_cls("timeslice") is TimesliceFullyAsyncTrainer, "timeslice trainer not registered"
+    try:
+        from timeslice import OrchestratorClient  # noqa: F401
+    except ImportError:  # newer client versions export TimeSliceOrchestratorClient instead (same API)
+        from timeslice import TimeSliceOrchestratorClient as OrchestratorClient
+    print("timeslice trainer install OK; registered as:", get_trainer_cls("timeslice").__name__)
+    CHK
+
+    echo "=== Phase 1c: pyext (prime_code dependency; shim if pip install broken) ==="
+    pip install pyext 2>&1 | tail -2 || true
+    python3 << 'PYEXTFIX'
+    try:
+        from pyext import RuntimeModule  # noqa: F401
+        print("pyext OK (pip)")
+    except Exception:
+        import os
+        import sysconfig
+
+        SHIM = '''"""Minimal pyext shim: only RuntimeModule.from_string, as used by
+    verl.utils.reward_score.prime_code.testing_util (pyext 0.7 does not install on
+    Python >= 3.11). Semantically identical: build a module object from source."""
+    import types
+
+
+    class RuntimeModule:
+        @staticmethod
+        def from_string(name, docstring, code):
+            mod = types.ModuleType(name, docstring)
+            exec(compile(code, name, "exec"), mod.__dict__)
+            return mod
+    '''
+        sp = sysconfig.get_paths()["purelib"]
+        with open(os.path.join(sp, "pyext.py"), "w") as f:
+            f.write(SHIM)
+        from pyext import RuntimeModule  # noqa: F401
+
+        print(f"pyext shim installed at {sp}/pyext.py")
+    PYEXTFIX
+
+    echo "=== Phase 1d: reward smoke test (prime_code local execution, pre-GPU fail-fast) ==="
+    python3 << 'REWARDCHECK'
+    import json
+    import time
+
+    from verl.utils.reward_score import default_compute_score
+
+    gt = json.dumps({"inputs": ["1 2\n", "5 7\n"], "outputs": ["3\n", "12\n"]})
+
+    good = "<think>ok</think>\nFinal solution:\n```python\na, b = map(int, input().split())\nprint(a + b)\n```"
+    s = default_compute_score("taco", good, gt)
+    print("good ->", s)
+    assert s == 1.0, s
+
+    partial = "```python\na, b = map(int, input().split())\nprint(a + b if a == 1 else 0)\n```"
+    s = default_compute_score("taco", partial, gt)
+    print("partial ->", s)
+    assert abs(s - 0.5) < 1e-6, s
+
+    bad = "no code block at all, model rambled"
+    s = default_compute_score("taco", bad, gt)
+    print("no-block ->", s)
+    assert s == 0.0, s
+
+    t0 = time.time()
+    loop = "```python\nwhile True:\n    pass\n```"
+    s = default_compute_score("taco", loop, gt)
+    dt = time.time() - t0
+    print(f"infinite-loop -> {s} in {dt:.1f}s")
+    assert s == 0.0 and dt < 130, (s, dt)
+
+    # call-based: each input is newline-joined JSON-encoded args; output is a JSON string
+    fngt = json.dumps({"inputs": ["[3, 1, 2]", "[5]"], "outputs": ["6", "5"], "fn_name": "total"})
+    fngood = "```python\nclass Solution:\n    def total(self, xs):\n        return sum(xs)\n```"
+    s = default_compute_score("taco", fngood, fngt)
+    print("fn_name ->", s)
+    assert s == 1.0, s
+    print("Reward smoke test OK: pass/partial/fail/timeout/call-based all behave")
+    REWARDCHECK
+
+  run_head.sh: |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+
+    # On ANY exit, kill background children so the stdout pipe to tee is
+    # released and the container surfaces the real exit status.
+    trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+
+    RESULTS_DIR="/workspace/results"
+    MODEL_ID="deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"   # HF id; cached per node under HF_HOME
+    TRAIN_FILE="/workspace/data/eurus_code/train.parquet"
+    VAL_FILE="/workspace/data/eurus_code/val.parquet"
+    # RUN_SECS mirrors the pod env RUN_SECONDS, with a script-side default.
+    RUN_SECS="${RUN_SECONDS:-5400}"
+    RAY_WAIT_BUDGET_S=2400     # 40 min: the rollout pod's installs take ~20 min
+
+    mkdir -p "$RESULTS_DIR"
+
+    echo "=== Phase 0: verify GPU visibility (DRA-injected) ==="
+    # The NVIDIA DRA driver injects the GPU + driver userspace via the pod's
+    # ResourceClaim — no PATH/LD_LIBRARY_PATH setup or elevated permissions needed.
+    # 1-GPU-per-node topology: exactly ONE GPU must be visible. No masks, no
+    # CUDA_VISIBLE_DEVICES — the node's only GPU is cuda:0 for every process.
+    NVIS=$(nvidia-smi -L | wc -l)
+    nvidia-smi -L
+    if [ "$NVIS" != 1 ]; then
+        echo "FATAL: expected exactly 1 visible GPU on the trainer node, got $NVIS"; exit 96
+    fi
+
+    source /workspace/scripts/install_common.sh
+
+    echo "=== Phase 2: start ray head (trainer_node custom resource pins the trainer PG here) ==="
+    # NOTE: --resources takes JSON with DOUBLE quotes; keep the single-quote wrapper.
+    ray start --head --port=6379 --num-gpus=1 --resources='{"trainer_node": 100}'
+    # Two jobs' head pods share the trainer node: never rely on
+    # ray.init(address='auto') discovery — pin every in-pod ray.init to OUR
+    # head explicitly.
+    export RAY_ADDRESS="$(hostname -i):6379"
+
+    echo "=== Phase 2b: wait for the rollout pod to join (budget ${RAY_WAIT_BUDGET_S}s) ==="
+    DEADLINE=$(( $(date +%s) + RAY_WAIT_BUDGET_S ))
+    until timeout 60 python3 -c "
+    import sys
+    import ray
+    ray.init(address='auto', log_to_driver=False)
+    gpus = sum(n['Resources'].get('GPU', 0) for n in ray.nodes() if n['Alive'])
+    print('ray cluster GPUs visible:', gpus, flush=True)
+    sys.exit(0 if gpus >= 2 else 1)
+    "; do
+        if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+            echo "FATAL: rollout pod did not join the ray cluster within ${RAY_WAIT_BUDGET_S}s"
+            ray status || true
+            exit 95
+        fi
+        echo "still waiting for the rollout pod to join (its installs take ~20 min); next poll in 20s — $(date)"
+        sleep 20
+    done
+    ray status
+
+    echo "=== Phase 3: prepare dataset (512 Eurus-2 code prompts, tests capped at 8) ==="
+    python3 /workspace/scripts/data_prep.py --out_dir /workspace/data/eurus_code \
+        --tokenizer "$MODEL_ID" --train_size 512 --val_size 64
+
+    echo "=== Phase 3b: chat-template sanity check (forced <think> must be active) ==="
+    python3 << 'TMPLCHECK'
+    import pandas as pd
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained("deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B")
+    df = pd.read_parquet("/workspace/data/eurus_code/train.parquet")
+    msgs = [dict(m) for m in df.iloc[0]["prompt"]]
+    rendered = tok.apply_chat_template(msgs, add_generation_prompt=True, tokenize=False)
+    print("RENDERED PROMPT TAIL:", rendered[-200:])
+    assert rendered.rstrip().endswith("<think>"), "chat template does not force <think> - CoT premise broken"
+    ntok = len(tok.apply_chat_template(msgs, add_generation_prompt=True))
+    print(f"prompt tokens: {ntok}")
+    assert ntok < 2048, f"prompt longer than max_prompt_length: {ntok}"
+    print("Chat template check OK")
+    TMPLCHECK
+
+    echo "=== Phase 4: fully-async code-RLVR training ==="
+    echo "  Model: DeepSeek-R1-Distill-Qwen-1.5B | Dataset: Eurus-2-RL-Data code (512 prompts)"
+    echo "  Reward: in-tree prime_code, LOCAL test execution on the rollout side"
+    echo "  lr=${ACTOR_LR:-1e-6} exp=${EXP_NAME:-unnamed} staleness=${STALENESS_THRESHOLD:-8}"
+    echo "  timeslice: job=${TIMESLICE_JOB_ID:-?} group=${TIMESLICE_GROUP:-?} orch=${TIMESLICE_ORCH_ADDR:-?}"
+    nvidia-smi
+
+    export PYTHONUNBUFFERED=1
+    export HYDRA_FULL_ERROR=1
+
+    TOTAL_ROLLOUT_STEPS=65536   # >> trainer consumption; None-sentinel must not fire
+
+    run_training() {
+        # timeout bounds the experiment; exit 124 (timeout) is the EXPECTED end state.
+        timeout --signal=INT --kill-after=120 "$RUN_SECS" \
+        python3 -m verl.experimental.fully_async_policy.fully_async_main \
+            data.train_files="$TRAIN_FILE" \
+            data.val_files="$VAL_FILE" \
+            data.prompt_key=prompt \
+            data.truncation=left \
+            data.max_prompt_length=2048 \
+            data.max_response_length=16384 \
+            data.train_batch_size=0 \
+            data.gen_batch_size=1 \
+            data.return_raw_chat=True \
+            actor_rollout_ref.model.path="$MODEL_ID" \
+            actor_rollout_ref.model.use_remove_padding=True \
+            actor_rollout_ref.model.enable_gradient_checkpointing=True \
+            actor_rollout_ref.hybrid_engine=False \
+            actor_rollout_ref.actor.strategy=fsdp \
+            actor_rollout_ref.actor.ppo_mini_batch_size=64 \
+            actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+            actor_rollout_ref.actor.use_kl_loss=False \
+            actor_rollout_ref.actor.kl_loss_coef=0.0 \
+            actor_rollout_ref.actor.entropy_coeff=0 \
+            actor_rollout_ref.actor.grad_clip=1.0 \
+            actor_rollout_ref.actor.loss_agg_mode=token-mean \
+            actor_rollout_ref.actor.use_dynamic_bsz=True \
+            actor_rollout_ref.actor.ppo_max_token_len_per_gpu=32768 \
+            actor_rollout_ref.actor.optim.lr="${ACTOR_LR:-1e-6}" \
+            actor_rollout_ref.actor.optim.lr_warmup_steps=-1 \
+            actor_rollout_ref.actor.fsdp_config.param_offload=False \
+            actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+            actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True \
+            actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=32768 \
+            actor_rollout_ref.rollout.name=vllm \
+            actor_rollout_ref.rollout.mode=async \
+            actor_rollout_ref.rollout.n=8 \
+            actor_rollout_ref.rollout.calculate_log_probs=True \
+            actor_rollout_ref.rollout.checkpoint_engine.backend=nccl \
+            +actor_rollout_ref.rollout.checkpoint_engine.engine_kwargs.nccl.rebuild_group=True \
+            actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+            actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+            actor_rollout_ref.rollout.max_model_len=18432 \
+            actor_rollout_ref.rollout.max_num_batched_tokens=18432 \
+            actor_rollout_ref.rollout.enable_chunked_prefill=True \
+            actor_rollout_ref.rollout.temperature=1.0 \
+            actor_rollout_ref.rollout.top_p=1.0 \
+            actor_rollout_ref.rollout.top_k=-1 \
+            algorithm.adv_estimator=grpo \
+            algorithm.use_kl_in_reward=False \
+            algorithm.kl_ctrl.kl_coef=0.0 \
+            trainer.logger="['console']" \
+            trainer.val_before_train=False \
+            trainer.save_freq=-1 \
+            trainer.resume_mode=disable \
+            trainer.nnodes=1 \
+            trainer.n_gpus_per_node=1 \
+            trainer.total_epochs=10 \
+            trainer.test_freq=-1 \
+            trainer.project_name=timeslice-demo \
+            trainer.experiment_name="${EXP_NAME:-two-jobs-code-b}" \
+            trainer.default_local_dir="$RESULTS_DIR/ckpts" \
+            rollout.nnodes=1 \
+            rollout.n_gpus_per_node=1 \
+            rollout.total_rollout_steps="$TOTAL_ROLLOUT_STEPS" \
+            async_training.staleness_threshold="${STALENESS_THRESHOLD:-8}" \
+            async_training.trainer_name=timeslice \
+            async_training.trigger_parameter_sync_step=1 \
+            async_training.use_dynamic_resource_scheduling=False \
+            async_training.use_trainer_do_validate=False \
+            "ray_pg_extra_resources={trainer_pool: {trainer_node: 1}, rollout_pool: {rollout_node: 1}}" \
+            2>&1 | tee "$RESULTS_DIR/train.log"
+        return "${PIPESTATUS[0]}"
+    }
+
+    set +e
+    run_training
+    TRAIN_RC=$?
+    set -e
+    if [ "$TRAIN_RC" = "124" ]; then
+        echo "Training stopped by planned ${RUN_SECS}s timeout (expected end state)"
+    elif [ "$TRAIN_RC" != "0" ]; then
+        echo "WARNING: training exited rc=$TRAIN_RC before planned timeout"
+    fi
+
+    echo "=== Keeping pod alive for result collection ==="
+    sleep 7200
+
+  run_rollout.sh: |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+
+    trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+
+    RESULTS_DIR="/workspace/results"
+    RAY_HEAD_ADDR="job-b-head.default.svc.cluster.local:6379"
+
+    mkdir -p "$RESULTS_DIR"
+
+    echo "=== Phase 0: verify GPU visibility (device-plugin) ==="
+    NVIS=$(nvidia-smi -L | wc -l)
+    nvidia-smi -L
+    if [ "$NVIS" != 1 ]; then
+        echo "FATAL: expected exactly 1 visible GPU on the rollout node, got $NVIS"; exit 96
+    fi
+
+    source /workspace/scripts/install_common.sh
+
+    # verl's FullyAsyncRollouter actor runs on
+    # THIS pod (rollout PG pinning) and loads the train/val parquet itself;
+    # there is no shared volume, so the dataset must be prepared here too
+    # (same seed as the head -> identical files).
+    echo "=== Phase 1e: prepare dataset locally (FullyAsyncRollouter reads it on THIS pod) ==="
+    python3 /workspace/scripts/data_prep.py --out_dir /workspace/data/eurus_code \
+        --tokenizer deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --train_size 512 --val_size 64
+
+    echo "=== Phase 2: join the ray cluster ==="
+    # Join loop: the head pod may still be installing (its ray head comes up
+    # ~20 min after apply). ray start fails fast while the head is
+    # unreachable; --block keeps this script attached to the raylet once
+    # joined. The rollout_node custom resource pins the rollout PG here.
+    # NOTE: --resources takes JSON with DOUBLE quotes; keep the single-quote wrapper.
+    set +e
+    while true; do
+        ray start --block --address="$RAY_HEAD_ADDR" --num-gpus=1 --resources='{"rollout_node": 100}'
+        RC=$?
+        echo "ray start exited rc=$RC (head not up yet, or head gone); retrying in 15s — $(date)"
+        ray stop --force >/dev/null 2>&1 || true
+        sleep 15
+    done
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: job-b-head
+  namespace: default
+  labels:
+    app: job-b-head
+    # Exact keys the platform selects on (pod-utils.go JobIDLabel/GroupLabel,
+    # orchestrator kubernetes.go JobLabelKey/PodLabelKey). ONLY the head pod
+    # carries them: the trainer is the sole time-sliced (snapshotted) process.
+    timeslice.io/job-id: job-b-trainer
+    timeslice.io/group: trainers
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    group.timeslice.io/trainers: "true"
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: timeslice.io/shared
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+  resourceClaims:
+  - name: accelerator
+    resourceClaimName: shared-trainers-gpu-claim   # SAME claim as job-a-head
+  containers:
+  - name: head
+    image: verlai/verl:vllm020.dev2
+    env:
+    - name: VLLM_USE_V1
+      value: "1"
+    - name: STALENESS_THRESHOLD
+      value: "8"
+    - name: RUN_SECONDS
+      value: "5400"
+    - name: HF_HOME
+      value: "/workspace/hf"         # model + dataset cache, per node (no shared volume)
+    # Precautionary NCCL settings around cuda-checkpoint; keep as set.
+    - name: NCCL_CUMEM_ENABLE
+      value: "0"
+    - name: NCCL_NVLS_ENABLE
+      value: "0"
+    - name: ACTOR_LR
+      value: "1e-6"
+    - name: EXP_NAME
+      value: "two-jobs-code-b"
+    # --- timeslice trainer (timeslice_verl, pip install from repo) ---
+    - name: TIMESLICE_FULLY_ASYNC
+      value: "1"
+    - name: TIMESLICE_JOB_ID
+      value: "job-b-trainer"         # must equal the timeslice.io/job-id label
+    - name: TIMESLICE_ORCH_ADDR
+      value: "timeslice-timesliceorchestrator.timeslice-system.svc:50051"
+    - name: TIMESLICE_GROUP
+      value: "trainers"
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      set -euo pipefail
+      echo "=== time-slicing guide: job B (code RLVR) — HEAD (trainer node) ==="
+      echo "Node: $(hostname)"
+      echo "Date: $(date)"
+      bash /workspace/scripts/run_head.sh 2>&1 | tee /workspace/results/experiment.log
+    ports:
+    - containerPort: 6379            # ray GCS (behind headless Service job-b-head)
+    - containerPort: 8265            # ray dashboard (optional)
+    resources:
+      requests:
+        cpu: "8"
+        memory: "80Gi"
+      limits:
+        memory: "110Gi"              # two head pods must fit one a3-highgpu-1g (26 vCPU / 234 Gi)
+      claims:
+      - name: accelerator
+    volumeMounts:
+    - name: scripts
+      mountPath: /workspace/scripts
+    - name: results
+      mountPath: /workspace/results
+    - name: dshm
+      mountPath: /dev/shm
+  volumes:
+  - name: scripts
+    configMap:
+      name: ts-job-b
+      defaultMode: 0755
+  - name: results
+    emptyDir: {}
+  - name: dshm
+    emptyDir:
+      medium: Memory
+      sizeLimit: 16Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: job-b-rollout
+  namespace: default
+  labels:
+    app: job-b-rollout
+    # NO timeslice.io labels: this pod must NEVER be selected for snapshot —
+    # the rollout engine keeps generating while the trainer is checkpointed.
+spec:
+  restartPolicy: Never
+  # Placement: any GPU node except the trainer node. The GPU comes from the
+  # ordinary device plugin (nvidia.com/gpu below); the anti-affinity keeps
+  # this pod off the trainer node, whose GPU is claim-managed.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: group.timeslice.io/trainers
+            operator: DoesNotExist
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: timeslice.io/shared
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+  containers:
+  - name: rollout
+    image: verlai/verl:vllm020.dev2
+    env:
+    - name: VLLM_USE_V1
+      value: "1"
+    - name: HF_HOME
+      value: "/workspace/hf"         # model downloads land here, per node
+    - name: NCCL_CUMEM_ENABLE
+      value: "0"
+    - name: NCCL_NVLS_ENABLE
+      value: "0"
+    # The trainer driver actor (the registered timeslice trainer subclass)
+    # is a CPU-only Ray actor that can be scheduled on either Ray node and
+    # inherits the raylet's env, not the driver's - keep the timeslice env
+    # identical on both pods.
+    - name: TIMESLICE_FULLY_ASYNC
+      value: "1"
+    - name: TIMESLICE_JOB_ID
+      value: "job-b-trainer"
+    - name: TIMESLICE_ORCH_ADDR
+      value: "timeslice-timesliceorchestrator.timeslice-system.svc:50051"
+    - name: TIMESLICE_GROUP
+      value: "trainers"
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      set -euo pipefail
+      echo "=== time-slicing guide: job B (code RLVR) — ROLLOUT (dedicated node) ==="
+      echo "Node: $(hostname)"
+      echo "Date: $(date)"
+      bash /workspace/scripts/run_rollout.sh 2>&1 | tee /workspace/results/experiment.log
+    resources:
+      requests:
+        cpu: "16"
+        memory: "120Gi"
+      limits:
+        nvidia.com/gpu: "1"          # ordinary device-plugin GPU (no claim)
+    volumeMounts:
+    - name: scripts
+      mountPath: /workspace/scripts
+    - name: results
+      mountPath: /workspace/results
+    - name: dshm
+      mountPath: /dev/shm
+  volumes:
+  - name: scripts
+    configMap:
+      name: ts-job-b
+      defaultMode: 0755
+  - name: results
+    emptyDir: {}
+  - name: dshm
+    emptyDir:
+      medium: Memory
+      sizeLimit: 32Gi
+---
+# Headless Service: stable DNS for the ray head; the rollout pod joins via
+# job-b-head.default.svc.cluster.local:6379.
+apiVersion: v1
+kind: Service
+metadata:
+  name: job-b-head
+  namespace: default
+spec:
+  clusterIP: None
+  selector:
+    app: job-b-head
+  ports:
+  - name: ray-gcs
+    port: 6379
+    targetPort: 6379
+  - name: ray-dashboard
+    port: 8265
+    targetPort: 8265

--- a/guides/rl-frameworks/verl/examples/fully-async/resource-claims.yaml
+++ b/guides/rl-frameworks/verl/examples/fully-async/resource-claims.yaml
@@ -1,0 +1,22 @@
+# The single DRA ResourceClaim for the two-job verl fully-async time-slicing
+# demo. Apply BEFORE launching the jobs: kubectl apply -f resource-claims.yaml
+#
+# Both jobs' head pods reference the SAME shared-trainers-gpu-claim — that is
+# what lets the two trainers co-locate on the one shared trainer GPU without
+# scheduler blocking (each holds the full, unpartitioned GPU during its turn).
+# This is the ONLY ResourceClaim in the recipe: sharing is what only DRA can
+# express. The rollout pods request their GPUs the ordinary way
+# (nvidia.com/gpu: 1 via the device plugin) — see the job manifests.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: shared-trainers-gpu-claim
+  namespace: default
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        allocationMode: ExactCount
+        count: 1


### PR DESCRIPTION
Proposal: https://docs.google.com/document/d/1-JzdzHJ77fZCjgcBVfnANz1z8dipmJWA2vtJ4AzIq2w/edit?tab=t.0#heading=h.dzy9irmry6l

## Summary

Adds the verl fully-async time-slicing guide: two fully-async RL jobs time-slicing one shared trainer GPU via the timeslice-verl package (PR #175) and the verl fork's lifecycle hooks (aishukamal/verl@feat/fully-async-lifecycle-hooks).

**Depends on #175:** requires the timeslice-verl package PR to merge first (the guide pip-installs the package from the repo subdirectory pkg/integrations/verl/).

## What is included

| File | Purpose |
|------|---------|
| guides/rl-frameworks/verl/README.md | Package-based integration guide (platform setup, pip install, hydra overrides, lock protocol) |
| guides/rl-frameworks/verl/examples/fully-async/ | Runnable two-job example (job-a math + job-b code) with per-job rollout GPUs and a time-sliced trainer GPU |
| guides/rl-frameworks/README.md | Adds verl to the supported-frameworks list |

## Test plan

- [x] E2E validated: both jobs trained end to end on H100 cluster, trainer lock handoffs visible (waited=Xms, context_restored=True)
- [x] Guide walkthrough: every command executed as documented



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive guidance for integrating `verl` with `llm-d-rl-time-slicing`.
  * Added a fully asynchronous example running two independent reinforcement-learning jobs with shared trainer GPU time-slicing.
  * Added ready-to-use Kubernetes manifests for workloads, GPU resource claims, Ray services, data preparation, monitoring, and troubleshooting.
* **Documentation**
  * Updated the framework integration guide to include `verl` among supported pre-packaged integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->