### PR TITLE
snapshot-agent: resolve each job's backend via explicit config, workload channel, pod annotation, then default

### DIFF
--- a/guides/snapshot-agent/README.md
+++ b/guides/snapshot-agent/README.md
@@ -145,7 +145,7 @@ result = client.snapshot_and_wait(job_id="my-k8s-job-id")
 
 ## 3. Backends
 
-The Snapshot Agent supports multiple backends for different GPU memory management strategies. Each backend is selected per-request via the `backend_config` field.
+The Snapshot Agent supports multiple backends for different GPU memory management strategies. Each request's backend is picked by the [resolution chain](#backend-resolution) below; passing an explicit `backend_config` (as in the examples that follow) is the first and strongest link of that chain.
 
 | Backend | Config | How it works | VRAM Freed | Resume Time |
 |---------|--------|-------------|------------|-------------|
@@ -154,6 +154,52 @@ The Snapshot Agent supports multiple backends for different GPU memory managemen
 | Application-Aware | `app_channel` | Suspend/resume pushed over a channel the workload registered (Python-API workloads, no HTTP server) | ~96% | ~50-100ms |
 
 The VRAM Freed and Resume Time figures are illustrative, measured with a small model (Qwen2.5-0.5B) on an H100; actual numbers depend on the model size, hardware, and engine version.
+
+### Backend resolution
+
+Every Snapshot and Restore request resolves its backend through one chain, in
+strict precedence order — the first source that applies wins, and the agent
+logs one line per resolution stating the source and the chosen backend:
+
+1. **Explicit `backend_config` in the request** — honored as-is (all the
+   examples below use this).
+2. **Live workload channel** — a config-less request for a job with a live
+   registered workload channel routes to the
+   [app_channel](#application-aware-app_channel) backend. This is how
+   orchestrator-driven requests (which carry no `backend_config`) reach
+   application-aware workloads.
+3. **Pod annotation** (Kubernetes mode) — a backend declared on the
+   workload's pods via the `timeslice.io/backend` annotation, read through
+   the same Kubernetes client that discovers the job's pods. Values are
+   `BackendConfig` field names — `cuda`, `app_endpoint`, `app_channel`,
+   `direct_memory` — or `noop`. Backends that need configuration take it from
+   the companion `timeslice.io/backend-config` annotation, holding the
+   backend's config message in protobuf JSON form. A malformed or unknown
+   declaration fails the operation — it never falls through silently.
+4. **Agent default** — the `cuda` backend.
+
+Declaring the backend on the workload's pods:
+
+```yaml
+metadata:
+  labels:
+    timeslice.io/job-id: my-vllm-job
+  annotations:
+    timeslice.io/backend: app_endpoint
+    timeslice.io/backend-config: |
+      {"app": "APP_VLLM", "endpoints": ["http://localhost:8000"]}
+```
+
+```yaml
+metadata:
+  labels:
+    timeslice.io/job-id: my-training-job
+  annotations:
+    timeslice.io/backend: cuda   # explicit; same as the agent default
+```
+
+When a job spans several local pods, their declarations must agree —
+conflicting annotations fail the operation.
 
 ### CUDA Checkpoint
 
@@ -330,7 +376,9 @@ before any command is sent (e.g. DISCARD against a trainer that only supports
 OFFLOAD fails the operation immediately).
 
 **Caller side** — the usual `Snapshot`/`Restore` with an `app_channel` config.
-An empty config means "suspend however the workload declared at registration":
+An empty config means "suspend however the workload declared at registration".
+Callers that send no `backend_config` at all (e.g. the orchestrator) land here
+too, through step 2 of the [resolution chain](#backend-resolution):
 
 ```python
 channel_config = snapshot.BackendConfig(app_channel=snapshot.AppChannelConfig())

--- a/pkg/snapshot-agent/backends/app_channel.go
+++ b/pkg/snapshot-agent/backends/app_channel.go
@@ -60,6 +60,17 @@ func (s *WorkloadSession) close() {
 	s.closeOnce.Do(func() { close(s.closed) })
 }
 
+// Closed reports whether the session is gone (its stream dropped or its
+// registration was replaced). A closed session cannot receive commands.
+func (s *WorkloadSession) Closed() bool {
+	select {
+	case <-s.closed:
+		return true
+	default:
+		return false
+	}
+}
+
 // Dispatch assigns the command a unique ID, sends it once, and waits for the
 // matching CommandResult, the session to drop, or ctx to expire.
 func (s *WorkloadSession) Dispatch(ctx context.Context, cmd *pb.AgentCommand) error {

--- a/pkg/snapshot-agent/backends/app_channel_test.go
+++ b/pkg/snapshot-agent/backends/app_channel_test.go
@@ -180,6 +180,29 @@ func TestAppChannelReregistrationReplacesSession(t *testing.T) {
 	}
 }
 
+func TestWorkloadSessionClosed(t *testing.T) {
+	registry := backends.NewChannelRegistry()
+	send := func(*pb.AgentCommand) error { return nil }
+
+	s1 := registry.Register("job-1", nil, send)
+	if s1.Closed() {
+		t.Error("Expected a freshly registered session to not be closed")
+	}
+
+	s2 := registry.Register("job-1", nil, send)
+	if !s1.Closed() {
+		t.Error("Expected a replaced session to be closed")
+	}
+	if s2.Closed() {
+		t.Error("Expected the replacement session to not be closed")
+	}
+
+	registry.Unregister(s2)
+	if !s2.Closed() {
+		t.Error("Expected an unregistered session to be closed")
+	}
+}
+
 func TestAppChannelModeResolution(t *testing.T) {
 	offloadOnly := &pb.WorkloadCapabilities{
 		SupportedModes: []pb.SuspendMode{pb.SuspendMode_SUSPEND_MODE_OFFLOAD},

--- a/pkg/snapshot-agent/server/backend_resolver.go
+++ b/pkg/snapshot-agent/server/backend_resolver.go
@@ -1,0 +1,230 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/backends"
+	podutils "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/utils"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
+
+// resolutionSource identifies which link of the resolution chain decided a
+// request's backend.
+type resolutionSource string
+
+const (
+	// sourceRequest is an explicit BackendConfig carried by the request.
+	sourceRequest resolutionSource = "request"
+	// sourceWorkloadChannel is a live workload channel registered for the job.
+	sourceWorkloadChannel resolutionSource = "workload-channel"
+	// sourcePodAnnotation is a backend declared on the workload's pods via
+	// the timeslice.io/backend annotation.
+	sourcePodAnnotation resolutionSource = "pod-annotation"
+	// sourceDefault is the agent's configured default backend.
+	sourceDefault resolutionSource = "default"
+)
+
+// backendResolver picks the backend and effective config for every Snapshot
+// and Restore request. The sources are consulted in fixed precedence order —
+// the first one that applies wins:
+//
+//  1. an explicit BackendConfig on the request, honored as-is;
+//  2. a live workload channel registered for the job (a workload that
+//     registered a channel expects suspend/resume pushes, and checkpointing
+//     its PIDs behind its back would bypass them);
+//  3. a backend declared on the workload's pods through the
+//     timeslice.io/backend annotation (with optional config in
+//     timeslice.io/backend-config) — malformed or unknown declarations fail
+//     the operation rather than falling through silently;
+//  4. the agent's configured default backend.
+type backendResolver struct {
+	defaultBackend backends.BackendType
+	registry       *backends.ChannelRegistry
+	// lookupPodBackend reads the backend declaration from the job's local
+	// pods. Nil disables the pod-annotation source (standalone mode has no
+	// pods to consult).
+	lookupPodBackend func(ctx context.Context, jobID string) (*podutils.JobBackendAnnotation, error)
+}
+
+// newBackendResolver wires the resolution chain for the deployment mode: in
+// k8s mode pod annotations are read through the same Kubernetes client that
+// job discovery uses; standalone mode has no pods, so that source is
+// disabled.
+func newBackendResolver(
+	defaultBackend backends.BackendType,
+	registry *backends.ChannelRegistry,
+	deploymentMode string,
+) *backendResolver {
+	resolver := &backendResolver{
+		defaultBackend: defaultBackend,
+		registry:       registry,
+	}
+	if deploymentMode == "k8s" {
+		resolver.lookupPodBackend = podutils.GetJobBackendAnnotation
+	}
+	return resolver
+}
+
+// Resolve runs the resolution chain for one request and logs a single line
+// stating the deciding source and the chosen backend.
+func (r *backendResolver) Resolve(
+	ctx context.Context, jobID string, explicit *pb.BackendConfig,
+) (backends.BackendType, *pb.BackendConfig, error) {
+	backendType, config, source, err := r.resolve(ctx, jobID, explicit)
+	if err != nil {
+		return "", nil, err
+	}
+	slog.InfoContext(ctx, "Resolved backend", "jobID", jobID, "source", source, "backend", backendType)
+	return backendType, config, nil
+}
+
+// resolve is the chain itself; Resolve adds the logging.
+//
+//nolint:nonamedreturns // Conflict between gocritic's unnamedResult and nonamedreturns
+func (r *backendResolver) resolve(
+	ctx context.Context, jobID string, explicit *pb.BackendConfig,
+) (backendType backends.BackendType, config *pb.BackendConfig, source resolutionSource, err error) {
+	if explicit != nil {
+		return r.typeForConfig(explicit), explicit, sourceRequest, nil
+	}
+	if r.hasLiveChannel(ctx, jobID) {
+		// The mode is left unspecified so the app-channel backend resolves it
+		// from the workload's registered capabilities (declared default, then
+		// OFFLOAD).
+		return backends.BackendAppChannel, &pb.BackendConfig{
+			Backend: &pb.BackendConfig_AppChannel{AppChannel: &pb.AppChannelConfig{}},
+		}, sourceWorkloadChannel, nil
+	}
+	backendType, config, found, err := r.fromPodAnnotation(ctx, jobID)
+	if err != nil {
+		return "", nil, "", err
+	}
+	if found {
+		return backendType, config, sourcePodAnnotation, nil
+	}
+	return r.defaultBackend, nil, sourceDefault, nil
+}
+
+// typeForConfig maps an explicit BackendConfig to the backend that serves
+// it. Configs that select no known backend fall through to the default.
+//
+// NOTE: direct_memory is not routed yet and falls through to the default
+// backend. It is unreachable unless the DirectMemoryBackend feature gate is
+// enabled (checkFeatureGates rejects it on the resolved config).
+func (r *backendResolver) typeForConfig(config *pb.BackendConfig) backends.BackendType {
+	switch {
+	case config.GetCuda() != nil:
+		return backends.BackendCuda
+	case config.GetDirectMemory() != nil:
+		return backends.BackendDirectMemory
+	case config.GetAppEndpoint() != nil:
+		return backends.BackendAppEndpoint
+	case config.GetAppChannel() != nil:
+		return backends.BackendAppChannel
+	case config.GetMemoryRegions() != nil:
+		return backends.BackendMemoryRegions
+	default:
+		return r.defaultBackend
+	}
+}
+
+// hasLiveChannel reports whether the job has a live registered workload
+// channel. A registered-but-disconnected channel does not count: resolution
+// continues down the chain with a warning.
+func (r *backendResolver) hasLiveChannel(ctx context.Context, jobID string) bool {
+	if r.registry == nil {
+		return false
+	}
+	session, err := r.registry.Session(jobID)
+	if err != nil {
+		return false
+	}
+	if session.Closed() {
+		slog.WarnContext(ctx, "Workload channel is registered but disconnected, continuing backend resolution without it",
+			"jobID", jobID)
+		return false
+	}
+	return true
+}
+
+// fromPodAnnotation resolves the backend declared on the workload's local
+// pods via the timeslice.io/backend annotation. A declaration that cannot be
+// resolved — unknown backend name, unparsable config, conflicting pods, or a
+// failed pod lookup — fails the operation loudly; it never silently falls
+// through to the default.
+//
+//nolint:nonamedreturns // Conflict between gocritic's unnamedResult and nonamedreturns
+func (r *backendResolver) fromPodAnnotation(
+	ctx context.Context, jobID string,
+) (backendType backends.BackendType, config *pb.BackendConfig, found bool, err error) {
+	if r.lookupPodBackend == nil {
+		return "", nil, false, nil
+	}
+	annotation, err := r.lookupPodBackend(ctx, jobID)
+	if err != nil {
+		return "", nil, false, status.Errorf(codes.Internal,
+			"failed to read the %s annotation for job %s: %v", podutils.BackendAnnotation, jobID, err)
+	}
+	if annotation == nil {
+		return "", nil, false, nil
+	}
+	backendType, config, err = r.parseAnnotation(annotation)
+	if err != nil {
+		return "", nil, false, status.Errorf(codes.FailedPrecondition,
+			"invalid backend declaration on the pods of job %s: %v", jobID, err)
+	}
+	return backendType, config, true, nil
+}
+
+// parseAnnotation maps a pod backend declaration to a backend and config.
+// The annotation value is a BackendConfig field name (cuda, app_endpoint,
+// app_channel, direct_memory) or noop; the optional companion annotation
+// carries the protojson encoding of that backend's config message, e.g.
+// {"endpoints": ["http://localhost:8000"]} for app_endpoint.
+func (r *backendResolver) parseAnnotation(
+	annotation *podutils.JobBackendAnnotation,
+) (backends.BackendType, *pb.BackendConfig, error) {
+	var message proto.Message
+	var config *pb.BackendConfig
+	switch annotation.Backend {
+	case "cuda":
+		cuda := &pb.CudaBackendConfig{}
+		message = cuda
+		config = &pb.BackendConfig{Backend: &pb.BackendConfig_Cuda{Cuda: cuda}}
+	case "app_endpoint":
+		endpoint := &pb.AppEndpointConfig{}
+		message = endpoint
+		config = &pb.BackendConfig{Backend: &pb.BackendConfig_AppEndpoint{AppEndpoint: endpoint}}
+	case "app_channel":
+		channel := &pb.AppChannelConfig{}
+		message = channel
+		config = &pb.BackendConfig{Backend: &pb.BackendConfig_AppChannel{AppChannel: channel}}
+	case "direct_memory":
+		direct := &pb.DirectMemoryBackendConfig{}
+		message = direct
+		config = &pb.BackendConfig{Backend: &pb.BackendConfig_DirectMemory{DirectMemory: direct}}
+	case string(backends.BackendNoop):
+		if annotation.Config != "" {
+			return "", nil, fmt.Errorf("backend %q takes no %s annotation",
+				annotation.Backend, podutils.BackendConfigAnnotation)
+		}
+		return backends.BackendNoop, nil, nil
+	default:
+		return "", nil, fmt.Errorf(
+			"unknown backend %q in the %s annotation (known: cuda, app_endpoint, app_channel, direct_memory, noop)",
+			annotation.Backend, podutils.BackendAnnotation)
+	}
+	if annotation.Config != "" {
+		if err := protojson.Unmarshal([]byte(annotation.Config), message); err != nil {
+			return "", nil, fmt.Errorf("failed to parse the %s annotation as a %s config: %w",
+				podutils.BackendConfigAnnotation, annotation.Backend, err)
+		}
+	}
+	return r.typeForConfig(config), config, nil
+}

--- a/pkg/snapshot-agent/server/server.go
+++ b/pkg/snapshot-agent/server/server.go
@@ -26,10 +26,10 @@ type Server struct {
 	pb.UnimplementedSnapshotAgentServiceServer
 	state           *sm.StateManager
 	backendMap      map[backends.BackendType]backends.Backend
-	defaultBackend  backends.BackendType
 	deploymentMode  string
 	channelRegistry *backends.ChannelRegistry
 	featureGates    features.Gates
+	resolver        *backendResolver
 }
 
 // NewServer creates a new Server instance. channelRegistry is shared with
@@ -47,16 +47,18 @@ func NewServer(
 	return &Server{
 		state:           sm.NewStateManager(),
 		backendMap:      backendMap,
-		defaultBackend:  defaultBackend,
 		deploymentMode:  deploymentMode,
 		channelRegistry: channelRegistry,
 		featureGates:    featureGates,
+		resolver:        newBackendResolver(defaultBackend, channelRegistry, deploymentMode),
 	}
 }
 
 // checkFeatureGates rejects configs that select an experimental backend
-// whose feature gate is off. It runs before backend routing so a gated
-// config never silently falls through to another backend.
+// whose feature gate is off. It runs on the resolved config, so a gated
+// backend is rejected whichever source selected it (an explicit request
+// config or a pod annotation) and never silently falls through to another
+// backend.
 func (s *Server) checkFeatureGates(config *pb.BackendConfig) error {
 	if config.GetDirectMemory() != nil && !s.featureGates.Enabled(features.DirectMemoryBackend) {
 		return status.Errorf(codes.FailedPrecondition,
@@ -81,11 +83,13 @@ func (s *Server) Snapshot(ctx context.Context, req *pb.SnapshotRequest) (*pb.Sna
 	ctx = logging.WithJobID(ctx, req.GetJobId())
 	ctx = logging.WithGroupID(ctx, req.GetGroup())
 
-	if err := s.checkFeatureGates(req.GetBackendConfig()); err != nil {
+	backendType, config, err := s.resolver.Resolve(ctx, req.GetJobId(), req.GetBackendConfig())
+	if err != nil {
 		return nil, err
 	}
-
-	backendType := s.getSnapshotBackendType(req.GetBackendConfig())
+	if err := s.checkFeatureGates(config); err != nil {
+		return nil, err
+	}
 	slog.InfoContext(ctx, "Snapshot called", "backend", backendType)
 
 	backend, ok := s.backendMap[backendType]
@@ -96,7 +100,6 @@ func (s *Server) Snapshot(ctx context.Context, req *pb.SnapshotRequest) (*pb.Sna
 	s.ensureJobRunningIfGPUOccupied(ctx, req.GetJobId(), req.GetGroup())
 
 	bgCtx := context.WithoutCancel(ctx)
-	config := req.GetBackendConfig()
 
 	snapshotFn, fnErr := s.buildSnapshotFn(bgCtx, req.GetJobId(), backendType, backend, config)
 	if fnErr != nil {
@@ -110,28 +113,6 @@ func (s *Server) Snapshot(ctx context.Context, req *pb.SnapshotRequest) (*pb.Sna
 	}
 
 	return &pb.SnapshotResponse{OperationId: opID}, nil
-}
-
-func (s *Server) getSnapshotBackendType(config *pb.BackendConfig) backends.BackendType {
-	if config == nil {
-		return s.defaultBackend
-	}
-	if config.GetCuda() != nil {
-		return backends.BackendCuda
-	}
-	if config.GetDirectMemory() != nil {
-		return backends.BackendDirectMemory
-	}
-	if config.GetAppEndpoint() != nil {
-		return backends.BackendAppEndpoint
-	}
-	if config.GetAppChannel() != nil {
-		return backends.BackendAppChannel
-	}
-	if config.GetMemoryRegions() != nil {
-		return backends.BackendMemoryRegions
-	}
-	return s.defaultBackend
 }
 
 // ensureJobRunningIfGPUOccupied registers the job and, if it is IDLE while
@@ -309,11 +290,13 @@ func (s *Server) Restore(ctx context.Context, req *pb.RestoreRequest) (*pb.Resto
 	ctx = logging.WithJobID(ctx, req.GetJobId())
 	ctx = logging.WithGroupID(ctx, req.GetGroup())
 
-	if err := s.checkFeatureGates(req.GetBackendConfig()); err != nil {
+	backendType, restoreConfig, err := s.resolver.Resolve(ctx, req.GetJobId(), req.GetBackendConfig())
+	if err != nil {
 		return nil, err
 	}
-
-	backendType := s.getSnapshotBackendType(req.GetBackendConfig())
+	if err := s.checkFeatureGates(restoreConfig); err != nil {
+		return nil, err
+	}
 	slog.InfoContext(ctx, "Restore called", "backend", backendType)
 
 	backend, ok := s.backendMap[backendType]
@@ -322,7 +305,6 @@ func (s *Server) Restore(ctx context.Context, req *pb.RestoreRequest) (*pb.Resto
 	}
 
 	bgCtx := context.WithoutCancel(ctx)
-	restoreConfig := req.GetBackendConfig()
 
 	restoreFn, fnErr := s.buildRestoreFn(bgCtx, req.GetJobId(), backendType, backend, restoreConfig)
 	if fnErr != nil {

--- a/pkg/snapshot-agent/server/server_internal_test.go
+++ b/pkg/snapshot-agent/server/server_internal_test.go
@@ -775,7 +775,7 @@ func (m *mockDirectMemoryBackend) Restore(ctx context.Context, req backends.Requ
 	return nil
 }
 
-func TestServer_GetSnapshotBackendType_DirectMemory(t *testing.T) {
+func TestServer_ResolverTypeForConfig_DirectMemory(t *testing.T) {
 	srv := NewServer(nil, backends.BackendCuda, "k8s", backends.NewChannelRegistry(),
 		features.Gates{features.DirectMemoryBackend: true})
 	cfg := &pb.BackendConfig{
@@ -783,9 +783,9 @@ func TestServer_GetSnapshotBackendType_DirectMemory(t *testing.T) {
 			DirectMemory: &pb.DirectMemoryBackendConfig{},
 		},
 	}
-	got := srv.getSnapshotBackendType(cfg)
+	got := srv.resolver.typeForConfig(cfg)
 	if got != backends.BackendDirectMemory {
-		t.Errorf("getSnapshotBackendType() = %v, want %v", got, backends.BackendDirectMemory)
+		t.Errorf("typeForConfig() = %v, want %v", got, backends.BackendDirectMemory)
 	}
 }
 

--- a/pkg/snapshot-agent/server/server_routing_internal_test.go
+++ b/pkg/snapshot-agent/server/server_routing_internal_test.go
@@ -1,0 +1,462 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/backends"
+	podutils "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/utils"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/status"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/proto"
+)
+
+// TestBackendResolver_Resolve covers the resolution chain source by source:
+// explicit configs always win and pass through untouched; config-less
+// requests prefer the job's live registered workload channel, then the
+// backend declared on the job's pods, then the configured default. Malformed
+// or unknown pod declarations fail the resolution instead of falling
+// through.
+func TestBackendResolver_Resolve(t *testing.T) {
+	cudaConfig := &pb.BackendConfig{
+		Backend: &pb.BackendConfig_Cuda{Cuda: &pb.CudaBackendConfig{}},
+	}
+	endpointConfig := &pb.BackendConfig{
+		Backend: &pb.BackendConfig_AppEndpoint{AppEndpoint: &pb.AppEndpointConfig{}},
+	}
+	channelConfig := &pb.BackendConfig{
+		Backend: &pb.BackendConfig_AppChannel{AppChannel: &pb.AppChannelConfig{Mode: pb.SuspendMode_SUSPEND_MODE_DISCARD}},
+	}
+	emptyConfig := &pb.BackendConfig{}
+	cudaAnnotation := &podutils.JobBackendAnnotation{Backend: "cuda"}
+
+	tests := []struct {
+		name           string
+		config         *pb.BackendConfig
+		registeredJobs []string
+		annotation     *podutils.JobBackendAnnotation
+		annotationErr  error
+		jobID          string
+		wantType       backends.BackendType
+		wantSource     resolutionSource
+		wantConfig     *pb.BackendConfig // expected pass-through config (pointer identity)
+		wantProto      *pb.BackendConfig // expected built config (proto equality)
+		wantNilConfig  bool              // expect no config at all
+		wantCode       codes.Code        // expected resolution error; OK means success
+	}{
+		{
+			name:           "explicit config wins over a registered channel and an annotation",
+			config:         cudaConfig,
+			registeredJobs: []string{"job-1"},
+			annotation:     &podutils.JobBackendAnnotation{Backend: "app_endpoint"},
+			jobID:          "job-1",
+			wantType:       backends.BackendCuda,
+			wantSource:     sourceRequest,
+			wantConfig:     cudaConfig,
+		},
+		{
+			name:       "explicit app-endpoint config passes through",
+			config:     endpointConfig,
+			jobID:      "job-1",
+			wantType:   backends.BackendAppEndpoint,
+			wantSource: sourceRequest,
+			wantConfig: endpointConfig,
+		},
+		{
+			name:       "explicit app-channel config passes through",
+			config:     channelConfig,
+			jobID:      "job-1",
+			wantType:   backends.BackendAppChannel,
+			wantSource: sourceRequest,
+			wantConfig: channelConfig,
+		},
+		{
+			name:           "empty non-nil config selects the default backend",
+			config:         emptyConfig,
+			registeredJobs: []string{"job-1"},
+			jobID:          "job-1",
+			wantType:       backends.BackendCuda,
+			wantSource:     sourceRequest,
+			wantConfig:     emptyConfig,
+		},
+		{
+			name:          "no config, channel, or annotation selects the default backend",
+			jobID:         "job-1",
+			wantType:      backends.BackendCuda,
+			wantSource:    sourceDefault,
+			wantNilConfig: true,
+		},
+		{
+			name:           "live channel wins over an annotation",
+			registeredJobs: []string{"job-1"},
+			annotation:     cudaAnnotation,
+			jobID:          "job-1",
+			wantType:       backends.BackendAppChannel,
+			wantSource:     sourceWorkloadChannel,
+			wantProto: &pb.BackendConfig{
+				Backend: &pb.BackendConfig_AppChannel{AppChannel: &pb.AppChannelConfig{}},
+			},
+		},
+		{
+			name:           "channel for another job falls through to the annotation",
+			registeredJobs: []string{"other-job"},
+			annotation:     cudaAnnotation,
+			jobID:          "job-1",
+			wantType:       backends.BackendCuda,
+			wantSource:     sourcePodAnnotation,
+			wantProto:      cudaConfig,
+		},
+		{
+			name:       "cuda annotation selects the cuda backend",
+			annotation: cudaAnnotation,
+			jobID:      "job-1",
+			wantType:   backends.BackendCuda,
+			wantSource: sourcePodAnnotation,
+			wantProto:  cudaConfig,
+		},
+		{
+			name: "app_endpoint annotation with config JSON builds the app-endpoint config",
+			annotation: &podutils.JobBackendAnnotation{
+				Backend: "app_endpoint",
+				Config:  `{"app": "APP_VLLM", "endpoints": ["http://localhost:8000"], "mode": "SUSPEND_MODE_DISCARD"}`,
+			},
+			jobID:      "job-1",
+			wantType:   backends.BackendAppEndpoint,
+			wantSource: sourcePodAnnotation,
+			wantProto: &pb.BackendConfig{
+				Backend: &pb.BackendConfig_AppEndpoint{AppEndpoint: &pb.AppEndpointConfig{
+					App:       pb.App_APP_VLLM,
+					Endpoints: []string{"http://localhost:8000"},
+					Mode:      pb.SuspendMode_SUSPEND_MODE_DISCARD,
+				}},
+			},
+		},
+		{
+			name:          "noop annotation selects the noop backend without a config",
+			annotation:    &podutils.JobBackendAnnotation{Backend: "noop"},
+			jobID:         "job-1",
+			wantType:      backends.BackendNoop,
+			wantSource:    sourcePodAnnotation,
+			wantNilConfig: true,
+		},
+		{
+			// direct_memory is not routed yet: like an explicit direct_memory
+			// config and resolves to the direct-memory backend; the feature
+			// gate check rejects the resolved config at the RPC layer unless
+			// the gate is enabled.
+			name:       "direct_memory annotation builds the config and resolves to direct-memory",
+			annotation: &podutils.JobBackendAnnotation{Backend: "direct_memory"},
+			jobID:      "job-1",
+			wantType:   backends.BackendDirectMemory,
+			wantSource: sourcePodAnnotation,
+			wantProto: &pb.BackendConfig{
+				Backend: &pb.BackendConfig_DirectMemory{DirectMemory: &pb.DirectMemoryBackendConfig{}},
+			},
+		},
+		{
+			name:       "unknown annotation backend fails the resolution",
+			annotation: &podutils.JobBackendAnnotation{Backend: "warp-drive"},
+			jobID:      "job-1",
+			wantCode:   codes.FailedPrecondition,
+		},
+		{
+			name: "malformed annotation config JSON fails the resolution",
+			annotation: &podutils.JobBackendAnnotation{
+				Backend: "app_endpoint",
+				Config:  `{"endpoints": not-json`,
+			},
+			jobID:    "job-1",
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name: "config JSON on the config-less noop backend fails the resolution",
+			annotation: &podutils.JobBackendAnnotation{
+				Backend: "noop",
+				Config:  `{}`,
+			},
+			jobID:    "job-1",
+			wantCode: codes.FailedPrecondition,
+		},
+		{
+			name:          "failed annotation lookup fails the resolution",
+			annotationErr: errors.New("pod list failed"),
+			jobID:         "job-1",
+			wantCode:      codes.Internal,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			registry := backends.NewChannelRegistry()
+			for _, jobID := range tc.registeredJobs {
+				registry.Register(jobID, nil, func(*pb.AgentCommand) error { return nil })
+			}
+			resolver := newBackendResolver(backends.BackendCuda, registry, "k8s")
+			resolver.lookupPodBackend = func(context.Context, string) (*podutils.JobBackendAnnotation, error) {
+				return tc.annotation, tc.annotationErr
+			}
+
+			gotType, gotConfig, gotSource, err := resolver.resolve(context.Background(), tc.jobID, tc.config)
+			if tc.wantCode != codes.OK {
+				if status.Code(err) != tc.wantCode {
+					t.Fatalf("Expected resolution to fail with %v, got type=%s err=%v", tc.wantCode, gotType, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Expected resolution to succeed, got: %v", err)
+			}
+			if gotType != tc.wantType {
+				t.Errorf("Expected backend %s, got %s", tc.wantType, gotType)
+			}
+			if gotSource != tc.wantSource {
+				t.Errorf("Expected source %s, got %s", tc.wantSource, gotSource)
+			}
+			switch {
+			case tc.wantNilConfig:
+				if gotConfig != nil {
+					t.Errorf("Expected no config, got %v", gotConfig)
+				}
+			case tc.wantConfig != nil:
+				if gotConfig != tc.wantConfig {
+					t.Errorf("Expected the request config to pass through unchanged, got %v", gotConfig)
+				}
+			default:
+				if !proto.Equal(gotConfig, tc.wantProto) {
+					t.Errorf("Expected config %v, got %v", tc.wantProto, gotConfig)
+				}
+			}
+		})
+	}
+}
+
+// TestBackendResolver_StandaloneSkipsPodAnnotations verifies that standalone
+// mode, which has no pods to consult, resolves config-less requests straight
+// to the default backend.
+func TestBackendResolver_StandaloneSkipsPodAnnotations(t *testing.T) {
+	resolver := newBackendResolver(backends.BackendCuda, backends.NewChannelRegistry(), "standalone")
+	if resolver.lookupPodBackend != nil {
+		t.Fatal("Expected the pod-annotation source to be disabled in standalone mode")
+	}
+
+	gotType, gotConfig, gotSource, err := resolver.resolve(context.Background(), "job-1", nil)
+	if err != nil {
+		t.Fatalf("Expected resolution to succeed, got: %v", err)
+	}
+	if gotType != backends.BackendCuda || gotSource != sourceDefault || gotConfig != nil {
+		t.Errorf("Expected the default backend with no config, got %s from %s with %v", gotType, gotSource, gotConfig)
+	}
+}
+
+// recordingBackend counts invocations; the routing tests use it to prove a
+// backend was bypassed (or hit).
+type recordingBackend struct {
+	backends.NoopBackend
+	snapshots atomic.Int32
+	restores  atomic.Int32
+}
+
+func (b *recordingBackend) Snapshot(ctx context.Context, req backends.Request) error {
+	b.snapshots.Add(1)
+	return b.NoopBackend.Snapshot(ctx, req)
+}
+
+func (b *recordingBackend) Restore(ctx context.Context, req backends.Request) error {
+	b.restores.Add(1)
+	return b.NoopBackend.Restore(ctx, req)
+}
+
+// newRoutingTestServer starts a server whose backend map holds the given
+// backends (the default type must be among them) plus a real app-channel
+// backend sharing the registry with the WorkloadChannel handler, and returns
+// a connected client. The server's pod-annotation lookup is stubbed to find
+// nothing; tests override srv.resolver.lookupPodBackend as needed.
+func newRoutingTestServer(
+	t *testing.T,
+	defaultType backends.BackendType,
+	backendsByType map[backends.BackendType]backends.Backend,
+	mode string,
+) (*Server, *backends.ChannelRegistry, pb.SnapshotAgentServiceClient) {
+	t.Helper()
+	lisRoute := bufconn.Listen(bufSize)
+	s := grpc.NewServer()
+	registry := backends.NewChannelRegistry()
+	backendsMap := map[backends.BackendType]backends.Backend{
+		backends.BackendAppChannel: backends.NewAppChannelBackend(registry),
+	}
+	for backendType, backend := range backendsByType {
+		backendsMap[backendType] = backend
+	}
+	srv := NewServer(backendsMap, defaultType, mode, registry, nil)
+	srv.resolver.lookupPodBackend = func(context.Context, string) (*podutils.JobBackendAnnotation, error) {
+		return nil, nil
+	}
+	pb.RegisterSnapshotAgentServiceServer(s, srv)
+	go func() {
+		if err := s.Serve(lisRoute); err != nil {
+			return
+		}
+	}()
+	t.Cleanup(s.GracefulStop)
+
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(func(context.Context, string) (net.Conn, error) {
+			return lisRoute.Dial()
+		}),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	return srv, registry, pb.NewSnapshotAgentServiceClient(conn)
+}
+
+// TestServer_NoConfig_RoutesToWorkloadChannel verifies the orchestrator
+// scenario end to end: Snapshot/Restore requests without a BackendConfig
+// reach a registered workload through its channel instead of the configured
+// default (CUDA) backend.
+func TestServer_NoConfig_RoutesToWorkloadChannel(t *testing.T) {
+	defaultBackend := &recordingBackend{}
+	srv, registry, client := newRoutingTestServer(t, backends.BackendCuda,
+		map[backends.BackendType]backends.Backend{backends.BackendCuda: defaultBackend}, "k8s")
+	ctx := context.Background()
+
+	registerWorkload(ctx, t, client, registry, "routed-job", &pb.WorkloadCapabilities{
+		SupportedModes: []pb.SuspendMode{pb.SuspendMode_SUSPEND_MODE_OFFLOAD},
+		DefaultMode:    pb.SuspendMode_SUSPEND_MODE_OFFLOAD,
+	})
+	if err := srv.state.TransitionToRunning("routed-job", nil); err != nil {
+		t.Fatalf("Failed to transition job to RUNNING: %v", err)
+	}
+
+	snapResp, err := client.Snapshot(ctx, &pb.SnapshotRequest{JobId: "routed-job"})
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	opResp := waitForOperation(ctx, t, client, snapResp.GetOperationId())
+	if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_COMPLETE {
+		t.Fatalf("Expected snapshot COMPLETE, got %v (error: %q)", opResp.GetStatus(), opResp.GetError())
+	}
+
+	restoreResp, err := client.Restore(ctx, &pb.RestoreRequest{JobId: "routed-job"})
+	if err != nil {
+		t.Fatalf("Restore failed: %v", err)
+	}
+	opResp = waitForOperation(ctx, t, client, restoreResp.GetOperationId())
+	if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_COMPLETE {
+		t.Fatalf("Expected restore COMPLETE, got %v (error: %q)", opResp.GetStatus(), opResp.GetError())
+	}
+
+	if got := defaultBackend.snapshots.Load(); got != 0 {
+		t.Errorf("Expected the default backend to be bypassed for snapshot, got %d calls", got)
+	}
+	if got := defaultBackend.restores.Load(); got != 0 {
+		t.Errorf("Expected the default backend to be bypassed for restore, got %d calls", got)
+	}
+}
+
+// TestServer_NoConfig_PodAnnotationRoutesBackend verifies the pod-annotation
+// source end to end: a config-less Snapshot for a job whose pods declare
+// timeslice.io/backend=app_endpoint reaches the app-endpoint backend instead
+// of the configured default (CUDA) backend.
+func TestServer_NoConfig_PodAnnotationRoutesBackend(t *testing.T) {
+	defaultBackend := &recordingBackend{}
+	annotatedBackend := &recordingBackend{}
+	srv, _, client := newRoutingTestServer(t, backends.BackendCuda,
+		map[backends.BackendType]backends.Backend{
+			backends.BackendCuda:        defaultBackend,
+			backends.BackendAppEndpoint: annotatedBackend,
+		}, "k8s")
+	srv.resolver.lookupPodBackend = func(context.Context, string) (*podutils.JobBackendAnnotation, error) {
+		return &podutils.JobBackendAnnotation{
+			Backend: "app_endpoint",
+			Config:  `{"app": "APP_VLLM", "endpoints": ["http://localhost:8000"]}`,
+		}, nil
+	}
+	ctx := context.Background()
+
+	srv.state.RegisterJob("annotated-job", "")
+	if err := srv.state.TransitionToRunning("annotated-job", nil); err != nil {
+		t.Fatalf("Failed to transition job to RUNNING: %v", err)
+	}
+
+	snapResp, err := client.Snapshot(ctx, &pb.SnapshotRequest{JobId: "annotated-job"})
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	opResp := waitForOperation(ctx, t, client, snapResp.GetOperationId())
+	if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_COMPLETE {
+		t.Fatalf("Expected snapshot COMPLETE, got %v (error: %q)", opResp.GetStatus(), opResp.GetError())
+	}
+
+	if got := annotatedBackend.snapshots.Load(); got != 1 {
+		t.Errorf("Expected the annotated backend to handle the snapshot, got %d calls", got)
+	}
+	if got := defaultBackend.snapshots.Load(); got != 0 {
+		t.Errorf("Expected the default backend to be bypassed, got %d calls", got)
+	}
+}
+
+// TestServer_MalformedPodAnnotationFailsLoudly verifies that an unknown pod
+// backend declaration fails both RPCs with FAILED_PRECONDITION instead of
+// silently falling through to the default backend.
+func TestServer_MalformedPodAnnotationFailsLoudly(t *testing.T) {
+	defaultBackend := &recordingBackend{}
+	srv, _, client := newRoutingTestServer(t, backends.BackendCuda,
+		map[backends.BackendType]backends.Backend{backends.BackendCuda: defaultBackend}, "k8s")
+	srv.resolver.lookupPodBackend = func(context.Context, string) (*podutils.JobBackendAnnotation, error) {
+		return &podutils.JobBackendAnnotation{Backend: "warp-drive"}, nil
+	}
+	ctx := context.Background()
+
+	srv.state.RegisterJob("misdeclared-job", "")
+	if err := srv.state.TransitionToRunning("misdeclared-job", nil); err != nil {
+		t.Fatalf("Failed to transition job to RUNNING: %v", err)
+	}
+
+	_, err := client.Snapshot(ctx, &pb.SnapshotRequest{JobId: "misdeclared-job"})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("Expected Snapshot to fail with FAILED_PRECONDITION, got: %v", err)
+	}
+	_, err = client.Restore(ctx, &pb.RestoreRequest{JobId: "misdeclared-job"})
+	if status.Code(err) != codes.FailedPrecondition {
+		t.Errorf("Expected Restore to fail with FAILED_PRECONDITION, got: %v", err)
+	}
+	if got := defaultBackend.snapshots.Load() + defaultBackend.restores.Load(); got != 0 {
+		t.Errorf("Expected no backend calls for a misdeclared job, got %d", got)
+	}
+}
+
+// TestServer_NoConfig_NoChannelUsesDefault verifies that config-less requests
+// for jobs without a registered workload channel still hit the configured
+// default backend (standalone mode passes the config through untouched).
+func TestServer_NoConfig_NoChannelUsesDefault(t *testing.T) {
+	defaultBackend := &recordingBackend{}
+	srv, _, client := newRoutingTestServer(t, backends.BackendNoop,
+		map[backends.BackendType]backends.Backend{backends.BackendNoop: defaultBackend}, "standalone")
+	ctx := context.Background()
+
+	srv.state.RegisterJob("plain-job", "")
+	if err := srv.state.TransitionToRunning("plain-job", nil); err != nil {
+		t.Fatalf("Failed to transition job to RUNNING: %v", err)
+	}
+
+	snapResp, err := client.Snapshot(ctx, &pb.SnapshotRequest{JobId: "plain-job"})
+	if err != nil {
+		t.Fatalf("Snapshot failed: %v", err)
+	}
+	opResp := waitForOperation(ctx, t, client, snapResp.GetOperationId())
+	if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_COMPLETE {
+		t.Fatalf("Expected snapshot COMPLETE, got %v (error: %q)", opResp.GetStatus(), opResp.GetError())
+	}
+	if got := defaultBackend.snapshots.Load(); got != 1 {
+		t.Errorf("Expected the default backend to handle the snapshot, got %d calls", got)
+	}
+}

--- a/pkg/snapshot-agent/utils/pod-utils.go
+++ b/pkg/snapshot-agent/utils/pod-utils.go
@@ -19,7 +19,25 @@ const (
 	// JobIDLabel is the label used to identify pods by their job ID.
 	JobIDLabel = "timeslice.io/job-id"
 	GroupLabel = "timeslice.io/group"
+	// BackendAnnotation declares which snapshot/restore backend handles the
+	// pod's workload when a request carries no explicit BackendConfig and the
+	// job has no live workload channel. Values are BackendConfig field names
+	// (cuda, app_endpoint, app_channel, direct_memory) or noop.
+	BackendAnnotation = "timeslice.io/backend"
+	// BackendConfigAnnotation optionally accompanies BackendAnnotation with
+	// the protojson encoding of the declared backend's config message, e.g.
+	// {"endpoints": ["http://localhost:8000"]} for app_endpoint.
+	BackendConfigAnnotation = "timeslice.io/backend-config"
 )
+
+// JobBackendAnnotation is a backend declaration read from a job's pods.
+type JobBackendAnnotation struct {
+	// Backend is the value of the timeslice.io/backend annotation.
+	Backend string
+	// Config is the value of the timeslice.io/backend-config annotation, or
+	// empty when the pods declare none.
+	Config string
+}
 
 var (
 	// For mocking in tests.
@@ -105,6 +123,40 @@ func GetLocalPods(ctx context.Context, jobID string) ([]corev1.Pod, error) {
 	}
 
 	return podList.Items, nil
+}
+
+// GetJobBackendAnnotation returns the backend declared on the job's local
+// pods (the same pods job discovery matches by the timeslice.io/job-id
+// label), or nil when no pod declares one. Pods of the same job must agree:
+// conflicting declarations are an error rather than an arbitrary pick.
+func GetJobBackendAnnotation(ctx context.Context, jobID string) (*JobBackendAnnotation, error) {
+	pods, err := GetLocalPods(ctx, jobID)
+	if err != nil {
+		return nil, err
+	}
+
+	var declared *JobBackendAnnotation
+	var declaredBy string
+	for i := range pods {
+		pod := &pods[i]
+		backend, ok := pod.Annotations[BackendAnnotation]
+		if !ok {
+			continue
+		}
+		current := &JobBackendAnnotation{
+			Backend: backend,
+			Config:  pod.Annotations[BackendConfigAnnotation],
+		}
+		if declared == nil {
+			declared, declaredBy = current, pod.Name
+			continue
+		}
+		if *declared != *current {
+			return nil, fmt.Errorf("pods %s and %s of job %s carry conflicting %s declarations",
+				declaredBy, pod.Name, jobID, BackendAnnotation)
+		}
+	}
+	return declared, nil
 }
 
 // GetPodPIDs returns the host-namespace PIDs of all CUDA-context-holding processes belonging to the specified pod.

--- a/pkg/snapshot-agent/utils/pod-utils_test.go
+++ b/pkg/snapshot-agent/utils/pod-utils_test.go
@@ -13,6 +13,7 @@ import (
 	snapshotutils "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/utils"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/fake"
@@ -315,6 +316,127 @@ func TestGetLocalPods(t *testing.T) {
 			}
 			if !tt.expectError && len(pods) != tt.expectedLen {
 				t.Errorf("GetLocalPods() len = %d, expected %d", len(pods), tt.expectedLen)
+			}
+		})
+	}
+}
+
+func TestGetJobBackendAnnotation(t *testing.T) {
+	origGetK8sClient := snapshotutils.GetK8sClient
+	defer func() { snapshotutils.GetK8sClient = origGetK8sClient }()
+
+	nodeName := "test-node"
+	jobID := "test-job"
+
+	newPod := func(name string, annotations map[string]string) *corev1.Pod {
+		return &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        name,
+				Labels:      map[string]string{snapshotutils.JobIDLabel: jobID},
+				Annotations: annotations,
+			},
+			Spec: corev1.PodSpec{NodeName: nodeName},
+		}
+	}
+
+	tests := []struct {
+		name        string
+		nodeEnv     string
+		pods        []*corev1.Pod
+		want        *snapshotutils.JobBackendAnnotation
+		expectError bool
+	}{
+		{
+			name:    "Backend with config declared",
+			nodeEnv: nodeName,
+			pods: []*corev1.Pod{
+				newPod("pod1", map[string]string{
+					snapshotutils.BackendAnnotation:       "app_endpoint",
+					snapshotutils.BackendConfigAnnotation: `{"endpoints": ["http://localhost:8000"]}`,
+				}),
+			},
+			want: &snapshotutils.JobBackendAnnotation{
+				Backend: "app_endpoint",
+				Config:  `{"endpoints": ["http://localhost:8000"]}`,
+			},
+		},
+		{
+			name:    "Backend without config declared",
+			nodeEnv: nodeName,
+			pods:    []*corev1.Pod{newPod("pod1", map[string]string{snapshotutils.BackendAnnotation: "cuda"})},
+			want:    &snapshotutils.JobBackendAnnotation{Backend: "cuda"},
+		},
+		{
+			name:    "No declaration",
+			nodeEnv: nodeName,
+			pods:    []*corev1.Pod{newPod("pod1", nil)},
+			want:    nil,
+		},
+		{
+			name:    "Agreeing pods",
+			nodeEnv: nodeName,
+			pods: []*corev1.Pod{
+				newPod("pod1", map[string]string{snapshotutils.BackendAnnotation: "cuda"}),
+				newPod("pod2", map[string]string{snapshotutils.BackendAnnotation: "cuda"}),
+				newPod("pod3", nil), // silent pods do not conflict
+			},
+			want: &snapshotutils.JobBackendAnnotation{Backend: "cuda"},
+		},
+		{
+			name:    "Conflicting backends",
+			nodeEnv: nodeName,
+			pods: []*corev1.Pod{
+				newPod("pod1", map[string]string{snapshotutils.BackendAnnotation: "cuda"}),
+				newPod("pod2", map[string]string{snapshotutils.BackendAnnotation: "app_endpoint"}),
+			},
+			expectError: true,
+		},
+		{
+			name:    "Conflicting configs",
+			nodeEnv: nodeName,
+			pods: []*corev1.Pod{
+				newPod("pod1", map[string]string{
+					snapshotutils.BackendAnnotation:       "app_endpoint",
+					snapshotutils.BackendConfigAnnotation: `{"endpoints": ["http://localhost:8000"]}`,
+				}),
+				newPod("pod2", map[string]string{
+					snapshotutils.BackendAnnotation:       "app_endpoint",
+					snapshotutils.BackendConfigAnnotation: `{"endpoints": ["http://localhost:9000"]}`,
+				}),
+			},
+			expectError: true,
+		},
+		{
+			name:        "Missing NODE_NAME",
+			nodeEnv:     "",
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.nodeEnv != "" {
+				os.Setenv("NODE_NAME", tt.nodeEnv)
+				defer os.Setenv("NODE_NAME", "")
+			} else {
+				os.Unsetenv("NODE_NAME")
+			}
+
+			objects := make([]runtime.Object, 0, len(tt.pods))
+			for _, pod := range tt.pods {
+				objects = append(objects, pod)
+			}
+			snapshotutils.GetK8sClient = func() (kubernetes.Interface, error) {
+				return fake.NewSimpleClientset(objects...), nil
+			}
+
+			got, err := snapshotutils.GetJobBackendAnnotation(context.Background(), jobID)
+			if (err != nil) != tt.expectError {
+				t.Errorf("GetJobBackendAnnotation() error = %v, expectError %v", err, tt.expectError)
+				return
+			}
+			if !tt.expectError && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("GetJobBackendAnnotation() = %v, expected %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Orchestrator-driven Snapshot/Restore requests carry no backend_config, so the agent always fell through to the default (CUDA) backend and cuda-checkpointed workloads that had registered an app channel, bypassing their suspend/resume hooks.

This PR makes the server resolve the backend of every Snapshot and Restore request through a single per-job chain, in strict precedence order:

1. **Explicit `BackendConfig`** — always wins, passes through untouched.
2. **Registered workload channel** — a job with a live channel routes to the app-channel backend with a synthesized config (mode resolves from the workload's registered capabilities). A registered-but-disconnected channel falls through with a warning.
3. **Pod annotation** — `timeslice.io/backend` on the workload's pods (a `BackendConfig` field name or `noop`), with the optional `timeslice.io/backend-config` annotation carrying a protojson config. Malformed, unknown, or conflicting declarations fail the operation loudly; they never fall through silently.
4. **Agent default backend** — unchanged.

Design notes: the chain lives in a small `backendResolver` whose sources are individually testable; both RPCs go through it and each resolution logs one line naming the deciding source and chosen backend. Feature gates are checked on the resolved config, so a gated backend is rejected regardless of which source selected it. The user guide documents the chain with annotation examples.

Validation: unit tests included (resolver routing suite + pod-annotation parsing tests); the workload-channel routing behavior this generalizes was validated e2e on GKE (RL + batch-inference interleaving runs, 9/9 mixed-backend C/R cycles).
