### PR TITLE
Add RL + batch-inference interleaving guide

### DIFF
--- a/guides/rl-batch-interleaving/README.md
+++ b/guides/rl-batch-interleaving/README.md
@@ -1,0 +1,639 @@
+# Interleaving a verl RL Trainer with a Batch-Inference Server on One GPU
+
+This guide is a step-by-step walkthrough for time-slicing **one verl
+`fully_async_policy` RL training job** with **a batch-inference server** on
+the same GPU through the llm-d-rl-time-slicing platform. In verl's
+fully-async recipe, rollout generation runs continuously while the trainer
+sits idle whenever it waits for the next batch of samples — in our reference
+runs that idle fraction was 40–70% of wall-clock. Instead of backfilling
+those valleys with another RL trainer, this recipe backfills them with
+latency-tolerant batch inference: the RL trainer has **absolute priority**,
+and the batch server holds the GPU only while the trainer doesn't want it.
+Neither workload's source is modified.
+
+The two tenants yield the GPU through two different checkpoint/restore
+mechanisms, chosen to match their duty cycles:
+
+- **The trainer** is checkpointed with **`cuda-checkpoint`** (the platform's
+  default backend): the snapshot agent dumps its entire GPU state to host RAM
+  at each yield (~10–35 s per swap for small models), amortized against
+  training bursts that run for minutes.
+- **The batch server** yields through the snapshot agent's **workload
+  channel**: it registers sleep/wake callbacks that map to the inference
+  engine's native offload (vLLM sleep mode moves weights + KV cache to host
+  RAM in ~1–2 s and back in under a second — no process restart, no model
+  reload). Second-scale yields are what make it safe for the batch tenant to
+  give the GPU back the moment the trainer queues.
+
+The RL job keeps a dedicated 1-GPU node for its rollout engine, which never
+stops generating; the FSDP trainer and the batch server take turns on the
+shared node:
+
+```
+  ROLLOUT NODE (dedicated)             TRAINER NODE (SHARED, time-sliced)
+  ┌──────────────────────────┐         ┌──────────────────────────────────┐
+  │ RL rollout pod           │  ray    │ RL head pod      batch server pod│
+  │ rollout engine (vLLM,    │◀───────▶│ FSDP trainer ⇄   inference engine│
+  │ generates continuously)  │         │ cuda-checkpoint  + supervisor    │
+  └──────────────────────────┘         │      C/R         sleep/wake      │
+                                       └──────────────────────────────────┘
+  lock owner over time on the trainer node's GPU:
+  batch ███████░T██████████░T█████████░T████████   (T = training burst)
+               ▲ trainer queues → batch yields in ≤ poll(0.5s) + drain(~3s) + sleep(~1-2s)
+```
+
+This README is the generic walkthrough for running **any** verl fully-async
+RL job against **any** batch tenant that can sleep/wake (or be
+cuda-checkpointed). A complete pinned runnable — concrete models, manifests,
+and a load generator, launchable in a handful of commands — is in
+**[examples/](examples/README.md)**.
+
+---
+
+## Table of Contents
+1. [Cluster Prerequisites](#1-cluster-prerequisites)
+2. [Deploy the Time-Slicing Platform](#2-deploy-the-time-slicing-platform)
+3. [Integrate Your RL Workload](#3-integrate-your-rl-workload)
+4. [The Batch Tenant and the Supervisor](#4-the-batch-tenant-and-the-supervisor)
+5. [Deploy the Tenants](#5-deploy-the-tenants)
+6. [Submit and Observe](#6-submit-and-observe)
+7. [Troubleshooting](#7-troubleshooting)
+
+---
+
+## 1. Cluster Prerequisites
+
+Before deploying, ensure your environment meets the following requirements:
+
+* Kubernetes **v1.34** or later (we validated on GKE, COS nodes) with 1-GPU
+  nodes (H100-class recommended). The GPUs used for time-slicing must NOT be
+  in use by anything else.
+* GPU nodes must run **NVIDIA GPU Driver 565 or later**. This is a strict
+  requirement to support **NVIDIA Dynamic Resource Allocation (DRA)**. The
+  NVIDIA DRA driver itself ships with the platform Helm chart (§2).
+* Cluster-admin access; `kubectl`, `helm` (v3), and `git` on your
+  workstation.
+* Nodes can pull your job images and reach GitHub + HuggingFace from pods
+  (verl jobs typically fetch the model by HF id per node at startup — no
+  shared volume needed).
+* **Two 1-GPU nodes minimum**: one **shared trainer node** (RL head pod +
+  batch server pod, one GPU between them) and one dedicated RL rollout node.
+
+### Node Labeling and Time-Slice Groups
+
+The orchestrator discovers resource pools (*groups*) from node labels. Jobs
+in the same group take turns holding the group's accelerator lock. The
+principle is that time-slicing machinery touches ONLY time-sliced nodes:
+the **shared trainer node** carries all the time-slicing markers — the
+group label (drives group discovery), the `timeslice.io/enabled` label
+(the platform-wide marker for nodes participating in time-slicing — the
+same convention the slime guide uses; in this recipe that is only the
+trainer node — and what the platform install in §2 targets snapshot-agent
+and DRA kubelet-plugin placement at), and the isolation taint (keeps
+unrelated workloads off the shared GPU; the pods in this guide already
+carry the matching toleration) — while the **rollout node carries nothing
+timeslice-related**. Set up the trainer node with three commands:
+
+```bash
+kubectl label node <trainer-node> group.timeslice.io/trainers=true --overwrite
+kubectl label node <trainer-node> timeslice.io/enabled=true --overwrite
+kubectl taint node <trainer-node> timeslice.io/shared=true:NoSchedule --overwrite
+```
+
+Do NOT put either label on any other node, and do not put
+`timeslice.io/*` pod labels on the rollout pod: only labeled pods on
+labeled nodes are snapshot candidates, so the unlabeled rollout process is
+never touched by the platform — while the trainer is checkpointed off the
+shared GPU, the rollout keeps generating samples into the staleness queue.
+The rollout node needs **no labels or taints at all** — the rollout pod
+requests its GPU the ordinary way (§ Shared DRA Resource Claim below),
+which is GPU access, not time-slicing. Placement follows from three
+guarantees.
+
+1. The RL head pod and the batch server pod co-locate on the trainer node
+   because they consume the SAME shared `ResourceClaim`, and a claim's
+   consumers must run where its device is. (If the trainer node lacks
+   CPU/RAM headroom for the second tenant, that pod goes Pending; see the
+   host-RAM sizing rule below.)
+2. The rollout pod can never land on the trainer node: it carries a
+   required node anti-affinity on `group.timeslice.io/trainers`.
+3. The device plugin allocates whole GPUs exclusively, so rollout pods
+   always land on distinct GPUs; on a 1-GPU-per-node topology that means
+   distinct nodes. On multi-GPU nodes this becomes distinct GPUs, possibly
+   on the same node.
+
+On clusters with GPU nodes beyond the recipe's, rollouts may schedule onto
+any free GPU node; operators running amid other workloads should scope
+their GPU pool (e.g. with their own labels/taints).
+
+### Shared DRA Resource Claim
+
+Cooperative time-slicing leverages Kubernetes **Dynamic Resource Allocation
+(DRA)** so multiple tenants' pods can share physical GPU hardware without
+scheduler blocking — and without elevated pod permissions: the NVIDIA DRA
+driver injects the GPU and driver userspace into ordinary pods. The recipe
+contains exactly ONE `ResourceClaim` — the **shared** trainer claim —
+because sharing is what only DRA can express: reference it from BOTH
+tenants on the trainer node (the RL head pod and the batch server pod —
+that is what lets them co-locate on the one GPU, each holding the full,
+unpartitioned GPU during its turn). The rollout pod requests its GPU the
+ordinary way (`nvidia.com/gpu: 1` via the device plugin) — it needs no
+claim. (On clusters that manage GPUs purely via DRA, with no device plugin,
+give the rollout pod its own `ExactCount: 1` claim instead — and since the
+DRA kubelet plugin must then run on the rollout node too, drop or widen the
+`kubeletPlugin` nodeSelector flag from the §2 install.)
+
+```yaml
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: shared-trainers-gpu-claim
+  namespace: default
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        allocationMode: ExactCount
+        count: 1
+```
+
+Apply the claim before submitting any tenant (the example ships this exact
+file as `examples/resource-claims.yaml`):
+
+```bash
+kubectl apply -f resource-claims.yaml
+```
+
+### Host-RAM Sizing Rule
+
+Everything yielded on the shared node lands in host RAM, so size the trainer
+node for BOTH tenants' offloads:
+
+* The RL head pod's memory limit must fit its normal RSS **plus its entire
+  GPU allocation** — the cuda-checkpoint dump of the trainer's full GPU state
+  lands in pod memory.
+* The batch server pod's memory limit must additionally fit its sleep
+  offload: the engine's weights + KV cache move to host RAM at every yield
+  (for reference, the example demo budgets 80 Gi/110 Gi for a 1.5 B trainer
+  head and 60 Gi for the batch server's sleep offload, on a 234 Gi node).
+
+---
+
+## 2. Deploy the Time-Slicing Platform
+
+Deploy the core platform components — **TimeSlice Orchestrator** (Deployment:
+the gRPC lock service) and **Snapshot Agent** (DaemonSet on the time-sliced
+nodes: performs each tenant's snapshot/restore when the orchestrator hands
+the lock over) — using the parent Helm chart.
+
+### Step 1: Clone the Repository
+
+```bash
+git clone https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git
+cd llm-d-rl-time-slicing
+```
+
+> **Release pin:** the chart is not published to a registry — you install it
+> from the clone. To pin a release, clone the repo at the release tag
+> (`git clone --branch <version> https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git`)
+> so the chart matches the pinned images, and pin the images with
+> `--set timesliceorchestrator.image.tag=<version> --set snapshot-agent.image.tag=<version>`
+> (the chart defaults pull the official
+> `ghcr.io/llm-d-incubation/llm-d-rl-time-slicing/*` images at `latest`).
+> Until the first tagged release is cut, `main` + `latest` is the only
+> option. One constraint specific to this recipe: whatever you pin, the
+> snapshot agent must support **per-job backend resolution** — the workload
+> channel is how the agent drives the batch engine's sleep/wake instead of
+> cuda-checkpointing it (the official images at `latest`, the chart default,
+> do).
+
+### Step 2: Install the Helm Chart
+
+Install into a dedicated namespace (`timeslice-system`), pinning the
+node-level platform components to `timeslice.io/enabled` nodes:
+
+```bash
+helm dependency update ./deploy
+helm install timeslice ./deploy -n timeslice-system --create-namespace \
+  --set-string "snapshot-agent.nodeSelector.timeslice\.io/enabled=true" \
+  --set-string "nvidia-dra-driver-gpu.kubeletPlugin.nodeSelector.timeslice\.io/enabled=true"
+```
+
+The first flag pins the snapshot agent (a `hostPID` DaemonSet) to
+`timeslice.io/enabled` nodes — in this recipe, just the trainer node;
+agents on rollout nodes would perform no work anyway (all prior runs
+confirmed this). The second flag pins the NVIDIA DRA driver's kubelet
+plugin — the bundled driver's only node-level component, which publishes
+`ResourceSlice`s and injects the GPU into claim-consuming pods — to the
+same nodes: DRA is needed exactly where the shared claim binds, and gating
+it keeps other GPU nodes free of `ResourceSlice`s advertising their GPUs
+as claimable.
+
+**Zero-impact principle:** you can share the cluster with non-timeslice
+workloads with zero impact to them. This install plus the labels + taint
+in §1 touch only the trainer node — the snapshot agent and the DRA kubelet
+plugin run only there, and every other node carries no platform
+components, labels, or taints, so workloads on those nodes are unaffected.
+The recipe's rollout pod competes for free GPUs like any ordinary
+workload: standard scheduling, no special machinery.
+
+> If a `timeslice` release already exists, do a clean
+> `helm uninstall timeslice -n timeslice-system` first — `helm install` fails
+> on an existing release name. (Note: uninstalling also removes the bundled
+> NVIDIA DRA driver DaemonSet until you reinstall.)
+
+### Step 3: Verify Platform Health
+
+Verify the orchestrator is Running, and that an agent pod and a
+`nvidia-dra-driver-gpu-kubelet-plugin` pod run on the trainer node — and
+only there; no other node should carry either:
+
+```bash
+kubectl -n timeslice-system get pods -o wide
+```
+
+After labeling the trainer node (§1), verify the orchestrator synced the
+group:
+
+```bash
+kubectl -n timeslice-system logs deploy/timeslice-timesliceorchestrator --tail=50 \
+  | grep -i trainers | tail -3
+```
+
+Optionally verify with the `rlts` CLI (requires Go toolchain; from the repo
+root — the same binary is used to observe lock handoffs while tenants run):
+
+```bash
+go build -o bin/rlts ./cmd/rlts
+./bin/rlts orchestrator list
+```
+
+No snapshot-device filter is needed in this topology: every node has one GPU,
+and only the labeled pods on the trainer node are snapshot targets — the
+rollout pod is unlabeled on another node.
+
+---
+
+## 3. Integrate Your RL Workload
+
+### How It Works
+
+The `llm-d-timeslice-verl` package ships `TimesliceFullyAsyncTrainer`, a
+subclass of verl's `fully_async_policy` trainer that overrides the trainer's
+empty `on_*` lifecycle hooks to acquire/release the orchestrator lock at the
+trainer's natural wait points. It registers under the trainer name
+`timeslice` (verl's `register_trainer` registry; the package's `verl.plugins`
+entry point makes `import verl` load the registering module) and is selected
+with a single hydra override: `async_training.trainer_name=timeslice`. No
+monkey-patching and no verl source edits in your job — it requires a verl
+build with the fully-async lifecycle hooks + trainer registry and per-pool
+placement-group bundle resources (currently the
+`feat/fully-async-lifecycle-hooks` fork branch, until the commits land
+upstream).
+
+Lock protocol:
+
+| Trainer lifecycle point | Lock action |
+|---|---|
+| `init_workers` (model load) | ACQUIRE → load → YIELD |
+| initial weight sync (pre-fit) | ACQUIRE → sync → YIELD |
+| a batch of samples is ready | ACQUIRE (this is the resume point) |
+| weight update + param sync done | YIELD |
+
+### Placement-Group Pinning
+
+Pin trainer/rollout placement with Ray **custom resources** — start ray on
+the head with `--resources='{"trainer_node": 100}'`, on the worker with
+`--resources='{"rollout_node": 100}'`, and pass verl's per-pool
+placement-group bundle resources (hydra override
+`ray_pg_extra_resources={trainer_pool: {trainer_node: 1}, rollout_pool: {rollout_node: 1}}`)
+so verl's trainer placement group requests `{trainer_node: 1}` and the
+rollout PG `{rollout_node: 1}`.
+
+### Installing verl (Pinned Fork)
+
+In each job pod (or your job image), clone the
+[`feat/fully-async-lifecycle-hooks`](https://github.com/aishukamal/verl/tree/feat/fully-async-lifecycle-hooks)
+branch of `github.com/aishukamal/verl` — upstream
+`983cb0f24443f87b3d161fad318445130a620b07` + two feature commits (fully-async
+lifecycle hooks + trainer registry; per-pool PG bundle resources) — and
+install it with `pip install -e ".[gpu]"`. This is a temporary fork until the
+commits land upstream; once they do, point the install at mainline verl
+instead (the example manifests parameterize this as the `VERL_REPO`/`VERL_REF`
+pod envs).
+
+### Installing the `llm-d-timeslice-verl` Package
+
+Install the timeslice client and the integration package in every job pod
+(or bake them into your job image):
+
+```bash
+# Install the timeslice client library
+pip install "git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/client/python"
+
+# Install the llm-d-timeslice-verl trainer package
+pip install --no-cache-dir --no-deps "llm-d-timeslice-verl @ git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/integrations/verl"
+```
+
+> **Why `--no-deps`?** The package declares no dependencies of its own — the
+> timeslice client it uses is installed separately (above), so there is
+> nothing for pip to resolve.
+
+### The Job Contract
+
+Every time-sliced verl job must carry this contract:
+
+* **Hydra overrides** on the verl launch command:
+  * `async_training.trainer_name=timeslice` — selects the registered
+    timeslice trainer.
+  * `"ray_pg_extra_resources={trainer_pool: {trainer_node: 1}, rollout_pool: {rollout_node: 1}}"`
+    — pins the placement groups (see
+    [Placement-Group Pinning](#placement-group-pinning)).
+  * `trainer.save_freq=-1` — checkpoint saving is disabled under
+    time-slicing: a save RPCs the FSDP worker, which may be checkpointed off
+    the GPU at that moment. The timeslice trainer vetoes saves (with a
+    warning) if this is left `> 0`. Note the consequence: time-sliced runs
+    write no training checkpoints.
+  * `+actor_rollout_ref.rollout.checkpoint_engine.engine_kwargs.nccl.rebuild_group=true`
+    — tears down and rebuilds the trainer↔rollout weight-sync NCCL
+    communicator around each sync, so no communicator exists outside
+    lock-held windows.
+  * `async_training.trigger_parameter_sync_step=1` — yield the GPU once per
+    training step; larger values hold the lock across sample-queue waits
+    (and starve the batch tenant for no benefit).
+  * `async_training.use_dynamic_resource_scheduling=false` and
+    `async_training.use_trainer_do_validate=false` — keep dynamic
+    rescheduling and validation off the time-sliced trainer GPU (both would
+    touch the GPU outside the lock protocol).
+* **`ray start` custom resources**: head
+  `--resources='{"trainer_node": 100}'`, rollout worker
+  `--resources='{"rollout_node": 100}'`.
+* **Environment variables** (set as container-level env vars on both pods,
+  kept identical — the trainer driver actor is a CPU-only Ray actor that can
+  be scheduled on either Ray node and inherits the raylet's env):
+  * `TIMESLICE_FULLY_ASYNC=1` — activates the hooks (they are inert without
+    it).
+  * `TIMESLICE_JOB_ID` — unique per tenant; must equal the head pod's
+    `timeslice.io/job-id` label.
+  * `TIMESLICE_GROUP` — the group whose lock the trainer takes (e.g.
+    `trainers`).
+  * `TIMESLICE_ORCH_ADDR` — orchestrator gRPC address
+    (`timeslice-timesliceorchestrator.timeslice-system.svc:50051`).
+* **Pod labels** on the head pod ONLY (the trainer is the sole time-sliced
+  process in the RL job; the rollout pod stays unlabeled):
+  `timeslice.io/job-id: <job id>` and `timeslice.io/group: <group>` — the
+  exact keys the platform selects snapshot candidates on.
+* **NCCL environment**: set `NCCL_CUMEM_ENABLE=0` and `NCCL_NVLS_ENABLE=0` on
+  every job pod (the example manifests set both) — precautionary settings
+  around cuda-checkpoint; keep them as set.
+
+> **See also:** the [verl integration guide](../rl-frameworks/verl/README.md)
+> walks through this same contract in the setting where the second tenant is
+> another RL trainer.
+
+---
+
+## 4. The Batch Tenant and the Supervisor
+
+Everything in §3 is the standard time-sliced verl setup. The ONE component
+this recipe adds is the batch tenant's side of the lock protocol: an RL
+trainer yields at its natural wait points, but a serving engine has no
+natural wait points — something must decide when it yields and how it
+freezes. Two requirements, and they generalize to any batch engine:
+
+1. **A cheap freeze/thaw path.** The engine should offload weights + KV
+   cache to host RAM and restore them without a process restart or model
+   reload. In vLLM this is **sleep mode** (`--enable-sleep-mode`, with
+   `VLLM_SERVER_DEV_MODE=1` exposing the `/sleep`, `/wake_up`, `/is_sleeping`
+   dev endpoints); other engines have equivalents (e.g. SGLang's
+   release/resume memory occupation). An engine with no such API can still
+   participate — the platform simply cuda-checkpoints the whole process like
+   a trainer — but yields then cost tens of seconds instead of ~1–2 s, which
+   the trainer eats at every handoff.
+2. **A drain path.** The engine must stop admitting requests and finish (or
+   fail fast) in-flight work BEFORE freezing. vLLM's `/sleep` does NOT drain
+   the scheduler, and sleeping with a request mid-decode is a fatal CUDA
+   error (vllm#28714; requests sent to a sleeping engine crash it too,
+   vllm#15483).
+
+### The Supervisor (Reference Implementation)
+
+`examples/shadow-vllm.yaml` (EXAMPLE-ONLY, demo-quality) wraps **stock
+`vllm serve`** with a ~100-line supervisor script that adapts it to the
+platform's lock protocol. Whatever engine you run, your supervisor needs the
+same four behaviors:
+
+- **Priority by construction.** The supervisor acquires the group lock and
+  holds it only while nobody else waits: every `WAITER_POLL_SECONDS`
+  (default 0.5 s) it polls the orchestrator's waiter queue and yields as soon
+  as the trainer queues. The trainer therefore never waits behind batch work
+  for more than poll + drain + sleep (seconds), while the batch engine soaks
+  up every idle minute.
+- **Workload-channel registration.** At startup the supervisor registers
+  sleep/wake callbacks with the node-local snapshot agent
+  (`TIMESLICE_AGENT_ADDR`, the node IP :9001). The agent resolves each job's
+  snapshot backend per job (explicit config → live workload channel → pod
+  annotation → default cuda), so for this job it invokes the registered
+  callbacks — `POST /sleep` / `POST /wake_up` — instead of
+  cuda-checkpointing the engine process.
+- **Drain before yield — required, not a nicety** (see requirement 2 above).
+  Before releasing the lock the supervisor closes its readiness gate (the pod
+  leaves the Service endpoints, so new batch requests fail fast) and waits
+  until the engine's `running+waiting == 0` (~3 s) — only then `release()`.
+- **Reopen after wake.** After reacquiring the lock and waking the engine,
+  the supervisor reopens its readiness gate so the pod rejoins the Service.
+
+A handoff, end to end:
+
+1. The trainer's sample batch becomes ready → the timeslice trainer's hook
+   calls `acquire()` and queues.
+2. The supervisor's 0.5 s poll sees `waiter_queue_depth > 0` → it drains
+   (above) → calls `release()`.
+3. The orchestrator snapshots the batch job — through the registered
+   workload channel, so the agent triggers `POST /sleep`.
+4. The orchestrator restores the trainer (cuda-checkpoint) and grants the
+   lock. The trainer runs its burst (minutes), then yields; the platform
+   snapshots it and wakes the batch engine the same way in reverse; the
+   supervisor reopens its readiness gate after the wake.
+5. Batch requests sent while the engine is draining or asleep fail fast at
+   the Service (connection refused — the pod is NotReady). Production
+   clients should queue and retry — see §7.
+
+### Swapping In Your Engine or Model
+
+- **Bigger batch model**: anything that fits in the engine's GPU-memory
+  fraction (the example's `VLLM_GPU_FRAC`, default 0.7) of the shared GPU
+  alongside zero trainer residency (the two tenants never co-reside in HBM).
+  Sleep/wake time scales with weight size (~1 s per 15 GB to host RAM) —
+  re-check host-RAM sizing (§1) when you grow it.
+- **Another engine**: keep the supervisor's loop and swap the three engine
+  touchpoints — the freeze/thaw calls, the drain check (queue depths), and
+  the health probe. Register the same way on the workload channel.
+- **Yield latency vs. poll cost**: `WAITER_POLL_SECONDS` (default 0.5) is
+  the worst-case extra wait the trainer sees before the supervisor notices
+  it.
+
+---
+
+## 5. Deploy the Tenants
+
+### The RL Job
+
+Deploy the RL job as a **2-node Ray cluster**:
+
+* **Head pod** — runs the verl driver + FSDP trainer. Schedule it on the
+  shared, group-labeled trainer node
+  (`nodeSelector: group.timeslice.io/trainers: "true"`), reference the
+  **shared** `ResourceClaim`, and carry the `timeslice.io/job-id` +
+  `timeslice.io/group` pod labels.
+* **Rollout pod** — runs the rollout engine as a ray worker. Request its
+  GPU the ordinary way (`resources.limits: nvidia.com/gpu: "1"` — the
+  device plugin, no claim), and keep it off the trainer node (whose GPU is
+  claim-managed) with a required node anti-affinity on
+  `group.timeslice.io/trainers` (`operator: DoesNotExist`): it can then
+  land on any GPU node except the trainer node, and since the device plugin
+  allocates whole GPUs exclusively, it always gets a GPU of its own. Leave
+  it unlabeled (no `timeslice.io/*` labels).
+* **Headless Service** — pointing at the head pod, so the rollout pod can
+  resolve the ray head address.
+* **Tolerations** — give both pods tolerations for the GPU-node taints they
+  must land on (the example tolerates `nvidia.com/gpu` and
+  `timeslice.io/shared=true:NoSchedule`).
+
+### The Batch Server Pod
+
+* Schedule it on the SAME group-labeled trainer node and reference the SAME
+  shared `ResourceClaim` as the RL head pod — the shared claim is what lets
+  the two tenants co-locate on the one GPU.
+* Give it its own `timeslice.io/job-id` label (unique — it is a full lock
+  participant) and the same `timeslice.io/group` label as the RL head pod.
+* Set `TIMESLICE_AGENT_ADDR` to the node-local snapshot agent (node IP,
+  port 9001 — downward-API `status.hostIP` works) so the supervisor can
+  register its workload channel, plus the same `TIMESLICE_ORCH_ADDR` /
+  `TIMESLICE_JOB_ID` / `TIMESLICE_GROUP` envs the supervisor reads.
+* Front it with a regular Service; the supervisor's readiness gate controls
+  endpoint membership during drains.
+
+### Launch Order
+
+Start the **batch server first**, so it owns the GPU (and serves traffic)
+throughout the RL job's long CPU-side setup; then the RL job (both pods at
+once — the rollout pod's installs run in parallel with the head's); then
+your batch client/load. A verl job typically spends 20–45 minutes on
+installs, ray join, and model + dataset download before it first requests
+the GPU — all of it CPU-side, all of it batch-serving time.
+
+Placement needs no rollout node labels: the trainer-node tenants land where
+their shared claim binds, and the rollout pod lands on any GPU node except
+the trainer node (required anti-affinity) with an ordinary device-plugin
+GPU (`nvidia.com/gpu: 1`). Neither path needs elevated pod permissions.
+
+---
+
+## 6. Submit and Observe
+
+Apply the batch tenant, the RL job, and your load in the order above
+(§5; the [example](examples/README.md) is the literal command sequence).
+
+Grab the agent pod on the trainer node — its log shows every
+snapshot/restore:
+
+```bash
+AGENT_POD=$(kubectl -n timeslice-system get pods -l app.kubernetes.io/name=snapshot-agent \
+  --field-selector spec.nodeName=<trainer-node> -o jsonpath='{.items[0].metadata.name}')
+echo "$AGENT_POD"
+```
+
+### Watch the Lock
+
+Port-forward the orchestrator gRPC service and watch the shared pool with
+the `rlts` CLI (built in §2):
+
+```bash
+kubectl port-forward svc/timeslice-timesliceorchestrator 50051:50051 -n timeslice-system
+watch -n 0.5 ./bin/rlts orchestrator status trainers
+```
+
+**Expected output:** the `Active Job` and `Locking Job` alternate between
+your RL job id and your batch job id. Most of the time the batch tenant
+holds the lock (it harvests idle time); when the trainer's batch is ready,
+the RL job id appears in the `Waiter Queue Depth` (depth = 1), the
+supervisor drains and yields within seconds, and the lock flips to the
+trainer for the training burst. The RL rollout never appears here — it takes
+no locks.
+
+### Watch the Logs
+
+```bash
+# lock handoffs: the integration package logs every acquire/release
+# ([timeslice] ... ACQUIRE/RELEASE lines, forwarded into the head pod's log):
+kubectl logs <rl-head-pod> --tail=2000 | grep -E "ACQUIRE|RELEASE" | tail -4
+# [timeslice] job=<rl job id> ACQUIRE group=trainers waited=8210ms context_restored=True
+# [timeslice] job=<rl job id> RELEASE group=trainers pending_waiters=1 snapshot_deferred=False
+
+# supervisor handoffs on the batch pod:
+kubectl logs <batch-pod> --tail=10
+# [supervisor] trainer is waiting - yielding GPU
+# [supervisor] drained in 2.82s
+# [supervisor] vLLM slept (HBM -> host RAM) in 0.97s
+# [supervisor] lock reacquired (waited 214380 ms, context_restored=True)
+# [supervisor] vLLM woke in 0.05s
+
+# snapshot/restore operations on the shared trainer GPU:
+kubectl -n timeslice-system logs "$AGENT_POD" --tail=100 | grep -i "cuda-checkpoint"
+```
+
+### What Healthy Looks Like
+
+Batch throughput **alternates by design**: full throughput in every
+trainer-idle window, then a few-minutes-long window of fast failures during
+each training burst (the pod is NotReady while drained/asleep — that is the
+priority contract working, not an outage; see §7 for the client posture).
+Healthy steady state: supervisor drain ≈ 3 s, sleep ≤ 3 s, wake ≤ 1 s;
+trainer `waited=` on ACQUIRE in the seconds range (poll latency + drain +
+engine sleep + the trainer's own cuda-checkpoint context restore — the
+trainer never queues behind batch work).
+
+Success criteria to check after ~3 training steps:
+
+- Trainer step time within ~10% of a solo run (run the RL job alone for the
+  baseline — with no contention the trainer acquires instantly and the
+  platform defers snapshots, so it behaves like an unshared run).
+- Batch throughput > 0 in every trainer-idle window.
+- No cuda-checkpoint operations targeting the rollout node in any agent log
+  (the rollout node must never show cuda-checkpoint activity).
+
+---
+
+## 7. Troubleshooting
+
+Failures specific to the example's manifests are in the
+[example's troubleshooting section](examples/README.md#7-troubleshooting).
+Generic to the recipe:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| Trainer placement group lands on the rollout node (or rollout work on the trainer node) | PG pinning not active — `--resources` missing on a `ray start` line, or the `ray_pg_extra_resources` hydra override is missing/typo'd, or the verl build lacks the feature | Verify both `ray start` lines carry `--resources`, keep the `ray_pg_extra_resources={trainer_pool: ...}` override intact, and use the pinned verl branch (§3); check `ray status` custom resources |
+| Rollout throughput collapses when the trainer runs; agent log shows cuda-checkpoint activity on the ROLLOUT node | The rollout pod carries `timeslice.io/*` labels, or the rollout node is labeled into the group | Rollout pods/nodes must stay unlabeled — only the head pod, the batch pod, and the trainer node (§1) |
+| The batch tenant never yields, or the trainer's restore fails with OOM on the shared GPU | The batch job's workload-channel registration didn't reach the agent, so the platform can't drive its sleep | Check the supervisor log for the registration and the agent log for the accepted channel; `TIMESLICE_AGENT_ADDR` must be the node-local agent (node IP :9001), not the orchestrator |
+| Batch engine crashes with a CUDA error seconds after a sleep | It was frozen with requests in flight — the engine does not drain itself (vLLM: vllm#28714, vllm#15483) | Your supervisor must drain (stop admitting + in-flight = 0) BEFORE `release()`; never call the engine's freeze endpoint directly while it serves |
+| Hydra error `Key 'use_trainer_do_validate' is not in struct trainer` | Wrong config key path | These flags live under `async_training.*`, not `trainer.*` |
+| `save_freq` / checkpoint-save-skipped warning in the trainer log | Checkpoint saving would RPC a possibly-frozen worker | By design: the timeslice trainer vetoes saves when `save_freq > 0`; keep `trainer.save_freq=-1` |
+| RL staleness queue near `staleness_threshold × batch` | Long trainer lock-out or very slow steps | Raise `async_training.staleness_threshold` or shorten training bursts; queue overflow drops samples |
+| `Found multiple active Ray instances` warning on the shared node | Ray's `address='auto'` discovery found more than one GCS on the node | `export RAY_ADDRESS="$(hostname -i):6379"` right after `ray start --head` |
+
+**The fail-fast client caveat**, worth stating to any consumer of the batch
+Service: while the engine is draining or asleep, new batch requests fail
+fast at the Service (the pod is NotReady). A demo client can simply count
+those errors and retry later; a production batch front-end should be
+queue-based with retries — e.g.
+[llm-d async processor](https://github.com/llm-d/llm-d-async) as the batch
+dispatcher — so that trainer bursts show up as latency, not failures.
+
+---
+
+For a complete pinned runnable of everything above — concrete models,
+manifests, load generator, and the exact command sequence — see
+**[examples/README.md](examples/README.md)**.

--- a/guides/rl-batch-interleaving/examples/README.md
+++ b/guides/rl-batch-interleaving/examples/README.md
@@ -1,0 +1,223 @@
+# Time-Sliced verl RL Trainer + vLLM Batch Inference Example
+
+Runnable demo of the [RL + batch interleaving guide](../README.md): one verl
+fully-async code-RLVR job (GRPO on `deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B`,
+Eurus-2 code split) and a stock `vllm serve` of `Qwen/Qwen2.5-0.5B-Instruct`
+share one H100 — the trainer has absolute priority, vLLM harvests its idle
+valleys. Both models are ungated (no HuggingFace token).
+
+**Reference-run behavior** (2× GKE `a3-highgpu-1g`, H100):
+
+| Metric | Value |
+|---|---|
+| Trainer ACQUIRE wait at each handoff | 5–11 s |
+| Trainer step time vs. solo run | within ~10% (reference median 570 s/step) |
+| vLLM yield (drain + sleep) / wake | ~3 s + ~1–2 s / ≤ 1 s |
+| Batch throughput | full throughput in every trainer-idle window |
+
+---
+
+## 1. Architecture
+
+```
+  ROLLOUT NODE (dedicated)             TRAINER NODE (SHARED, time-sliced)
+  ┌──────────────────────────┐         ┌──────────────────────────────────┐
+  │ RL rollout pod           │  ray    │ RL head pod      batch server pod│
+  │ rollout engine (vLLM,    │◀───────▶│ FSDP trainer ⇄   inference engine│
+  │ generates continuously)  │         │ cuda-checkpoint  + supervisor    │
+  └──────────────────────────┘         │      C/R         sleep/wake      │
+                                       └──────────────────────────────────┘
+  lock owner over time on the trainer node's GPU:
+  batch ███████░T██████████░T█████████░T████████   (T = training burst)
+               ▲ trainer queues → batch yields in ≤ poll(0.5s) + drain(~3s) + sleep(~1-2s)
+```
+
+The RL job is a 2-node Ray cluster: the head pod (verl driver + FSDP trainer)
+shares the trainer node's GPU with the batch server pod, while the rollout pod
+keeps its own dedicated node and never stops generating. At each handoff the
+trainer is checkpointed with **`cuda-checkpoint`** (its entire GPU state dumps
+to host RAM), while vLLM yields through the snapshot agent's workload channel:
+a supervisor drains the engine, puts it to sleep (weights + KV cache to host
+RAM, no process restart), and wakes it when the trainer releases. How the
+supervisor works is covered in
+[root guide §4](../README.md#4-the-batch-tenant-and-the-supervisor).
+
+## 2. Prerequisites
+
+The time-slicing platform must already be deployed and healthy, with the
+cluster requirements, node-labeling concept, shared DRA claim, and host-RAM
+sizing rule from [root guide §1](../README.md#1-cluster-prerequisites) and the
+platform install + verify steps from
+[root guide §2](../README.md#2-deploy-the-time-slicing-platform). Specific to
+this demo:
+
+- **Two otherwise-idle 1-GPU nodes** (reference shape GKE `a3-highgpu-1g`,
+  26 vCPU / 234 Gi, H100): a **trainer node** (shared: RL head pod + vLLM pod)
+  and a **rollout node** (dedicated to the RL rollout engine).
+- **Host RAM on the trainer node** must fit both tenants' offloads (see the
+  [host-RAM sizing rule](../README.md#host-ram-sizing-rule)): the RL head pod
+  requests 8 CPU + 80 Gi (110 Gi limit — the cuda-checkpoint dump lands in pod
+  memory) alongside the vLLM pod's 6 CPU + 60 Gi sleep offload.
+
+**Version pins** (change nothing on the first run) — all pins live in the
+manifests:
+
+| Component | Pin |
+|---|---|
+| RL job image | `verlai/verl:vllm020.dev2` |
+| Batch image | `vllm/vllm-openai:v0.9.2` |
+| verl | fork branch, via the `VERL_REPO`/`VERL_REF` pod envs |
+
+Files in this guide directory:
+
+| File | What it is |
+|---|---|
+| `resource-claims.yaml` | The single DRA claim: `shared-trainers-gpu-claim` (rl-head + shadow-vllm; rl-rollout uses an ordinary `nvidia.com/gpu` request instead) |
+| `rl-job.yaml` | The RL job: ConfigMap + head pod + rollout pod + headless Service |
+| `shadow-vllm.yaml` | EXAMPLE-ONLY: stock `vllm serve` + the supervisor |
+| `load-generator.yaml` | EXAMPLE-ONLY: continuous `/v1/completions` client + throughput log |
+
+## 3. Step 1 — Apply the resource claim and label the trainer node
+
+Apply the shared GPU claim (the recipe's only `ResourceClaim` — rl-rollout
+requests its GPU via the ordinary device plugin instead), then set up the
+trainer node. The trainer node carries all the time-slicing markers — the
+group label (group discovery), the `timeslice.io/enabled` label (the
+platform-wide marker for time-slicing nodes, which the root guide §2
+install targets snapshot-agent and DRA kubelet-plugin placement at) and
+the isolation taint (keeps unrelated workloads off the shared GPU; the
+pods in this guide already carry the matching toleration) — while the
+rollout node carries nothing timeslice-related:
+
+```bash
+kubectl apply -f resource-claims.yaml
+kubectl label node <trainer-node> group.timeslice.io/trainers=true --overwrite
+kubectl label node <trainer-node> timeslice.io/enabled=true --overwrite
+kubectl taint node <trainer-node> timeslice.io/shared=true:NoSchedule --overwrite
+```
+
+After labeling, the snapshot-agent and DRA kubelet-plugin pods (installed
+per the root guide §2) appear on the trainer node — and only there:
+
+```bash
+kubectl -n timeslice-system get pods -o wide
+```
+
+The rollout node needs no setup: rl-head and shadow-vllm co-locate where
+their shared claim binds, and rl-rollout lands on any GPU node except the
+trainer node (required anti-affinity; the guide's
+[labeling section](../README.md#node-labeling-and-time-slice-groups) spells
+out the placement guarantees).
+
+## 4. Step 2 — Launch the tenants
+
+Order matters. Launch the batch tenant FIRST — it owns the GPU during the RL
+job's long CPU-side setup — and wait for the supervisor to report the engine
+up:
+
+```bash
+kubectl apply -f shadow-vllm.yaml
+kubectl logs shadow-vllm --tail=20    # wait for "[supervisor] vLLM is up" (first model download ~2-4 min)
+```
+
+Then launch the RL job and the load (training budget: edit the `RUN_SECONDS`
+env in `rl-job.yaml`, default 5400 s):
+
+```bash
+kubectl apply -f rl-job.yaml
+kubectl apply -f load-generator.yaml
+```
+
+The RL job spends **20–45 minutes** on setup (verl install on both pods, ray
+join, model + dataset download) before it first requests the GPU; vLLM serves
+batch traffic the whole time. Slow ≠ stuck — the phases are logged in
+`kubectl logs rl-head`.
+
+## 5. Step 3 — Watch it work
+
+```bash
+# Batch throughput alternates with trainer bursts:
+kubectl logs batch-load-generator --tail=6
+# [12:01:05] last 5s: completed=41 errors_or_asleep=0     <- vLLM holds GPU
+# [12:04:35] last 5s: completed=0  errors_or_asleep=12    <- trainer burst
+# [12:08:10] last 5s: completed=38 errors_or_asleep=1     <- vLLM back
+
+# Supervisor handoffs (drain -> sleep -> reacquire -> wake):
+kubectl logs shadow-vllm --tail=10
+# [supervisor] trainer is waiting - yielding GPU
+# [supervisor] drained in 2.82s
+# [supervisor] vLLM slept (HBM -> host RAM) in 0.97s
+# [supervisor] lock reacquired (waited 214380 ms, context_restored=True)
+# [supervisor] vLLM woke in 0.05s
+
+# Trainer-side lock handoffs:
+kubectl logs rl-head --tail=2000 | grep -E "ACQUIRE|RELEASE" | tail -4
+```
+
+Or watch the orchestrator's group state directly (`rlts` built per the
+[root guide §2](../README.md#2-deploy-the-time-slicing-platform)):
+
+```bash
+kubectl port-forward svc/timeslice-timesliceorchestrator 50051:50051 -n timeslice-system
+watch -n 0.5 ./bin/rlts orchestrator status trainers
+```
+
+`Active Job` / `Locking Job` alternate between `rl-trainer` and `shadow-vllm`;
+`rl-trainer` appears briefly at `Waiter Queue Depth` = 1 at each handoff. The
+run ends when `RUN_SECONDS` expires — the log line `Training stopped by
+planned ... timeout (expected end state)` is success, and the head pod stays
+alive 2 h for collection.
+
+## 6. Step 4 — Collect results
+
+```bash
+mkdir -p results
+kubectl cp rl-head:/workspace/results/train.log results/train.log || true
+kubectl logs batch-load-generator --timestamps > results/batch_throughput.log
+kubectl logs shadow-vllm --timestamps > results/supervisor.log
+```
+
+## 7. Troubleshooting
+
+Generic failures (placement, labels, hydra keys, drain rationale, client
+retry posture) are in the [root guide §7](../README.md#7-troubleshooting).
+Demo-specific:
+
+| Symptom | Cause | Fix |
+|---|---|---|
+| vLLM never sleeps at handoff; trainer restore then fails with OOM on the shared GPU | Workload registration didn't reach the agent (check supervisor log for `workload registered`) | Verify `TIMESLICE_AGENT_ADDR` resolves to the node IP :9001 and agent logs show the registration; the supervisor's local wake fallback covers restores but sleep MUST go through the channel |
+| `POST /sleep` returns 404 | vLLM started without dev endpoints | `VLLM_SERVER_DEV_MODE=1` and `--enable-sleep-mode` are both required (set in the manifest) |
+| vLLM dies seconds after a sleep (`CUDA error: an illegal memory access` in EngineCore), then the group faults on the failed wake | `/sleep` was called with requests in flight — vLLM does not drain the scheduler on sleep (vllm#28714, also affects ≥0.10.x; requests sent to a sleeping engine crash it too, vllm#15483) | Keep the supervisor's readiness-gate drain (in the manifest): gate closed + `running+waiting==0` BEFORE `release()`. Never call `/sleep` on a serving engine directly |
+| `rl-head` log stuck at `Phase 2b: wait for the rollout pod to join`, then `FATAL: rollout pod did not join` | rl-rollout Pending/crashed, or headless Service `rl-head` missing | `kubectl get pod rl-rollout; kubectl logs rl-rollout --tail=50`; apply the whole rendered `rl-job.yaml` |
+| Load generator: 100% errors even when trainer is idle | vLLM crashed (supervisor exits, pod restarts) or Service selector mismatch | `kubectl logs shadow-vllm --previous`; check `kubectl get endpoints shadow-vllm` |
+| RL head or shadow vLLM pod Pending | Trainer node CPU/RAM too small for 8 CPU + 80 Gi (head) alongside 6 CPU + 60 Gi (vLLM) | Use an a3-highgpu-1g-class node (26 vCPU / 234 Gi), or shrink requests |
+
+## 8. Adapting to your workload
+
+The model/engine/poll knobs are in the root guide's
+[Swapping In Your Engine or Model](../README.md#swapping-in-your-engine-or-model)
+section: a bigger batch model must fit the engine's GPU-memory fraction
+(`VLLM_GPU_FRAC`, default 0.7) of the shared GPU, and sleep/wake time scales
+with weight size (~1 s per 15 GB to host RAM); another engine keeps the
+supervisor's loop and swaps the freeze/thaw calls, the drain check, and the
+health probe; `WAITER_POLL_SECONDS` (default 0.5) is the worst-case extra
+wait the trainer sees before the supervisor notices it.
+
+For the solo baseline (the reference table's step-time comparison), run the
+RL job alone: with no contention the trainer acquires instantly and the
+platform defers snapshots, so it behaves like an unshared run.
+
+## 9. Teardown
+
+```bash
+kubectl delete pod shadow-vllm batch-load-generator --ignore-not-found
+kubectl delete pod rl-head rl-rollout --ignore-not-found
+kubectl delete service shadow-vllm rl-head --ignore-not-found
+kubectl delete configmap shadow-vllm-scripts rlbatch-trainer --ignore-not-found
+kubectl delete -f resource-claims.yaml --ignore-not-found
+kubectl label node <trainer-node> group.timeslice.io/trainers- || true
+kubectl label node <trainer-node> timeslice.io/enabled- || true
+kubectl taint node <trainer-node> timeslice.io/shared- || true
+```
+
+(Platform teardown, if wanted: `helm uninstall timeslice -n timeslice-system`.)

--- a/guides/rl-batch-interleaving/examples/load-generator.yaml
+++ b/guides/rl-batch-interleaving/examples/load-generator.yaml
@@ -1,0 +1,52 @@
+# Continuous batch-inference client: hammers the shadow vLLM Service and
+# reports throughput every 5 s. Errors while the trainer holds the GPU are
+# EXPECTED (the server is asleep) — production clients should queue/retry;
+# this demo client just counts them.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: batch-load-generator
+  namespace: default
+  labels:
+    app: batch-load-generator
+spec:
+  restartPolicy: Always
+  containers:
+  - name: loadgen
+    image: python:3.11-slim
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      pip install --quiet requests
+      python3 - <<'PY'
+      import datetime, time, requests
+
+      URL = "http://shadow-vllm.default.svc.cluster.local:8000/v1/completions"
+      PROMPT = "Explain, in three sentences, why sharing a GPU between RL training and batch inference raises utilization."
+      MODEL = "Qwen/Qwen2.5-0.5B-Instruct"
+
+      completed = errors = 0
+      window = time.time()
+      print("batch load generator started", flush=True)
+      while True:
+          try:
+              r = requests.post(URL, json={"model": MODEL, "prompt": PROMPT,
+                                           "max_tokens": 48}, timeout=10)
+              if r.status_code == 200:
+                  completed += 1
+              else:
+                  errors += 1
+          except Exception:
+              errors += 1
+              time.sleep(0.5)
+          if time.time() - window >= 5.0:
+              ts = datetime.datetime.now().strftime("%H:%M:%S")
+              print(f"[{ts}] last 5s: completed={completed} errors_or_asleep={errors}",
+                    flush=True)
+              completed = errors = 0
+              window = time.time()
+      PY
+    resources:
+      requests:
+        cpu: "1"
+        memory: 1Gi

--- a/guides/rl-batch-interleaving/examples/resource-claims.yaml
+++ b/guides/rl-batch-interleaving/examples/resource-claims.yaml
@@ -1,0 +1,23 @@
+# The single DRA ResourceClaim for the RL + batch-inference interleaving
+# demo. Apply BEFORE launching the workloads:
+#   kubectl apply -f resource-claims.yaml
+#
+# rl-head and shadow-vllm reference the SAME shared-trainers-gpu-claim — that
+# is what lets the two tenants co-locate on the one shared GPU without
+# scheduler blocking (each holds the full, unpartitioned GPU during its
+# turn). This is the ONLY ResourceClaim in the recipe: sharing is what only
+# DRA can express. The RL rollout pod requests its GPU the ordinary way
+# (nvidia.com/gpu: 1 via the device plugin) — see rl-job.yaml.
+apiVersion: resource.k8s.io/v1
+kind: ResourceClaim
+metadata:
+  name: shared-trainers-gpu-claim
+  namespace: default
+spec:
+  devices:
+    requests:
+    - name: gpu
+      exactly:
+        deviceClassName: gpu.nvidia.com
+        allocationMode: ExactCount
+        count: 1

--- a/guides/rl-batch-interleaving/examples/rl-job.yaml
+++ b/guides/rl-batch-interleaving/examples/rl-job.yaml
@@ -1,0 +1,752 @@
+# RL trainer for the RL + batch-inference interleaving guide — disaggregated
+# 1-GPU-per-node shape. Code RLVR: Eurus-2 code split with prime_code reward
+# (live in-pod test execution), verl fully_async_policy, GRPO,
+# R1-Distill-Qwen-1.5B.
+# Training budget: edit the RUN_SECONDS env below (default 5400 s ~= 90 min).
+#
+# Topology: the RL job is a 2-node Ray cluster. Placement needs no rollout
+# node labels:
+#   rl-head    on the SHARED 1-GPU node (label group.timeslice.io/trainers=true;
+#              hosts rl-head AND the shadow vLLM pod): ray head, FSDP trainer
+#              (time-sliced with shadow vLLM)
+#   rl-rollout on any GPU node except the trainer node (required anti-affinity
+#              on group.timeslice.io/trainers); its GPU is an ordinary
+#              device-plugin request (nvidia.com/gpu: 1) — the device plugin
+#              allocates whole GPUs exclusively: ray worker, vLLM rollout
+#              engine (always on)
+# Placement is pinned by Ray CUSTOM RESOURCES, not GPU masks: the head starts
+# ray with --resources='{"trainer_node": 100}', the worker with
+# --resources='{"rollout_node": 100}', and verl's per-pool placement-group
+# bundle resources (hydra override ray_pg_extra_resources={trainer_pool:
+# {trainer_node: 1}, rollout_pool: {rollout_node: 1}}) make verl's trainer
+# placement group request {trainer_node: 1} and the rollout PG
+# {rollout_node: 1}.
+#
+# GPU access: the shared GPU is the recipe's ONLY DRA ResourceClaim (see
+# resource-claims.yaml) — rl-head and shadow-vllm reference the SAME
+# shared-trainers-gpu-claim, which is what lets both tenants co-locate on
+# the one shared GPU without scheduler blocking (each holds the full,
+# unpartitioned GPU during its turn); the NVIDIA DRA driver injects the GPU
+# + driver userspace into the container. The rollout pod requests its GPU
+# the ordinary way (nvidia.com/gpu: 1 via the device plugin). Neither path
+# needs elevated pod permissions. Each node has exactly ONE GPU, so there
+# is nothing to mask — every process sees cuda:0.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: rlbatch-trainer
+  namespace: default
+data:
+  data_prep.py: |
+    #!/usr/bin/env python3
+    """Prepare the Eurus-2-RL-Data CODE subset for the async code-RLVR experiment.
+
+    Source: HF dataset PRIME-RL/Eurus-2-RL-Data (train.parquet), ALREADY in verl
+    RLHFDataset format:
+      - data_source in {codecontests, apps, codeforces, taco} -> default reward routing
+        hits verl.utils.reward_score.prime_code.compute_score (local in-pod test-case
+        execution; extracts the LAST ```python fenced block)
+      - prompt = [{system (Eurus action protocol)}, {user: problem + "Write Python code
+        ... ```python ... ``` at the end"}]
+      - reward_model = {"style": "rule", "ground_truth": '{"inputs": [...], "outputs": [...]}'}
+
+    Transformations (documented in NOTES.md):
+      1. keep only ability == "code" rows with a data_source that routes to prime_code
+      2. DROP the Eurus system message (R1-Distill guidance: no system prompt; the
+         reward-relevant ```python instruction lives in the user message, kept verbatim)
+      3. truncate test suites to first 8 in/out pairs (bounds worst-case reward latency),
+         preserving fn_name; drop rows with unusable/oversized ground truth
+      4. filter to prompts <= --max_prompt_tokens under the actual chat template
+      5. subsample 512 train / 64 val, disjoint, dedup'd on user text
+    """
+
+    import argparse
+    import json
+    import os
+
+    import pandas as pd
+    from huggingface_hub import hf_hub_download
+
+    CODE_SOURCES = {"codecontests", "apps", "codeforces", "taco"}
+
+
+    def truncate_ground_truth(gt_str, max_tests, max_bytes):
+        """Return truncated JSON ground truth, or None if the row is unusable."""
+        try:
+            gt = json.loads(gt_str)
+        except Exception:
+            return None
+        if not isinstance(gt, dict):
+            return None
+        ins, outs = gt.get("inputs"), gt.get("outputs")
+        if not isinstance(ins, list) or not isinstance(outs, list):
+            return None
+        n = min(len(ins), len(outs), max_tests)
+        if n < 1:
+            return None
+        new_gt = {"inputs": ins[:n], "outputs": outs[:n]}
+        if gt.get("fn_name"):
+            new_gt["fn_name"] = gt["fn_name"]
+        try:
+            s = json.dumps(new_gt)
+        except Exception:
+            return None
+        if len(s) > max_bytes:
+            return None
+        return s
+
+
+    def main():
+        ap = argparse.ArgumentParser()
+        ap.add_argument("--repo_id", default="PRIME-RL/Eurus-2-RL-Data")
+        ap.add_argument("--filename", default="train.parquet")
+        ap.add_argument("--tokenizer", required=True)
+        ap.add_argument("--out_dir", default="/workspace/data/eurus_code")
+        ap.add_argument("--train_size", type=int, default=512)
+        ap.add_argument("--val_size", type=int, default=64)
+        ap.add_argument("--max_tests", type=int, default=8)
+        ap.add_argument("--max_gt_bytes", type=int, default=200000)
+        ap.add_argument("--max_prompt_tokens", type=int, default=1900)
+        ap.add_argument("--candidates", type=int, default=3000)
+        ap.add_argument("--seed", type=int, default=17)
+        args = ap.parse_args()
+
+        local = hf_hub_download(repo_id=args.repo_id, filename=args.filename, repo_type="dataset")
+        df = pd.read_parquet(local)
+        print(f"loaded {len(df)} rows, columns: {list(df.columns)}")
+
+        df = df[df["ability"] == "code"].reset_index(drop=True)
+        print(f"{len(df)} code rows; data_source counts:\n{df['data_source'].value_counts()}")
+        df = df[df["data_source"].isin(CODE_SOURCES)].reset_index(drop=True)
+        print(f"{len(df)} rows with prime_code-routable data_source")
+
+        # ---- rebuild rows: user-only prompt + truncated ground truth ----
+        rows = []
+        n_bad_gt, n_bad_prompt = 0, 0
+        for _, r in df.iterrows():
+            msgs = [dict(m) for m in r["prompt"]]
+            user = [m for m in msgs if m.get("role") == "user"]
+            if len(user) != 1 or "```python" not in user[0].get("content", ""):
+                n_bad_prompt += 1
+                continue
+            gt = truncate_ground_truth(dict(r["reward_model"])["ground_truth"], args.max_tests, args.max_gt_bytes)
+            if gt is None:
+                n_bad_gt += 1
+                continue
+            rows.append(
+                {
+                    "data_source": r["data_source"],
+                    "prompt": [{"role": "user", "content": user[0]["content"]}],
+                    "ability": "code",
+                    "reward_model": {"style": "rule", "ground_truth": gt},
+                    "extra_info": dict(r["extra_info"]) if r["extra_info"] is not None else {},
+                    "_ptext": user[0]["content"],
+                }
+            )
+        print(f"kept {len(rows)} rows (dropped {n_bad_prompt} bad-prompt, {n_bad_gt} bad-ground-truth)")
+
+        out = pd.DataFrame(rows).drop_duplicates("_ptext").reset_index(drop=True)
+        print(f"{len(out)} unique problems after dedup")
+
+        # cheap char prefilter, then exact token filter on a sampled candidate pool
+        out = out[out["_ptext"].str.len() <= 7000].reset_index(drop=True)
+        print(f"{len(out)} rows after 7000-char prefilter")
+        cand = out.sample(n=min(args.candidates, len(out)), random_state=args.seed).reset_index(drop=True)
+
+        from transformers import AutoTokenizer
+
+        tok = AutoTokenizer.from_pretrained(args.tokenizer)
+        keep_idx, tok_lens = [], []
+        for i, r in cand.iterrows():
+            ntok = len(tok.apply_chat_template(list(r["prompt"]), add_generation_prompt=True))
+            if ntok <= args.max_prompt_tokens:
+                keep_idx.append(i)
+                tok_lens.append(ntok)
+        cand = cand.loc[keep_idx].reset_index(drop=True)
+        print(
+            f"{len(cand)} candidates <= {args.max_prompt_tokens} prompt tokens "
+            f"(mean {sum(tok_lens) / max(len(tok_lens), 1):.0f})"
+        )
+
+        n = args.train_size + args.val_size
+        assert len(cand) >= n, f"only {len(cand)} candidates for {n} needed"
+        sub = cand.sample(n=n, random_state=args.seed + 1).reset_index(drop=True)
+        train = sub.iloc[: args.train_size].drop(columns="_ptext")
+        val = sub.iloc[args.train_size : n].drop(columns="_ptext")
+
+        # ---- final schema sanity checks (fail fast, before burning GPU time) ----
+        row = train.iloc[0]
+        assert row["data_source"] in CODE_SOURCES
+        p0 = dict(row["prompt"][0])
+        assert p0["role"] == "user" and "```python" in p0["content"]
+        gt = json.loads(dict(row["reward_model"])["ground_truth"])
+        assert len(gt["inputs"]) >= 1 and len(gt["inputs"]) == len(gt["outputs"])
+        ntests = [len(json.loads(dict(rm)["ground_truth"])["inputs"]) for rm in train["reward_model"]]
+        n_fn = sum(1 for rm in train["reward_model"] if "fn_name" in json.loads(dict(rm)["ground_truth"]))
+        print(f"tests/problem: mean {sum(ntests) / len(ntests):.1f} max {max(ntests)}; call-based (fn_name): {n_fn}")
+        print("sample prompt (first 400 chars):")
+        print(p0["content"][:400])
+        print("sample prompt (last 200 chars):")
+        print(p0["content"][-200:])
+        print("sample ground_truth (first 200 chars):", dict(row["reward_model"])["ground_truth"][:200])
+
+        os.makedirs(args.out_dir, exist_ok=True)
+        train.to_parquet(os.path.join(args.out_dir, "train.parquet"), index=False)
+        val.to_parquet(os.path.join(args.out_dir, "val.parquet"), index=False)
+        print(f"wrote {len(train)} train / {len(val)} val -> {args.out_dir}")
+
+
+    if __name__ == "__main__":
+        main()
+
+  install_common.sh: |
+    #!/usr/bin/env bash
+    # Phase 1 installs, identical on head and rollout pods (sourced). The
+    # prime_code reward deps + smoke test run on BOTH pods: reward scoring
+    # executes wherever Ray places the reward workers.
+    # verl with fully-async lifecycle hooks + trainer registry and per-pool
+    # PG bundle resources, installed directly from the fork branch
+    # (override via VERL_REPO/VERL_REF pod env).
+    VERL_REPO="${VERL_REPO:-https://github.com/aishukamal/verl.git}"
+    VERL_REF="${VERL_REF:-feat/fully-async-lifecycle-hooks}"
+
+    echo "=== Phase 1: install verl @ $VERL_REPO $VERL_REF ==="
+    pip install datasets TransferQueue 2>&1 | tail -5
+    git clone --filter=blob:none "$VERL_REPO" /workspace/verl-src
+    cd /workspace/verl-src
+    # A branch from a fresh clone exists only as a remote ref, and git's
+    # create-tracking-branch DWIM conflicts with --detach; try the remote
+    # ref first, then fall back for SHA/tag refs.
+    git checkout --detach "origin/$VERL_REF" 2>/dev/null || git checkout --detach "$VERL_REF"
+    git rev-parse HEAD | tee "$RESULTS_DIR/verl_commit"
+    pip install -e ".[gpu]" 2>&1 | tail -10
+    cd /workspace
+    pip install cupy-cuda12x 2>&1 | tail -3
+    python3 -c "import verl; print('verl version:', verl.__version__)"
+    python3 -c "import transfer_queue; print('transfer_queue OK')"
+
+    echo "=== Phase 1b: install timeslice lock client + verl plugin wrapper ==="
+    pip install "git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/client/python" 2>&1 | tail -3
+    # The client's generated stubs need grpcio>=1.81 and protobuf gencode
+    # 7.35; the image ships grpcio 1.80.0 / protobuf 6.33.6. Upgrade both
+    # before the import check below.
+    pip install "grpcio>=1.81.0" "protobuf>=7.35.0" 2>&1 | tail -2
+    # Install the llm-d-timeslice-verl integration package (lock protocol via
+    # verl's fully-async lifecycle hooks). It ships TimesliceFullyAsyncTrainer,
+    # a FullyAsyncTrainer subclass registered under the trainer name
+    # "timeslice" (selected by the async_training.trainer_name=timeslice hydra
+    # override in run_head.sh); installing it registers a `verl.plugins` entry
+    # point, so `import verl` loads the registering module in every process.
+    # The hooks are inert unless TIMESLICE_FULLY_ASYNC=1 is set.
+    # Placement-group pinning comes from
+    # verl's own ray_pg_extra_resources config (see the hydra overrides in
+    # run_head.sh).
+    # --no-deps: the timeslice client is already installed above and the
+    # package declares no other dependencies.
+    pip install --no-cache-dir --no-deps "llm-d-timeslice-verl @ git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/integrations/verl" 2>&1 | tail -3
+    python3 <<'CHK'
+    import importlib.metadata as md
+    eps = list(md.entry_points(group="verl.plugins"))
+    assert any(ep.name == "timeslice" for ep in eps), f"verl.plugins entry point missing: {eps}"
+    import verl  # noqa: F401 - loads verl.plugins entries -> registers the timeslice trainer
+    from verl.experimental.fully_async_policy.fully_async_trainer import get_trainer_cls
+    from timeslice_verl.trainer import TimesliceFullyAsyncTrainer
+    assert get_trainer_cls("timeslice") is TimesliceFullyAsyncTrainer, "timeslice trainer not registered"
+    try:
+        from timeslice import OrchestratorClient  # noqa: F401
+    except ImportError:  # newer client versions export TimeSliceOrchestratorClient instead (same API)
+        from timeslice import TimeSliceOrchestratorClient as OrchestratorClient
+    print("timeslice trainer install OK; registered as:", get_trainer_cls("timeslice").__name__)
+    CHK
+
+    echo "=== Phase 1c: pyext (prime_code dependency; shim if pip install broken) ==="
+    pip install pyext 2>&1 | tail -2 || true
+    python3 << 'PYEXTFIX'
+    try:
+        from pyext import RuntimeModule  # noqa: F401
+        print("pyext OK (pip)")
+    except Exception:
+        import os
+        import sysconfig
+
+        SHIM = '''"""Minimal pyext shim: only RuntimeModule.from_string, as used by
+    verl.utils.reward_score.prime_code.testing_util (pyext 0.7 does not install on
+    Python >= 3.11). Semantically identical: build a module object from source."""
+    import types
+
+
+    class RuntimeModule:
+        @staticmethod
+        def from_string(name, docstring, code):
+            mod = types.ModuleType(name, docstring)
+            exec(compile(code, name, "exec"), mod.__dict__)
+            return mod
+    '''
+        sp = sysconfig.get_paths()["purelib"]
+        with open(os.path.join(sp, "pyext.py"), "w") as f:
+            f.write(SHIM)
+        from pyext import RuntimeModule  # noqa: F401
+
+        print(f"pyext shim installed at {sp}/pyext.py")
+    PYEXTFIX
+
+    echo "=== Phase 1d: reward smoke test (prime_code local execution, pre-GPU fail-fast) ==="
+    python3 << 'REWARDCHECK'
+    import json
+    import time
+
+    from verl.utils.reward_score import default_compute_score
+
+    gt = json.dumps({"inputs": ["1 2\n", "5 7\n"], "outputs": ["3\n", "12\n"]})
+
+    good = "<think>ok</think>\nFinal solution:\n```python\na, b = map(int, input().split())\nprint(a + b)\n```"
+    s = default_compute_score("taco", good, gt)
+    print("good ->", s)
+    assert s == 1.0, s
+
+    partial = "```python\na, b = map(int, input().split())\nprint(a + b if a == 1 else 0)\n```"
+    s = default_compute_score("taco", partial, gt)
+    print("partial ->", s)
+    assert abs(s - 0.5) < 1e-6, s
+
+    bad = "no code block at all, model rambled"
+    s = default_compute_score("taco", bad, gt)
+    print("no-block ->", s)
+    assert s == 0.0, s
+
+    t0 = time.time()
+    loop = "```python\nwhile True:\n    pass\n```"
+    s = default_compute_score("taco", loop, gt)
+    dt = time.time() - t0
+    print(f"infinite-loop -> {s} in {dt:.1f}s")
+    assert s == 0.0 and dt < 130, (s, dt)
+
+    # call-based: each input is newline-joined JSON-encoded args; output is a JSON string
+    fngt = json.dumps({"inputs": ["[3, 1, 2]", "[5]"], "outputs": ["6", "5"], "fn_name": "total"})
+    fngood = "```python\nclass Solution:\n    def total(self, xs):\n        return sum(xs)\n```"
+    s = default_compute_score("taco", fngood, fngt)
+    print("fn_name ->", s)
+    assert s == 1.0, s
+    print("Reward smoke test OK: pass/partial/fail/timeout/call-based all behave")
+    REWARDCHECK
+
+  run_head.sh: |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+
+    # On ANY exit, kill background children so the stdout pipe to tee is
+    # released and the container surfaces the real exit status.
+    trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+
+    RESULTS_DIR="/workspace/results"
+    MODEL_ID="deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"   # HF id; cached per node under HF_HOME
+    TRAIN_FILE="/workspace/data/eurus_code/train.parquet"
+    VAL_FILE="/workspace/data/eurus_code/val.parquet"
+    # RUN_SECS mirrors the pod env RUN_SECONDS, with a script-side default.
+    RUN_SECS="${RUN_SECONDS:-5400}"
+    RAY_WAIT_BUDGET_S=2400     # 40 min: the rollout pod's installs take ~20 min
+
+    mkdir -p "$RESULTS_DIR"
+
+    echo "=== Phase 0: verify GPU visibility (DRA-injected) ==="
+    # The NVIDIA DRA driver injects the GPU + driver userspace via the pod's
+    # ResourceClaim — no PATH/LD_LIBRARY_PATH setup or elevated permissions needed.
+    # 1-GPU-per-node topology: exactly ONE GPU must be visible. No masks, no
+    # CUDA_VISIBLE_DEVICES — the node's only GPU is cuda:0 for every process.
+    NVIS=$(nvidia-smi -L | wc -l)
+    nvidia-smi -L
+    if [ "$NVIS" != 1 ]; then
+        echo "FATAL: expected exactly 1 visible GPU on the trainer node, got $NVIS"; exit 96
+    fi
+
+    source /workspace/scripts/install_common.sh
+
+    echo "=== Phase 2: start ray head (trainer_node custom resource pins the trainer PG here) ==="
+    # NOTE: --resources takes JSON with DOUBLE quotes; keep the single-quote wrapper.
+    ray start --head --port=6379 --num-gpus=1 --resources='{"trainer_node": 100}'
+    # The trainer node is shared: never rely on ray.init(address='auto')
+    # discovery — pin every in-pod ray.init to OUR head explicitly.
+    export RAY_ADDRESS="$(hostname -i):6379"
+
+    echo "=== Phase 2b: wait for the rollout pod to join (budget ${RAY_WAIT_BUDGET_S}s) ==="
+    DEADLINE=$(( $(date +%s) + RAY_WAIT_BUDGET_S ))
+    until timeout 60 python3 -c "
+    import sys
+    import ray
+    ray.init(address='auto', log_to_driver=False)
+    gpus = sum(n['Resources'].get('GPU', 0) for n in ray.nodes() if n['Alive'])
+    print('ray cluster GPUs visible:', gpus, flush=True)
+    sys.exit(0 if gpus >= 2 else 1)
+    "; do
+        if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+            echo "FATAL: rollout pod did not join the ray cluster within ${RAY_WAIT_BUDGET_S}s"
+            ray status || true
+            exit 95
+        fi
+        echo "still waiting for the rollout pod to join (its installs take ~20 min); next poll in 20s — $(date)"
+        sleep 20
+    done
+    ray status
+
+    echo "=== Phase 3: prepare dataset (512 Eurus-2 code prompts, tests capped at 8) ==="
+    python3 /workspace/scripts/data_prep.py --out_dir /workspace/data/eurus_code \
+        --tokenizer "$MODEL_ID" --train_size 512 --val_size 64
+
+    echo "=== Phase 3b: chat-template sanity check (forced <think> must be active) ==="
+    python3 << 'TMPLCHECK'
+    import pandas as pd
+    from transformers import AutoTokenizer
+
+    tok = AutoTokenizer.from_pretrained("deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B")
+    df = pd.read_parquet("/workspace/data/eurus_code/train.parquet")
+    msgs = [dict(m) for m in df.iloc[0]["prompt"]]
+    rendered = tok.apply_chat_template(msgs, add_generation_prompt=True, tokenize=False)
+    print("RENDERED PROMPT TAIL:", rendered[-200:])
+    assert rendered.rstrip().endswith("<think>"), "chat template does not force <think> - CoT premise broken"
+    ntok = len(tok.apply_chat_template(msgs, add_generation_prompt=True))
+    print(f"prompt tokens: {ntok}")
+    assert ntok < 2048, f"prompt longer than max_prompt_length: {ntok}"
+    print("Chat template check OK")
+    TMPLCHECK
+
+    echo "=== Phase 4: fully-async code-RLVR training ==="
+    echo "  Model: DeepSeek-R1-Distill-Qwen-1.5B | Dataset: Eurus-2-RL-Data code (512 prompts)"
+    echo "  Reward: in-tree prime_code, LOCAL test execution on the rollout side"
+    echo "  lr=${ACTOR_LR:-1e-6} exp=${EXP_NAME:-unnamed} staleness=${STALENESS_THRESHOLD:-8}"
+    echo "  timeslice: job=${TIMESLICE_JOB_ID:-?} group=${TIMESLICE_GROUP:-?} orch=${TIMESLICE_ORCH_ADDR:-?}"
+    nvidia-smi
+
+    export PYTHONUNBUFFERED=1
+    export HYDRA_FULL_ERROR=1
+
+    TOTAL_ROLLOUT_STEPS=65536   # >> trainer consumption; None-sentinel must not fire
+
+    run_training() {
+        # timeout bounds the experiment; exit 124 (timeout) is the EXPECTED end state.
+        timeout --signal=INT --kill-after=120 "$RUN_SECS" \
+        python3 -m verl.experimental.fully_async_policy.fully_async_main \
+            data.train_files="$TRAIN_FILE" \
+            data.val_files="$VAL_FILE" \
+            data.prompt_key=prompt \
+            data.truncation=left \
+            data.max_prompt_length=2048 \
+            data.max_response_length=16384 \
+            data.train_batch_size=0 \
+            data.gen_batch_size=1 \
+            data.return_raw_chat=True \
+            actor_rollout_ref.model.path="$MODEL_ID" \
+            actor_rollout_ref.model.use_remove_padding=True \
+            actor_rollout_ref.model.enable_gradient_checkpointing=True \
+            actor_rollout_ref.hybrid_engine=False \
+            actor_rollout_ref.actor.strategy=fsdp \
+            actor_rollout_ref.actor.ppo_mini_batch_size=64 \
+            actor_rollout_ref.actor.ppo_micro_batch_size_per_gpu=1 \
+            actor_rollout_ref.actor.use_kl_loss=False \
+            actor_rollout_ref.actor.kl_loss_coef=0.0 \
+            actor_rollout_ref.actor.entropy_coeff=0 \
+            actor_rollout_ref.actor.grad_clip=1.0 \
+            actor_rollout_ref.actor.loss_agg_mode=token-mean \
+            actor_rollout_ref.actor.use_dynamic_bsz=True \
+            actor_rollout_ref.actor.ppo_max_token_len_per_gpu=32768 \
+            actor_rollout_ref.actor.optim.lr="${ACTOR_LR:-1e-6}" \
+            actor_rollout_ref.actor.optim.lr_warmup_steps=-1 \
+            actor_rollout_ref.actor.fsdp_config.param_offload=False \
+            actor_rollout_ref.actor.fsdp_config.optimizer_offload=False \
+            actor_rollout_ref.ref.log_prob_use_dynamic_bsz=True \
+            actor_rollout_ref.ref.log_prob_max_token_len_per_gpu=32768 \
+            actor_rollout_ref.rollout.name=vllm \
+            actor_rollout_ref.rollout.mode=async \
+            actor_rollout_ref.rollout.n=8 \
+            actor_rollout_ref.rollout.calculate_log_probs=True \
+            actor_rollout_ref.rollout.checkpoint_engine.backend=nccl \
+            +actor_rollout_ref.rollout.checkpoint_engine.engine_kwargs.nccl.rebuild_group=True \
+            actor_rollout_ref.rollout.gpu_memory_utilization=0.8 \
+            actor_rollout_ref.rollout.tensor_model_parallel_size=1 \
+            actor_rollout_ref.rollout.max_model_len=18432 \
+            actor_rollout_ref.rollout.max_num_batched_tokens=18432 \
+            actor_rollout_ref.rollout.enable_chunked_prefill=True \
+            actor_rollout_ref.rollout.temperature=1.0 \
+            actor_rollout_ref.rollout.top_p=1.0 \
+            actor_rollout_ref.rollout.top_k=-1 \
+            algorithm.adv_estimator=grpo \
+            algorithm.use_kl_in_reward=False \
+            algorithm.kl_ctrl.kl_coef=0.0 \
+            trainer.logger="['console']" \
+            trainer.val_before_train=False \
+            trainer.save_freq=-1 \
+            trainer.resume_mode=disable \
+            trainer.nnodes=1 \
+            trainer.n_gpus_per_node=1 \
+            trainer.total_epochs=10 \
+            trainer.test_freq=-1 \
+            trainer.project_name=timeslice-demo \
+            trainer.experiment_name="${EXP_NAME:-rl-batch-code}" \
+            trainer.default_local_dir="$RESULTS_DIR/ckpts" \
+            rollout.nnodes=1 \
+            rollout.n_gpus_per_node=1 \
+            rollout.total_rollout_steps="$TOTAL_ROLLOUT_STEPS" \
+            async_training.staleness_threshold="${STALENESS_THRESHOLD:-8}" \
+            async_training.trainer_name=timeslice \
+            async_training.trigger_parameter_sync_step=1 \
+            async_training.use_dynamic_resource_scheduling=False \
+            async_training.use_trainer_do_validate=False \
+            "ray_pg_extra_resources={trainer_pool: {trainer_node: 1}, rollout_pool: {rollout_node: 1}}" \
+            2>&1 | tee "$RESULTS_DIR/train.log"
+        return "${PIPESTATUS[0]}"
+    }
+
+    set +e
+    run_training
+    TRAIN_RC=$?
+    set -e
+    if [ "$TRAIN_RC" = "124" ]; then
+        echo "Training stopped by planned ${RUN_SECS}s timeout (expected end state)"
+    elif [ "$TRAIN_RC" != "0" ]; then
+        echo "WARNING: training exited rc=$TRAIN_RC before planned timeout"
+    fi
+
+    echo "=== Keeping pod alive for result collection ==="
+    sleep 7200
+
+  run_rollout.sh: |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+
+    trap 'kill $(jobs -p) 2>/dev/null || true' EXIT
+
+    RESULTS_DIR="/workspace/results"
+    RAY_HEAD_ADDR="rl-head.default.svc.cluster.local:6379"
+
+    mkdir -p "$RESULTS_DIR"
+
+    echo "=== Phase 0: verify GPU visibility (device-plugin) ==="
+    NVIS=$(nvidia-smi -L | wc -l)
+    nvidia-smi -L
+    if [ "$NVIS" != 1 ]; then
+        echo "FATAL: expected exactly 1 visible GPU on the rollout node, got $NVIS"; exit 96
+    fi
+
+    source /workspace/scripts/install_common.sh
+
+    # verl's FullyAsyncRollouter actor runs on
+    # THIS pod (rollout PG pinning) and loads the train/val parquet itself;
+    # there is no shared volume, so the dataset must be prepared here too
+    # (same seed as the head -> identical files).
+    echo "=== Phase 1e: prepare dataset locally (FullyAsyncRollouter reads it on THIS pod) ==="
+    python3 /workspace/scripts/data_prep.py --out_dir /workspace/data/eurus_code \
+        --tokenizer deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --train_size 512 --val_size 64
+
+    echo "=== Phase 2: join the ray cluster ==="
+    # Join loop: the head pod may still be installing (its ray head comes up
+    # ~20 min after apply). ray start fails fast while the head is
+    # unreachable; --block keeps this script attached to the raylet once
+    # joined. The rollout_node custom resource pins the rollout PG here.
+    # NOTE: --resources takes JSON with DOUBLE quotes; keep the single-quote wrapper.
+    set +e
+    while true; do
+        ray start --block --address="$RAY_HEAD_ADDR" --num-gpus=1 --resources='{"rollout_node": 100}'
+        RC=$?
+        echo "ray start exited rc=$RC (head not up yet, or head gone); retrying in 15s — $(date)"
+        ray stop --force >/dev/null 2>&1 || true
+        sleep 15
+    done
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rl-head
+  namespace: default
+  labels:
+    app: rl-head
+    # Exact keys the platform selects on (pod-utils.go JobIDLabel/GroupLabel,
+    # orchestrator kubernetes.go JobLabelKey/PodLabelKey). ONLY the head pod
+    # carries them: the trainer is the sole time-sliced (snapshotted) process.
+    timeslice.io/job-id: rl-trainer
+    timeslice.io/group: trainers
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    group.timeslice.io/trainers: "true"
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: timeslice.io/shared
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+  resourceClaims:
+  - name: accelerator
+    resourceClaimName: shared-trainers-gpu-claim   # SAME claim as shadow-vllm
+  containers:
+  - name: head
+    image: verlai/verl:vllm020.dev2
+    env:
+    - name: VLLM_USE_V1
+      value: "1"
+    - name: STALENESS_THRESHOLD
+      value: "8"
+    - name: RUN_SECONDS
+      value: "5400"
+    - name: HF_HOME
+      value: "/workspace/hf"         # model + dataset cache, per node (no shared volume)
+    # Precautionary NCCL settings around cuda-checkpoint; keep as set.
+    - name: NCCL_CUMEM_ENABLE
+      value: "0"
+    - name: NCCL_NVLS_ENABLE
+      value: "0"
+    - name: ACTOR_LR
+      value: "1e-6"
+    - name: EXP_NAME
+      value: "rl-batch-code"
+    # --- timeslice trainer (timeslice_verl, pip install from repo) ---
+    - name: TIMESLICE_FULLY_ASYNC
+      value: "1"
+    - name: TIMESLICE_JOB_ID
+      value: "rl-trainer"            # must equal the timeslice.io/job-id label
+    - name: TIMESLICE_ORCH_ADDR
+      value: "timeslice-timesliceorchestrator.timeslice-system.svc:50051"
+    - name: TIMESLICE_GROUP
+      value: "trainers"
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      set -euo pipefail
+      echo "=== RL+batch guide: RL trainer (code RLVR) — HEAD (trainer node) ==="
+      echo "Node: $(hostname)"
+      echo "Date: $(date)"
+      bash /workspace/scripts/run_head.sh 2>&1 | tee /workspace/results/experiment.log
+    ports:
+    - containerPort: 6379            # ray GCS (behind headless Service rl-head)
+    - containerPort: 8265            # ray dashboard (optional)
+    resources:
+      requests:
+        cpu: "8"
+        memory: "80Gi"
+      limits:
+        memory: "110Gi"              # head + shadow vLLM must fit one a3-highgpu-1g (26 vCPU / 234 Gi)
+      claims:
+      - name: accelerator
+    volumeMounts:
+    - name: scripts
+      mountPath: /workspace/scripts
+    - name: results
+      mountPath: /workspace/results
+    - name: dshm
+      mountPath: /dev/shm
+  volumes:
+  - name: scripts
+    configMap:
+      name: rlbatch-trainer
+      defaultMode: 0755
+  - name: results
+    emptyDir: {}
+  - name: dshm
+    emptyDir:
+      medium: Memory
+      sizeLimit: 16Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rl-rollout
+  namespace: default
+  labels:
+    app: rl-rollout
+    # NO timeslice.io labels: this pod must NEVER be selected for snapshot —
+    # the rollout engine keeps generating while the trainer is checkpointed.
+spec:
+  restartPolicy: Never
+  # Placement: any GPU node except the trainer node. The GPU comes from the
+  # ordinary device plugin (nvidia.com/gpu below); the anti-affinity keeps
+  # this pod off the trainer node, whose GPU is claim-managed.
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: group.timeslice.io/trainers
+            operator: DoesNotExist
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: timeslice.io/shared
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+  containers:
+  - name: rollout
+    image: verlai/verl:vllm020.dev2
+    env:
+    - name: VLLM_USE_V1
+      value: "1"
+    - name: HF_HOME
+      value: "/workspace/hf"         # model downloads land here, per node
+    - name: NCCL_CUMEM_ENABLE
+      value: "0"
+    - name: NCCL_NVLS_ENABLE
+      value: "0"
+    # The trainer driver actor (the registered timeslice trainer subclass)
+    # is a CPU-only Ray actor that can be scheduled on either Ray node and
+    # inherits the raylet's env, not the driver's - keep the timeslice env
+    # identical on both pods.
+    - name: TIMESLICE_FULLY_ASYNC
+      value: "1"
+    - name: TIMESLICE_JOB_ID
+      value: "rl-trainer"
+    - name: TIMESLICE_ORCH_ADDR
+      value: "timeslice-timesliceorchestrator.timeslice-system.svc:50051"
+    - name: TIMESLICE_GROUP
+      value: "trainers"
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      set -euo pipefail
+      echo "=== RL+batch guide: RL trainer (code RLVR) — ROLLOUT (dedicated node) ==="
+      echo "Node: $(hostname)"
+      echo "Date: $(date)"
+      bash /workspace/scripts/run_rollout.sh 2>&1 | tee /workspace/results/experiment.log
+    resources:
+      requests:
+        cpu: "16"
+        memory: "120Gi"
+      limits:
+        nvidia.com/gpu: "1"          # ordinary device-plugin GPU (no claim)
+    volumeMounts:
+    - name: scripts
+      mountPath: /workspace/scripts
+    - name: results
+      mountPath: /workspace/results
+    - name: dshm
+      mountPath: /dev/shm
+  volumes:
+  - name: scripts
+    configMap:
+      name: rlbatch-trainer
+      defaultMode: 0755
+  - name: results
+    emptyDir: {}
+  - name: dshm
+    emptyDir:
+      medium: Memory
+      sizeLimit: 32Gi
+---
+# Headless Service: stable DNS for the ray head; the rollout pod joins via
+# rl-head.default.svc.cluster.local:6379.
+apiVersion: v1
+kind: Service
+metadata:
+  name: rl-head
+  namespace: default
+spec:
+  clusterIP: None
+  selector:
+    app: rl-head
+  ports:
+  - name: ray-gcs
+    port: 6379
+    targetPort: 6379
+  - name: ray-dashboard
+    port: 8265
+    targetPort: 8265

--- a/guides/rl-batch-interleaving/examples/shadow-vllm.yaml
+++ b/guides/rl-batch-interleaving/examples/shadow-vllm.yaml
@@ -1,0 +1,327 @@
+# EXAMPLE ONLY — demo-quality reference, not a supported platform component.
+# The embedded supervisor shows how a batch-inference server becomes a polite
+# time-slicing tenant; a production deployment should use a queue-based batch
+# front-end with retries (see README §8) and treat this file as a template.
+#
+# Shadow vLLM: a STOCK vLLM OpenAI-compatible server that harvests the RL
+# trainer's idle time on the shared GPU, plus a ~100-line supervisor that
+# makes it a polite time-slicing tenant.
+#
+# How it yields: vLLM runs with --enable-sleep-mode. The supervisor registers
+# the workload with the node's snapshot agent over the WORKLOAD CHANNEL
+# (timeslice.snapshot_agent.register_workload) with callbacks that POST to
+# vLLM's own /sleep and /wake_up endpoints. When the orchestrator hands the
+# GPU to the trainer it drives those callbacks through the agent — weights and
+# KV cache move to host RAM in ~1-2 s, and back in ~100 ms. The vLLM process
+# is never killed.
+#
+# Priority is structural: the supervisor holds the group lock ONLY while no
+# one is waiting (it polls waiter_queue_depth every 500 ms; when the trainer
+# queues it DRAINS — closes the readiness gate so the pod leaves the Service
+# endpoints and waits for in-flight requests to finish, ~3 s — then
+# releases), and re-requests the lock afterwards. The trainer therefore
+# never waits more than ~0.5 s poll + ~3 s drain + one vLLM sleep (~1-2 s).
+# The drain is REQUIRED: vLLM's /sleep does not drain the scheduler
+# (vllm#28714) and sleeping with a request mid-decode kills the server.
+#
+# Runs on the shared trainer node (nodeSelector group.timeslice.io/trainers)
+# — the 1-GPU node it shares with the RL head pod (rl-head). It references
+# the SAME shared-trainers-gpu-claim DRA ResourceClaim as rl-head (see
+# resource-claims.yaml): that shared claim is what lets both tenants
+# co-locate on the one GPU without scheduler blocking, each holding the
+# full, unpartitioned GPU during its turn. The node has a single GPU, so no
+# device selection is needed.
+#
+# No template variables — apply directly with kubectl apply -f.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: shadow-vllm-scripts
+  namespace: default
+data:
+  supervisor.py: |
+    #!/usr/bin/env python3
+    """Queue-depth-preemption supervisor for a stock vLLM server."""
+    import os
+    import subprocess
+    import sys
+    import time
+    import urllib.request
+
+    JOB_ID = os.environ.get("TIMESLICE_JOB_ID", "shadow-vllm")
+    GROUP = os.environ.get("TIMESLICE_GROUP", "trainers")
+    ORCH = os.environ["TIMESLICE_ORCH_ADDR"]
+    AGENT = os.environ["TIMESLICE_AGENT_ADDR"]          # node-local, <hostIP>:9001
+    MODEL = os.environ.get("VLLM_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
+    PORT = int(os.environ.get("VLLM_PORT", "8000"))
+    GPU_FRAC = os.environ.get("VLLM_GPU_FRAC", "0.7")
+    POLL_S = float(os.environ.get("WAITER_POLL_SECONDS", "0.5"))
+    # Readiness gate file (see the pod's readinessProbe): while it exists the
+    # pod is a Service endpoint; removing it makes new batch requests fail
+    # fast at the Service (connection refused) within ~1-2 s.
+    GATE = "/tmp/serving"
+
+    try:
+        from timeslice import OrchestratorClient
+    except ImportError:  # client class was renamed upstream; API identical
+        from timeslice import TimeSliceOrchestratorClient as OrchestratorClient
+    from timeslice.snapshot_agent import register_workload
+
+    def log(msg):
+        print(f"[supervisor] {msg}", flush=True)
+
+    def http(method, path, timeout):
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{PORT}{path}", data=b"" if method == "POST" else None,
+            method=method)
+        return urllib.request.urlopen(req, timeout=timeout)
+
+    def gate_open():
+        open(GATE, "w").close()
+
+    def gate_close():
+        try:
+            os.remove(GATE)
+        except FileNotFoundError:
+            pass
+
+    def inflight():
+        """running + waiting requests, from /metrics (None if unreadable)."""
+        try:
+            with http("GET", "/metrics", timeout=2) as r:
+                text = r.read().decode()
+            n = 0.0
+            for line in text.splitlines():
+                if line.startswith(("vllm:num_requests_running",
+                                    "vllm:num_requests_waiting")):
+                    n += float(line.rsplit(" ", 1)[1])
+            return n
+        except Exception:
+            return None
+
+    def drain(settle_s=2.5, max_wait_s=12.0):
+        """Stop new batch traffic and wait for in-flight requests to finish.
+        REQUIRED before sleeping: vLLM's /sleep does NOT drain the scheduler
+        (vllm-project/vllm#28714, unfixed as of v0.10.x) — freeing weights
+        with a request mid-decode is a fatal CUDA error that kills the
+        server. Gate first (readinessProbe pulls the pod out of the Service
+        in ~1-2 s; new requests then fail fast), then wait for running+
+        waiting == 0."""
+        t0 = time.time()
+        gate_close()
+        zeros = 0
+        while time.time() - t0 < max_wait_s:
+            n = inflight()
+            if n == 0 and time.time() - t0 >= settle_s:
+                zeros += 1
+                if zeros >= 2:
+                    log(f"drained in {time.time()-t0:.2f}s")
+                    return
+            else:
+                zeros = 0
+            time.sleep(0.25)
+        log(f"drain timed out after {max_wait_s}s (in_flight={inflight()}); sleeping anyway")
+
+    def vllm_sleep(mode=None, tags=None):
+        t0 = time.time()
+        http("POST", "/sleep?level=1", timeout=300)
+        log(f"vLLM slept (HBM -> host RAM) in {time.time()-t0:.2f}s")
+
+    def vllm_wake(tags=None):
+        t0 = time.time()
+        http("POST", "/wake_up", timeout=300)
+        gate_open()   # resume batch traffic only after weights are back
+        log(f"vLLM woke in {time.time()-t0:.2f}s")
+
+    def vllm_is_sleeping():
+        try:
+            import json
+            with http("GET", "/is_sleeping", timeout=5) as r:
+                return bool(json.load(r).get("is_sleeping"))
+        except Exception:
+            return None  # endpoint unavailable — assume unknown
+
+    def launch_vllm():
+        env = dict(os.environ)
+        env["VLLM_SERVER_DEV_MODE"] = "1"   # exposes /sleep, /wake_up, /is_sleeping
+        proc = subprocess.Popen(
+            ["vllm", "serve", MODEL,
+             "--port", str(PORT),
+             "--enable-sleep-mode",
+             "--gpu-memory-utilization", GPU_FRAC,
+             "--max-model-len", "4096"],
+            env=env)
+        deadline = time.time() + 900
+        while time.time() < deadline:
+            if proc.poll() is not None:
+                raise RuntimeError(f"vLLM exited rc={proc.returncode} during startup")
+            try:
+                http("GET", "/health", timeout=2)
+                log("vLLM is up")
+                return proc
+            except Exception:
+                time.sleep(2)
+        raise RuntimeError("vLLM did not become healthy in 900s")
+
+    def waiter_depth(client):
+        st = client.get_status(group_id=GROUP)
+        g = getattr(st, "group", st)
+        return int(getattr(g, "waiter_queue_depth", 0))
+
+    def main():
+        client = OrchestratorClient(target=ORCH, job_id=JOB_ID, group_id=GROUP)
+
+        # 1) Take the lock BEFORE creating any GPU context (cold start).
+        log("requesting lock for cold start...")
+        res = client.acquire()
+        log(f"lock acquired (waited {getattr(res, 'waited_ms', '?')} ms); launching vLLM")
+        proc = launch_vllm()
+        gate_open()   # vLLM healthy -> become a Service endpoint
+
+        # 2) Register with the node's snapshot agent: the platform drives our
+        #    sleep/wake through these callbacks at every lock handoff.
+        handle = register_workload(
+            AGENT, job_id=JOB_ID, group=GROUP,
+            on_snapshot=vllm_sleep, on_restore=vllm_wake,
+            supported_modes=["offload"], default_mode="offload")
+        log(f"workload registered with agent {AGENT}")
+
+        try:
+            while True:
+                # -- serving phase: hold the lock only while nobody waits --
+                while True:
+                    if proc.poll() is not None:
+                        log(f"vLLM died rc={proc.returncode}; releasing lock and exiting")
+                        client.release()
+                        sys.exit(1)
+                    try:
+                        if waiter_depth(client) > 0:
+                            log("trainer is waiting - yielding GPU")
+                            break
+                    except Exception as e:
+                        log(f"status poll error (transient): {e}")
+                    time.sleep(POLL_S)
+
+                drain()            # stop + flush batch traffic (sleep is NOT drain-safe)
+                client.release()   # platform snapshots us via the workload channel
+                time.sleep(1.0)
+
+                # -- reacquire: blocks until the trainer finishes its burst --
+                res = client.acquire()
+                log(f"lock reacquired (waited {getattr(res, 'waited_ms', '?')} ms, "
+                    f"context_restored={getattr(res, 'context_restored', '?')})")
+                # Belt and suspenders: if the platform didn't wake us, do it locally.
+                if vllm_is_sleeping():
+                    log("still sleeping after acquire - waking locally")
+                    vllm_wake()
+                gate_open()        # idempotent; re-admit batch traffic
+        finally:
+            handle.close()
+            proc.terminate()
+
+    if __name__ == "__main__":
+        main()
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: shadow-vllm
+  namespace: default
+  labels:
+    app: shadow-vllm
+    # Exact keys the platform selects on:
+    timeslice.io/job-id: shadow-vllm
+    timeslice.io/group: trainers
+spec:
+  restartPolicy: Always
+  nodeSelector:
+    group.timeslice.io/trainers: "true"
+  tolerations:
+  - key: nvidia.com/gpu
+    operator: Exists
+    effect: NoSchedule
+  - key: timeslice.io/shared
+    operator: Equal
+    value: "true"
+    effect: NoSchedule
+  resourceClaims:
+  - name: accelerator
+    resourceClaimName: shared-trainers-gpu-claim   # SAME claim as rl-head
+  containers:
+  - name: vllm
+    image: vllm/vllm-openai:v0.9.2
+    command: ["/bin/bash", "-c"]
+    args:
+    - |
+      set -euo pipefail
+      # GPU access via the pod's DRA ResourceClaim (the NVIDIA DRA driver
+      # injects the GPU + driver userspace — no setup needed here).
+      # 1-GPU node: the shared GPU is the only one visible — no device mask.
+      nvidia-smi -L
+      pip install --quiet "git+https://github.com/llm-d-incubation/llm-d-rl-time-slicing.git#subdirectory=pkg/client/python" \
+        "grpcio>=1.81.0" "protobuf>=7.35.0"
+      exec python3 /scripts/supervisor.py
+    env:
+    - name: TIMESLICE_JOB_ID
+      value: "shadow-vllm"            # must equal the timeslice.io/job-id label
+    - name: TIMESLICE_GROUP
+      value: "trainers"
+    - name: TIMESLICE_ORCH_ADDR
+      value: "timeslice-timesliceorchestrator.timeslice-system.svc:50051"
+    - name: NODE_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.hostIP
+    - name: TIMESLICE_AGENT_ADDR
+      value: "$(NODE_IP):9001"        # snapshot agent is hostNetwork on :9001
+    - name: VLLM_MODEL
+      value: "Qwen/Qwen2.5-0.5B-Instruct"
+    - name: VLLM_PORT
+      value: "8000"
+    - name: VLLM_GPU_FRAC
+      value: "0.7"
+    # Readiness gate: the supervisor removes /tmp/serving before yielding the
+    # GPU (drain) and recreates it after wake. NotReady -> the pod leaves the
+    # Service endpoints, so batch requests fail fast (connection refused)
+    # instead of reaching a sleeping engine — required because vLLM's /sleep
+    # does not drain in-flight requests (vllm#28714; a request mid-decode at
+    # sleep time is a fatal CUDA error).
+    readinessProbe:
+      exec:
+        command: ["cat", "/tmp/serving"]
+      periodSeconds: 1
+      failureThreshold: 1
+    ports:
+    - containerPort: 8000
+    resources:
+      requests:
+        cpu: "6"
+        memory: "60Gi"     # sleep mode offloads weights+KV here; sized to share the node with rl-head
+      claims:
+      - name: accelerator
+    volumeMounts:
+    - name: scripts
+      mountPath: /scripts
+    - name: dshm
+      mountPath: /dev/shm
+  volumes:
+  - name: scripts
+    configMap:
+      name: shadow-vllm-scripts
+      defaultMode: 0755
+  - name: dshm
+    emptyDir:
+      medium: Memory
+      sizeLimit: 8Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: shadow-vllm
+  namespace: default
+spec:
+  selector:
+    app: shadow-vllm
+  ports:
+  - port: 8000
+    targetPort: 8000


### PR DESCRIPTION
Stacked on #158; retarget to main after it merges.

Adds `guides/rl-batch-interleaving/`: time-slicing one verl fully-async RL training job with a stock vLLM batch-inference server on the same GPU. The trainer has absolute priority (cuda-checkpoint C/R); vLLM harvests the trainer's idle valleys via its native sleep mode, driven through the snapshot agent's workload channel.

Two-level structure:
- `README.md` — generic, self-sufficient step-by-step walkthrough for running any verl RL + batch tenant pair: cluster prerequisites and shared DRA claims, platform install, the verl job contract, what any batch engine must provide (with the supervisor as reference implementation), deployment shapes and launch order, observation, and generic troubleshooting.
- `examples/README.md` — quick start for the pinned runnable (DeepSeek-R1-Distill-Qwen-1.5B code-RLVR + Qwen2.5-0.5B vLLM): the literal command sequence, watch/collect/cleanup, and demo-specific troubleshooting.

Notes:
- The RL job manifest uses the timeslice-verl package from #158 (`pkg/integrations/verl`), with the verl lifecycle-hook and PG-pinning features installed directly from the fork branch `aishukamal/verl@feat/fully-async-lifecycle-hooks`.
- The vLLM supervisor and load generator are marked example-only: the supervisor demonstrates the polite-tenant pattern (waiter poll, readiness-gate drain before sleep, workload-channel registration); production batch serving should sit behind a queue-based front end with retries. The rationale for draining before sleep is documented in the guide.
- Requires a snapshot-agent build with workload-channel default routing (config-less Snapshot/Restore resolves the job's registered workload channel) — the chart-default `latest` platform images include it; the guide states this constraint in its release-pin note (no tagged release containing #152 and #159 is cut yet).

Validation: validated e2e on GKE (2x 1-GPU H100 nodes; 80-minute run, 9/9 mixed-backend cycles — vLLM app-channel sleep/wake alongside trainer cuda-checkpoint C/R — with no crash, fault, or NCCL errors).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a complete guide for time-slicing reinforcement learning training and batch inference on a shared GPU.
  - Added runnable Kubernetes examples for training, inference serving, load generation, shared GPU allocation, monitoring, and teardown.
  - Included deployment instructions, launch sequencing, success criteria, troubleshooting, and workload adaptation guidance.
- **Documentation**
  - Documented prerequisites, installation, configuration, monitoring, result collection, and solo-baseline comparison procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->