### PR TITLE
Add timeslice-slime integration package

### DIFF
--- a/pkg/integrations/slime/pyproject.toml
+++ b/pkg/integrations/slime/pyproject.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "llm-d-timeslice-slime"
+version = "0.1.0"
+description = "GPU time-slicing integration for Slime RL training"
+requires-python = ">=3.10"
+dependencies = []

--- a/pkg/integrations/slime/tests/test_callback.py
+++ b/pkg/integrations/slime/tests/test_callback.py
@@ -1,0 +1,364 @@
+"""Lock protocol tests for TimesliceCallback (no GPU, no Slime, no Ray).
+
+Simulates the exact phase sequences that Slime's sync and async drivers
+produce and asserts:
+  * Trainer-first global order (TRAINER never requested while SAMPLER held)
+  * No lock leaks (every acquire has a matching release)
+  * Dual-lock during weight_sync and init (both held during NCCL broadcast)
+  * No-op mode runs clean when env vars are absent
+  * All GPU-touching phases (generate, train, weight_sync, offload, onload,
+    eval, create) are covered by locks
+"""
+
+import importlib.util
+import os
+import unittest
+
+_LOCKS_PATH = os.path.join(os.path.dirname(__file__), "..", "timeslice_slime", "locks.py")
+_spec = importlib.util.spec_from_file_location("_timeslice_locks", _LOCKS_PATH)
+_locks = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_locks)
+
+SAMPLER = _locks.SAMPLER
+TRAINER = _locks.TRAINER
+RoleLocks = _locks.RoleLocks
+
+JOB = "job-a"
+ADDR = "orch:50051"
+TG = "trainers"
+SG = "samplers"
+
+
+class FakeClient:
+    def __init__(self, events, job_id, group_id):
+        self.events = events
+        self.job_id = job_id
+        self.group_id = group_id
+        self.closed = False
+
+    def acquire(self, group_id, timeout_sec=None):
+        assert group_id == self.group_id
+        self.events.append(("acquire", group_id))
+        return type("R", (), {"waited_ms": 0, "context_restored": False})()
+
+    def release(self, group_id):
+        assert group_id == self.group_id
+        self.events.append(("release", group_id))
+        return type("R", (), {"pending_waiters": 0, "snapshot_deferred": False})()
+
+    def close(self):
+        self.closed = True
+
+
+def make_locks(events):
+    return RoleLocks(
+        job_id=JOB,
+        orch_addr=ADDR,
+        trainer_group=TG,
+        sampler_group=SG,
+        client_factory=lambda target, job_id, group_id: FakeClient(events, job_id, group_id),
+    )
+
+
+def held_after(events):
+    held = set()
+    for op, group in events:
+        if op == "acquire":
+            assert group not in held, f"double acquire of {group}: {events}"
+            held.add(group)
+        else:
+            assert group in held, f"release of un-held {group}: {events}"
+            held.discard(group)
+    return held
+
+
+class CallbackHarness:
+    """Simulate TimesliceCallback without importing Slime."""
+
+    def __init__(self, locks):
+        self.locks = locks
+
+    def on_phase_begin(self, phase, role, context=None):
+        if role in ("trainer", "both"):
+            self.locks.acquire(TRAINER)
+        if role in ("sampler", "both"):
+            self.locks.acquire(SAMPLER)
+
+    def on_phase_end(self, phase, role, context=None):
+        if role in ("sampler", "both"):
+            self.locks.release(SAMPLER)
+        if role in ("trainer", "both"):
+            self.locks.release(TRAINER)
+
+    def close(self):
+        self.locks.close()
+
+
+class TestSyncDriverSequence(unittest.TestCase):
+    """Replay the sync driver (train.py) phase sequence."""
+
+    def _run_sync(self, n_steps, offload_rollout=False, release_train=False, with_eval=False):
+        events = []
+        locks = make_locks(events)
+        cb = CallbackHarness(locks)
+
+        cb.on_phase_begin("init", "both")
+        cb.on_phase_end("init", "both")
+
+        for step in range(n_steps):
+            ctx = {"rollout_id": step}
+
+            cb.on_phase_begin("generate", "sampler", ctx)
+            cb.on_phase_end("generate", "sampler", ctx)
+
+            if offload_rollout:
+                cb.on_phase_begin("offload", "sampler", ctx)
+                cb.on_phase_end("offload", "sampler", ctx)
+
+            if release_train:
+                cb.on_phase_begin("create", "trainer", ctx)
+                cb.on_phase_end("create", "trainer", ctx)
+
+            cb.on_phase_begin("train", "trainer", ctx)
+            self.assertTrue(locks.held(TRAINER))
+            self.assertFalse(locks.held(SAMPLER))
+            cb.on_phase_end("train", "trainer", ctx)
+
+            if offload_rollout and not release_train:
+                cb.on_phase_begin("onload", "sampler", ctx)
+                cb.on_phase_end("onload", "sampler", ctx)
+
+            cb.on_phase_begin("weight_sync", "both", ctx)
+            self.assertTrue(locks.held(TRAINER) and locks.held(SAMPLER))
+            cb.on_phase_end("weight_sync", "both", ctx)
+            self.assertFalse(locks.held(TRAINER), "TRAINER must be released after weight_sync")
+            self.assertFalse(locks.held(SAMPLER), "SAMPLER must be released after weight_sync")
+
+            if offload_rollout:
+                cb.on_phase_begin("onload", "sampler", ctx)
+                cb.on_phase_end("onload", "sampler", ctx)
+
+            if with_eval:
+                cb.on_phase_begin("eval", "sampler", ctx)
+                cb.on_phase_end("eval", "sampler", ctx)
+
+        cb.close()
+        return events, locks
+
+    def test_basic_3_steps(self):
+        events, _ = self._run_sync(3)
+        self.assertEqual(held_after(events), set())
+
+    def test_with_offload_rollout(self):
+        events, _ = self._run_sync(2, offload_rollout=True)
+        self.assertEqual(held_after(events), set())
+
+    def test_with_release_train(self):
+        events, _ = self._run_sync(2, release_train=True)
+        self.assertEqual(held_after(events), set())
+
+    def test_with_eval(self):
+        events, _ = self._run_sync(2, with_eval=True)
+        self.assertEqual(held_after(events), set())
+
+    def test_all_options(self):
+        events, _ = self._run_sync(2, offload_rollout=True, release_train=True, with_eval=True)
+        self.assertEqual(held_after(events), set())
+
+    def test_trainer_first_order(self):
+        events, _ = self._run_sync(3, offload_rollout=True, with_eval=True)
+        held = set()
+        for op, group in events:
+            if op == "acquire":
+                if group == TG:
+                    self.assertNotIn(SG, held, f"TRAINER acquired while SAMPLER held: {events}")
+                held.add(group)
+            else:
+                held.discard(group)
+
+    def test_no_locks_between_phases(self):
+        """After weight_sync end, no locks are held going into the next iteration."""
+        events = []
+        locks = make_locks(events)
+        cb = CallbackHarness(locks)
+        cb.on_phase_begin("init", "both")
+        cb.on_phase_end("init", "both")
+        for step in range(2):
+            ctx = {"rollout_id": step}
+            self.assertFalse(locks.held(TRAINER), f"TRAINER leaked into step {step}")
+            self.assertFalse(locks.held(SAMPLER), f"SAMPLER leaked into step {step}")
+            cb.on_phase_begin("generate", "sampler", ctx)
+            cb.on_phase_end("generate", "sampler", ctx)
+            cb.on_phase_begin("train", "trainer", ctx)
+            cb.on_phase_end("train", "trainer", ctx)
+            cb.on_phase_begin("weight_sync", "both", ctx)
+            cb.on_phase_end("weight_sync", "both", ctx)
+        cb.close()
+
+
+class TestAsyncDriverSequence(unittest.TestCase):
+    """Replay the async driver (train_async.py) phase sequence.
+
+    In async mode, generate is dispatched before train — the sampler lock
+    is acquired at dispatch and held through training until collection.
+    With per-job sampler groups this is a no-op on the orchestrator side.
+    """
+
+    def _run_async(self, n_steps, sync_interval=1, with_eval=False):
+        """Replay the async driver lock sequence.
+
+        Lock order in async overlap: TRAINER first, then SAMPLER.
+        Gen dispatch happens AFTER train begin (TRAINER held), so SAMPLER
+        acquisition respects the global order.
+        """
+        events = []
+        locks = make_locks(events)
+        cb = CallbackHarness(locks)
+
+        cb.on_phase_begin("init", "both")
+        cb.on_phase_end("init", "both")
+
+        # Pre-loop: dispatch first generate
+        cb.on_phase_begin("generate", "sampler", {"rollout_id": 0})
+
+        for step in range(n_steps):
+            ctx = {"rollout_id": step}
+
+            # Collect pending generation
+            cb.on_phase_end("generate", "sampler", ctx)
+
+            # Acquire TRAINER first
+            cb.on_phase_begin("train", "trainer", ctx)
+            self.assertTrue(locks.held(TRAINER))
+
+            # Then dispatch next gen (acquire SAMPLER — order respected)
+            if step + 1 < n_steps:
+                cb.on_phase_begin("generate", "sampler", {"rollout_id": step + 1})
+
+            # Training runs with both TRAINER and SAMPLER held
+            cb.on_phase_end("train", "trainer", ctx)
+
+            if (step + 1) % sync_interval == 0:
+                # Collect pending generate before weight sync
+                if step + 1 < n_steps and locks.held(SAMPLER):
+                    cb.on_phase_end("generate", "sampler", ctx)
+                cb.on_phase_begin("weight_sync", "both", ctx)
+                self.assertTrue(locks.held(TRAINER) and locks.held(SAMPLER))
+                cb.on_phase_end("weight_sync", "both", ctx)
+
+            if with_eval:
+                cb.on_phase_begin("eval", "sampler", ctx)
+                cb.on_phase_end("eval", "sampler", ctx)
+
+        cb.close()
+        return events, locks
+
+    def test_every_step_sync(self):
+        events, _ = self._run_async(4, sync_interval=1)
+        self.assertEqual(held_after(events), set())
+
+    def test_periodic_sync(self):
+        events, _ = self._run_async(6, sync_interval=3)
+        self.assertEqual(held_after(events), set())
+
+    def test_with_eval(self):
+        events, _ = self._run_async(3, sync_interval=1, with_eval=True)
+        self.assertEqual(held_after(events), set())
+
+    def test_trainer_first_order(self):
+        events, _ = self._run_async(4, sync_interval=2)
+        held = set()
+        for op, group in events:
+            if op == "acquire":
+                if group == TG:
+                    self.assertNotIn(SG, held, "TRAINER acquired while SAMPLER held")
+                held.add(group)
+            else:
+                held.discard(group)
+
+    def test_sampler_held_during_train(self):
+        """In async mode, sampler lock is held during training (overlapping GPU work).
+
+        Lock order: TRAINER acquired first (train begin), then SAMPLER
+        (gen dispatch).  Both held during training execution.
+        """
+        events = []
+        locks = make_locks(events)
+        cb = CallbackHarness(locks)
+        cb.on_phase_begin("init", "both")
+        cb.on_phase_end("init", "both")
+        # Dispatch gen 0
+        cb.on_phase_begin("generate", "sampler", {"rollout_id": 0})
+        # Collect gen 0
+        cb.on_phase_end("generate", "sampler", {"rollout_id": 0})
+        # Acquire TRAINER first (train begin)
+        cb.on_phase_begin("train", "trainer", {"rollout_id": 0})
+        self.assertTrue(locks.held(TRAINER))
+        # Dispatch gen 1 — acquire SAMPLER (order: TRAINER then SAMPLER)
+        cb.on_phase_begin("generate", "sampler", {"rollout_id": 1})
+        self.assertTrue(locks.held(SAMPLER), "SAMPLER must be held during async train")
+        self.assertTrue(locks.held(TRAINER), "TRAINER must be held during async train")
+        cb.on_phase_end("train", "trainer", {"rollout_id": 0})
+
+
+class TestNoopMode(unittest.TestCase):
+    def test_no_env_runs_clean(self):
+        locks = RoleLocks(None, None, None, None)
+        cb = CallbackHarness(locks)
+        cb.on_phase_begin("init", "both")
+        cb.on_phase_end("init", "both")
+        cb.on_phase_begin("generate", "sampler")
+        cb.on_phase_end("generate", "sampler")
+        cb.on_phase_begin("train", "trainer")
+        cb.on_phase_end("train", "trainer")
+        cb.on_phase_begin("weight_sync", "both")
+        cb.on_phase_end("weight_sync", "both")
+        cb.on_phase_begin("offload", "sampler")
+        cb.on_phase_end("offload", "sampler")
+        cb.on_phase_begin("onload", "sampler")
+        cb.on_phase_end("onload", "sampler")
+        cb.on_phase_begin("eval", "sampler")
+        cb.on_phase_end("eval", "sampler")
+        cb.on_phase_begin("create", "trainer")
+        cb.on_phase_end("create", "trainer")
+        cb.close()
+
+
+class TestRoleLocks(unittest.TestCase):
+    def test_idempotent_acquire(self):
+        events = []
+        locks = make_locks(events)
+        locks.acquire(TRAINER)
+        locks.acquire(TRAINER)
+        self.assertEqual(events, [("acquire", TG)])
+
+    def test_order_violation(self):
+        events = []
+        locks = make_locks(events)
+        locks.acquire(SAMPLER)
+        with self.assertRaises(RuntimeError):
+            locks.acquire(TRAINER)
+
+    def test_same_group_rejected(self):
+        with self.assertRaises(ValueError):
+            RoleLocks(JOB, ADDR, "g", "g", client_factory=lambda *a: FakeClient([], JOB, "g"))
+
+    def test_close_releases_all(self):
+        events = []
+        locks = make_locks(events)
+        locks.acquire(TRAINER)
+        locks.acquire(SAMPLER)
+        locks.close()
+        self.assertEqual(held_after(events), set())
+
+    def test_release_all_reverse_order(self):
+        events = []
+        locks = make_locks(events)
+        locks.acquire(TRAINER)
+        locks.acquire(SAMPLER)
+        locks.release_all()
+        self.assertEqual(events[-2:], [("release", SG), ("release", TG)])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pkg/integrations/slime/timeslice_slime/__init__.py
+++ b/pkg/integrations/slime/timeslice_slime/__init__.py
@@ -1,0 +1,3 @@
+from timeslice_slime.callback import TimesliceCallback
+
+__all__ = ["TimesliceCallback"]

--- a/pkg/integrations/slime/timeslice_slime/callback.py
+++ b/pkg/integrations/slime/timeslice_slime/callback.py
@@ -1,0 +1,64 @@
+"""TimesliceCallback: PhaseCallback for cooperative GPU time-slicing.
+
+Maps Slime driver phase transitions to orchestrator lock acquire/release
+so multiple RL jobs can share accelerator hardware.
+
+Lock protocol per phase:
+
+  begin("init", "both")         → acquire TRAINER, acquire SAMPLER
+  end("init", "both")           → release SAMPLER, release TRAINER
+
+  begin("generate", "sampler")  → acquire SAMPLER
+  end("generate", "sampler")    → release SAMPLER
+
+  begin("train", "trainer")     → acquire TRAINER
+  end("train", "trainer")       → release TRAINER
+
+  begin("weight_sync", "both")  → acquire TRAINER, acquire SAMPLER
+  end("weight_sync", "both")    → release SAMPLER, release TRAINER
+
+  begin("offload", "sampler")   → acquire SAMPLER
+  end("offload", "sampler")     → release SAMPLER
+
+  begin("onload", "sampler")    → acquire SAMPLER
+  end("onload", "sampler")      → release SAMPLER
+
+  begin("eval", "sampler")      → acquire SAMPLER
+  end("eval", "sampler")        → release SAMPLER
+
+  begin("create", "trainer")    → acquire TRAINER
+  end("create", "trainer")      → release TRAINER
+
+Env-gated: no-op when TIMESLICE_JOB_ID is not set. Same image works
+with and without the time-slicing platform.
+
+Environment variables:
+  TIMESLICE_JOB_ID          unique job identifier (e.g. "job-a")
+  TIMESLICE_ORCH_ADDR       orchestrator gRPC address (e.g. "localhost:50051")
+  TIMESLICE_TRAINER_GROUP   trainer pool group id (e.g. "trainers")
+  TIMESLICE_SAMPLER_GROUP   sampler pool group id (e.g. "samplers")
+"""
+
+from slime.utils.phase_callback import PhaseCallback
+
+from timeslice_slime.locks import SAMPLER, TRAINER, RoleLocks
+
+
+class TimesliceCallback(PhaseCallback):
+    def __init__(self):
+        self.locks = RoleLocks.from_env()
+
+    def on_phase_begin(self, phase, role, context=None):
+        if role in ("trainer", "both"):
+            self.locks.acquire(TRAINER)
+        if role in ("sampler", "both"):
+            self.locks.acquire(SAMPLER)
+
+    def on_phase_end(self, phase, role, context=None):
+        if role in ("sampler", "both"):
+            self.locks.release(SAMPLER)
+        if role in ("trainer", "both"):
+            self.locks.release(TRAINER)
+
+    def close(self):
+        self.locks.close()

--- a/pkg/integrations/slime/timeslice_slime/locks.py
+++ b/pkg/integrations/slime/timeslice_slime/locks.py
@@ -1,0 +1,183 @@
+"""RoleLocks: idempotent per-role lock helper for disaggregated Slime topologies.
+
+Configuration comes from the environment:
+  TIMESLICE_JOB_ID          unique job identifier (e.g. "job-a")
+  TIMESLICE_ORCH_ADDR       orchestrator gRPC address (e.g. "localhost:50051")
+  TIMESLICE_TRAINER_GROUP   trainer pool group id (e.g. "trainers")
+  TIMESLICE_SAMPLER_GROUP   sampler pool group id (e.g. "samplers")
+
+If any variable is missing the helper runs in NO-OP mode (with a one-time warning)
+so the same image works without the time-slicing platform.
+
+Global lock order (deadlock freedom): TRAINER before SAMPLER.
+  - A job may hold SAMPLER alone, but must never REQUEST TRAINER while
+    holding SAMPLER.
+  - Dual-lock spans (weight sync, init) acquire SAMPLER while already
+    holding TRAINER.
+With only these two wait shapes a wait-for cycle is impossible.
+"""
+
+import atexit
+import os
+import sys
+import time
+
+
+def _log(msg: str) -> None:
+    print(f"[timeslice] {msg}", flush=True)
+
+
+ENV_JOB_ID = "TIMESLICE_JOB_ID"
+ENV_ORCH_ADDR = "TIMESLICE_ORCH_ADDR"
+ENV_TRAINER_GROUP = "TIMESLICE_TRAINER_GROUP"
+ENV_SAMPLER_GROUP = "TIMESLICE_SAMPLER_GROUP"
+
+TRAINER = "trainer"
+SAMPLER = "sampler"
+
+
+class RoleLocks:
+    """Idempotent per-role orchestrator locks with enforced trainer-first order.
+
+    One OrchestratorClient per (job_id, group_id), as required by the
+    orchestrator client contract.  Roles map to groups:
+      TRAINER -> trainer_group (the trainers pool)
+      SAMPLER -> sampler_group (the samplers pool)
+
+    `client_factory(orch_addr, job_id, group_id)` is injectable for tests.
+    """
+
+    def __init__(
+        self,
+        job_id: str | None,
+        orch_addr: str | None,
+        trainer_group: str | None,
+        sampler_group: str | None,
+        client_factory=None,
+    ):
+        self.job_id = job_id
+        self.orch_addr = orch_addr
+        self.groups = {TRAINER: trainer_group, SAMPLER: sampler_group}
+        self.enabled = bool(job_id and orch_addr and trainer_group and sampler_group)
+        self._held: set = set()
+        self._clients: dict = {}
+        self._closed = False
+
+        if not self.enabled:
+            _log(
+                "WARNING: disagg time-slicing disabled (missing one of "
+                f"{ENV_JOB_ID}/{ENV_ORCH_ADDR}/{ENV_TRAINER_GROUP}/{ENV_SAMPLER_GROUP}); "
+                "RoleLocks is a no-op."
+            )
+            return
+        if trainer_group == sampler_group:
+            raise ValueError(
+                f"trainer_group and sampler_group must differ (both {trainer_group!r}): "
+                "the disaggregated topology places the pools on distinct groups/nodes."
+            )
+
+        if client_factory is None:
+            from timeslice import TimeSliceOrchestratorClient
+
+            def client_factory(target, job_id, group_id):
+                return TimeSliceOrchestratorClient(target=target, job_id=job_id, group_id=group_id)
+
+        # One client per (job_id, group_id).
+        for role, group in self.groups.items():
+            self._clients[role] = client_factory(self.orch_addr, self.job_id, group)
+        _log(
+            f"job={self.job_id} connected orchestrator={self.orch_addr} "
+            f"trainer_group={trainer_group} sampler_group={sampler_group}"
+        )
+        atexit.register(self._atexit_cleanup)
+
+    @classmethod
+    def from_env(cls, client_factory=None) -> "RoleLocks":
+        return cls(
+            job_id=os.environ.get(ENV_JOB_ID),
+            orch_addr=os.environ.get(ENV_ORCH_ADDR),
+            trainer_group=os.environ.get(ENV_TRAINER_GROUP),
+            sampler_group=os.environ.get(ENV_SAMPLER_GROUP),
+            client_factory=client_factory,
+        )
+
+    # ------------------------------------------------------------------ core
+    def held(self, role: str) -> bool:
+        return role in self._held
+
+    DEFAULT_ACQUIRE_TIMEOUT_SEC = 600
+
+    def acquire(self, role: str, timeout_sec: float | None = None) -> None:
+        """Blocking-acquire the group lock for `role` (idempotent).
+
+        Raises RuntimeError on a lock-order violation: TRAINER must never be
+        requested while SAMPLER is held.
+        Raises TimeoutError if the lock is not granted within `timeout_sec`
+        seconds (default: 600).
+        """
+        if role not in (TRAINER, SAMPLER):
+            raise ValueError(f"unknown role {role!r}")
+        if role == TRAINER and SAMPLER in self._held and TRAINER not in self._held:
+            raise RuntimeError(
+                "lock-order violation: acquiring TRAINER while holding SAMPLER "
+                "(global order is trainer-first; release SAMPLER first)"
+            )
+        if not self.enabled or role in self._held:
+            return
+        if timeout_sec is None:
+            timeout_sec = self.DEFAULT_ACQUIRE_TIMEOUT_SEC
+        t0 = time.monotonic()
+        result = self._clients[role].acquire(
+            group_id=self.groups[role],
+            timeout_sec=timeout_sec,
+        )
+        waited_ms = getattr(result, "waited_ms", None)
+        if waited_ms is None:
+            waited_ms = int((time.monotonic() - t0) * 1000)
+        self._held.add(role)
+        _log(
+            f"job={self.job_id} ACQUIRE role={role} group={self.groups[role]} "
+            f"waited={waited_ms}ms context_restored={getattr(result, 'context_restored', '?')}"
+        )
+
+    def release(self, role: str) -> None:
+        """Release the group lock for `role` (idempotent; errors logged, not raised)."""
+        if not self.enabled or role not in self._held:
+            return
+        try:
+            result = self._clients[role].release(group_id=self.groups[role])
+            _log(
+                f"job={self.job_id} RELEASE role={role} group={self.groups[role]} "
+                f"pending_waiters={getattr(result, 'pending_waiters', '?')} "
+                f"snapshot_deferred={getattr(result, 'snapshot_deferred', '?')}"
+            )
+        except Exception as e:  # noqa: BLE001 - never let a release error kill the job
+            _log(f"job={self.job_id} RELEASE role={role} FAILED: {e}")
+        finally:
+            self._held.discard(role)
+
+    def release_all(self) -> None:
+        """Release everything in reverse lock order (SAMPLER first, then TRAINER)."""
+        for role in (SAMPLER, TRAINER):
+            self.release(role)
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self.release_all()
+        for role, client in self._clients.items():
+            try:
+                client.close()
+            except Exception as e:  # noqa: BLE001
+                _log(f"job={self.job_id} client close role={role} FAILED: {e}")
+        self._closed = True
+
+    # ------------------------------------------------------------- internals
+    def _atexit_cleanup(self) -> None:
+        if self._closed or not self._held:
+            return
+        _log(f"job={self.job_id} atexit: releasing held roles {sorted(self._held)}")
+        try:
+            self.close()
+        except Exception as e:  # noqa: BLE001
+            print(f"[timeslice] atexit cleanup failed: {e}", file=sys.stderr, flush=True)


### PR DESCRIPTION
Proposal: https://docs.google.com/document/d/1-JzdzHJ77fZCjgcBVfnANz1z8dipmJWA2vtJ4AzIq2w/edit?tab=t.0#heading=h.dzy9irmry6l

## Summary

Adds the timeslice-slime pip package (pkg/integrations/slime/) — a pre-built PhaseCallback that maps Slime GPU phase boundaries to orchestrator lock acquire/release.

## What is included

| File | Purpose |
|------|---------|
| timeslice_slime/callback.py | TimesliceCallback — acquires/releases orchestrator locks at phase boundaries |
| timeslice_slime/locks.py | RoleLocks — per-role lock primitives with trainer-first ordering, atexit safety, env-gated no-op |
| timeslice_slime/__init__.py | Package root |
| pyproject.toml | Package metadata |
| tests/test_callback.py | 18 lock protocol tests (sync, async, no-op, primitives) |

## How it works

The Slime fork (aishukamal/slime@feat/phase-callbacks) adds --phase-callback-path and emits on_phase_begin/on_phase_end around GPU phases. Users pass --phase-callback-path timeslice_slime.callback.TimesliceCallback — no other Slime code changes needed.

## Test plan

- [x] 18 lock protocol tests pass (python3 -m unittest)
- [x] E2E validated: sync (both pools checkpointed/restored) and async (trainer-only) on H100 cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Timeslice integration to coordinate trainer and sampler phases.
  * Added configurable role-based locking with enforced acquisition order, idempotent operations, and safe cleanup.
  * Added no-op behavior when lock configuration is unavailable.
  * Exposed the Timeslice callback for integration use.

* **Tests**
  * Added comprehensive coverage for synchronous and asynchronous workflows, overlapping roles, lock validation, release behavior, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->