### PR TITLE
[GPU-CR Selective Checkpoint 5/N]: Make checkpoint buffer sizes runtime-configurable via env vars

### DIFF
--- a/third_party/gpu-cr/CMakeLists.txt
+++ b/third_party/gpu-cr/CMakeLists.txt
@@ -113,7 +113,7 @@ target_link_options(vGPU PRIVATE -shared -fPIC)
 set(_COORD_COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/comm/share_mem.cpp
     # multi_cr_client maps worker buffers at SHM_SIZE, a runtime value
-    # since KEP-0002 (gpu_cr::Config).
+    # read from gpu_cr::Config().
     ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu_cr_config.cpp
 )
 

--- a/third_party/gpu-cr/CMakeLists.txt
+++ b/third_party/gpu-cr/CMakeLists.txt
@@ -112,6 +112,9 @@ target_link_options(vGPU PRIVATE -shared -fPIC)
 # ---------------------------------------------------------------------------
 set(_COORD_COMMON_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/comm/share_mem.cpp
+    # multi_cr_client maps worker buffers at SHM_SIZE, a runtime value
+    # since KEP-0002 (gpu_cr::Config).
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu_cr_config.cpp
 )
 
 add_executable(cr_client
@@ -141,8 +144,8 @@ target_compile_options(multi_cr_client PRIVATE -O3 -g)
 # ---------------------------------------------------------------------------
 # Tests (GPU-free; run in Dockerfile.build)
 #   gpu_cr_unit_tests        — GoogleTest unit suite for the ctl-path,
-#                              dump-format, granule-clamp and region-spec
-#                              code, plus the
+#                              dump-format, granule-clamp, region-spec and
+#                              runtime-config code, plus the
 #                              upstream-baseline control channel, buffer
 #                              mapping, fd exchange and memcpy_multi
 #   fake_workload            — GPU-free stand-in for the vGPU.so side of the
@@ -169,6 +172,7 @@ if(GPU_CR_BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/common_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/ctl_path_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/dump_format_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/gpu_cr_config_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/ipc_fd_exchange_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/memcpy_multi_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/mmap_backend_test.cpp
@@ -177,6 +181,7 @@ if(GPU_CR_BUILD_TESTS)
         # GPU-free production sources under test (upstream-baseline functions)
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backend/mmap_backend.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/comm/share_mem.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu_cr_config.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/ipc_fd_exchange.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/memcpy_multi.cpp
     )

--- a/third_party/gpu-cr/src/common.h
+++ b/third_party/gpu-cr/src/common.h
@@ -20,6 +20,8 @@
 #include <atomic>
 #include <mutex>
 
+#include "gpu_cr_config.h"
+
 #define HUGE_PAGE_SIZE (2 * 1024 * 1024)
 #define ROUND_UP_2MB(x) (((x) + (2 * 1024 * 1024 - 1)) & ~(2 * 1024 * 1024 - 1))
 
@@ -53,8 +55,6 @@ constexpr size_t GranuleClampLen(uintptr_t dev_addr, size_t len) {
 #ifndef SHM_SIZE_GB
 #define SHM_SIZE_GB 25
 #endif
-
-#include "gpu_cr_config.h"
 
 namespace gpu_cr {
 inline constexpr size_t kShmDefaultBytes =

--- a/third_party/gpu-cr/src/common.h
+++ b/third_party/gpu-cr/src/common.h
@@ -45,7 +45,7 @@ constexpr size_t GranuleClampLen(uintptr_t dev_addr, size_t len) {
 // Each GPU process allocates SHM_SIZE + STAGING_BUF_SIZE*STAGING_BUF_NUM.
 // For TP=N, total hugepage needed = N * (SHM_SIZE + 2*staging) + overhead.
 //
-// KEP-0002: these are runtime values now. The compile-time SHM_SIZE_GB
+// These are runtime values now. The compile-time SHM_SIZE_GB
 // (cmake -DSHM_SIZE_GB=40) sets the DEFAULT; GPU_CR_SHM_GB / GPU_CR_SHM_MB
 // / GPU_CR_STAGING_MB env vars override it at library load. The macros
 // below keep every historical use site source-compatible while reading
@@ -84,7 +84,7 @@ inline constexpr size_t kStagingDefaultBytes = 1UL << 30;
 // Maximum number of processes in multi-GPU checkpoint
 #define MAX_MULTI_GPU_PROCS 32
 
-#define STAGING_BUF_SIZE (gpu_cr::Config().staging_size) // default 1GB, env-overridable (KEP-0002)
+#define STAGING_BUF_SIZE (gpu_cr::Config().staging_size) // default 1GB, env-overridable
 #define STAGING_BUF_NUM 2
 
 typedef void (*sighandler_t)(int);

--- a/third_party/gpu-cr/src/common.h
+++ b/third_party/gpu-cr/src/common.h
@@ -43,12 +43,26 @@ constexpr size_t GranuleClampLen(uintptr_t dev_addr, size_t len) {
 
 // SHM_SIZE: Per-GPU checkpoint buffer on hugepages.
 // Each GPU process allocates SHM_SIZE + STAGING_BUF_SIZE*STAGING_BUF_NUM.
-// For TP=N, total hugepage needed = N * (SHM_SIZE + 2GB) + overhead.
-// Override at compile time: cmake .. -DSHM_SIZE_GB=40
+// For TP=N, total hugepage needed = N * (SHM_SIZE + 2*staging) + overhead.
+//
+// KEP-0002: these are runtime values now. The compile-time SHM_SIZE_GB
+// (cmake -DSHM_SIZE_GB=40) sets the DEFAULT; GPU_CR_SHM_GB / GPU_CR_SHM_MB
+// / GPU_CR_STAGING_MB env vars override it at library load. The macros
+// below keep every historical use site source-compatible while reading
+// the cached runtime config.
 #ifndef SHM_SIZE_GB
 #define SHM_SIZE_GB 25
 #endif
-#define SHM_SIZE ((unsigned long)SHM_SIZE_GB << 30)
+
+#include "gpu_cr_config.h"
+
+namespace gpu_cr {
+inline constexpr size_t kShmDefaultBytes =
+    static_cast<size_t>(SHM_SIZE_GB) << 30;
+inline constexpr size_t kStagingDefaultBytes = 1UL << 30;
+}  // namespace gpu_cr
+
+#define SHM_SIZE (gpu_cr::Config().shm_size)
 
 #define MAX_FILE_NUM 4096
 #define COPY_THRESHOLD (1UL << 29) // 0.5GB, when to copy from host_buf to shm
@@ -70,7 +84,7 @@ constexpr size_t GranuleClampLen(uintptr_t dev_addr, size_t len) {
 // Maximum number of processes in multi-GPU checkpoint
 #define MAX_MULTI_GPU_PROCS 32
 
-#define STAGING_BUF_SIZE (1UL << 30) // 1GB staging buffer
+#define STAGING_BUF_SIZE (gpu_cr::Config().staging_size) // default 1GB, env-overridable (KEP-0002)
 #define STAGING_BUF_NUM 2
 
 typedef void (*sighandler_t)(int);

--- a/third_party/gpu-cr/src/gpu_cr_config.cpp
+++ b/third_party/gpu-cr/src/gpu_cr_config.cpp
@@ -2,7 +2,7 @@
 
 namespace gpu_cr {
 
-// Single definition of the KEP-0002 config singleton. Function-local
+// Single definition of the buffer config singleton. Function-local
 // static: initialized on first call (init() calls it first thing, so
 // signal handlers only ever see cached values), thread-safe per C++11.
 const BufConfig& Config() {

--- a/third_party/gpu-cr/src/gpu_cr_config.cpp
+++ b/third_party/gpu-cr/src/gpu_cr_config.cpp
@@ -1,10 +1,108 @@
+#include "gpu_cr_config.h"
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+
 #include "common.h"
 
 namespace gpu_cr {
+namespace internal {
+
+long long ParseNonNegative(const char* value, bool* ok) {
+  char* end = nullptr;
+  errno = 0;
+  long long n = strtoll(value, &end, 10);
+  *ok = (end && *end == '\0' && end != value && errno != ERANGE && n >= 0);
+  return n;
+}
+
+namespace {
+
+// Largest value that survives `n << shift` and the subsequent 2MiB
+// round-up without wrapping size_t.
+long long MaxShiftable(int shift) {
+  return static_cast<long long>((SIZE_MAX - (HUGE_PAGE_SIZE - 1)) >> shift);
+}
+
+}  // namespace
+
+BufConfig Load(size_t shm_default, size_t staging_default) {
+  BufConfig cfg;
+  cfg.shm_size = shm_default;
+  cfg.staging_size = staging_default;
+  cfg.shm_deferred = false;
+
+  // Legacy names were shipped in manifests for years but never read by
+  // any code; honoring them retroactively would break working
+  // deployments, so they warn instead.
+  if (getenv("GPUCR_SHM_GB") || getenv("GPUCR_STAGING_MB")) {
+    fprintf(stderr,
+            "[gpu-cr-config] WARNING: GPUCR_SHM_GB/GPUCR_STAGING_MB were "
+            "never read by any GPU-CR version and remain ignored; use "
+            "GPU_CR_SHM_GB / GPU_CR_SHM_MB / GPU_CR_STAGING_MB\n");
+  }
+
+  const char* src = "build default";
+  const char* mb = getenv("GPU_CR_SHM_MB");
+  const char* gb = getenv("GPU_CR_SHM_GB");
+  const bool use_mb = (mb && mb[0]);
+  const char* val = use_mb ? mb : ((gb && gb[0]) ? gb : nullptr);
+  if (val) {
+    const int shift = use_mb ? 20 : 30;
+    bool ok = false;
+    long long n = ParseNonNegative(val, &ok);
+    if (!ok || n > MaxShiftable(shift)) {
+      fprintf(stderr,
+              "[gpu-cr-config] WARNING: unparsable or out-of-range "
+              "GPU_CR_SHM_%s=%s; using build default\n",
+              use_mb ? "MB" : "GB", val);
+    } else if (n == 0) {
+      cfg.shm_deferred = true;
+      // Creation size if a buffer-path op forces materialization.
+      cfg.shm_size = kShmFloorBytes;
+      src = "env (deferred)";
+    } else if ((static_cast<size_t>(n) << shift) < kShmFloorBytes) {
+      fprintf(stderr,
+              "[gpu-cr-config] WARNING: GPU_CR_SHM below the 64MiB floor "
+              "(%s); using build default\n",
+              val);
+    } else {
+      cfg.shm_size = ROUND_UP_2MB(static_cast<size_t>(n) << shift);
+      src = use_mb ? "env GPU_CR_SHM_MB" : "env GPU_CR_SHM_GB";
+    }
+  }
+
+  const char* smb = getenv("GPU_CR_STAGING_MB");
+  if (smb && smb[0]) {
+    bool ok = false;
+    long long n = ParseNonNegative(smb, &ok);
+    if (!ok || n > MaxShiftable(20) ||
+        (static_cast<size_t>(n) << 20) < kStagingFloorBytes) {
+      fprintf(stderr,
+              "[gpu-cr-config] WARNING: GPU_CR_STAGING_MB=%s unparsable, "
+              "out-of-range or below the 128MiB floor; using default\n",
+              smb);
+    } else {
+      cfg.staging_size = ROUND_UP_2MB(static_cast<size_t>(n) << 20);
+    }
+  }
+
+  fprintf(stderr,
+          "[gpu-cr-config] dump buffer %zu MiB (%s)%s, staging 2 x %zu MiB\n",
+          cfg.shm_size >> 20, src,
+          cfg.shm_deferred ? " [deferred until first buffer-path op]" : "",
+          cfg.staging_size >> 20);
+  return cfg;
+}
+
+}  // namespace internal
 
 // Single definition of the buffer config singleton. Function-local
-// static: initialized on first call (init() calls it first thing, so
-// signal handlers only ever see cached values), thread-safe per C++11.
+// static: initialized on first call (init() calls it before registering
+// any signal handler, so handlers only ever see cached values),
+// thread-safe per C++11.
 const BufConfig& Config() {
   static BufConfig cfg =
       internal::Load(kShmDefaultBytes, kStagingDefaultBytes);

--- a/third_party/gpu-cr/src/gpu_cr_config.cpp
+++ b/third_party/gpu-cr/src/gpu_cr_config.cpp
@@ -1,9 +1,12 @@
 #include "gpu_cr_config.h"
 
+#include <sys/types.h>
+
 #include <cerrno>
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <limits>
 
 #include "common.h"
 
@@ -20,10 +23,21 @@ long long ParseNonNegative(const char* value, bool* ok) {
 
 namespace {
 
-// Largest value that survives `n << shift` and the subsequent 2MiB
-// round-up without wrapping size_t.
-long long MaxShiftable(int shift) {
-  return static_cast<long long>((SIZE_MAX - (HUGE_PAGE_SIZE - 1)) >> shift);
+// Largest value that survives `n << shift`, the subsequent 2MiB round-up,
+// and every downstream consumer of the resolved size. size_t alone is not
+// enough: the extent is handed to ftruncate() as a signed off_t, and the
+// staging buffers are ftruncate'd/mmap'd as ONE file of
+// `staging * consumers` bytes, whose product must not wrap either. A value
+// beyond this bound can never be honored on this platform, so it is
+// invalid input (warn + default) — unlike a large-but-representable size,
+// which is legal and bounded only by the hugepage pool at mmap time.
+long long MaxShiftable(int shift, unsigned long long consumers) {
+  unsigned long long cap = SIZE_MAX;
+  const unsigned long long off_cap = static_cast<unsigned long long>(
+      std::numeric_limits<off_t>::max());
+  if (off_cap < cap) cap = off_cap;
+  cap /= consumers;
+  return static_cast<long long>((cap - (HUGE_PAGE_SIZE - 1)) >> shift);
 }
 
 }  // namespace
@@ -53,7 +67,7 @@ BufConfig Load(size_t shm_default, size_t staging_default) {
     const int shift = use_mb ? 20 : 30;
     bool ok = false;
     long long n = ParseNonNegative(val, &ok);
-    if (!ok || n > MaxShiftable(shift)) {
+    if (!ok || n > MaxShiftable(shift, 1)) {
       fprintf(stderr,
               "[gpu-cr-config] WARNING: unparsable or out-of-range "
               "GPU_CR_SHM_%s=%s; using build default\n",
@@ -78,7 +92,7 @@ BufConfig Load(size_t shm_default, size_t staging_default) {
   if (smb && smb[0]) {
     bool ok = false;
     long long n = ParseNonNegative(smb, &ok);
-    if (!ok || n > MaxShiftable(20) ||
+    if (!ok || n > MaxShiftable(20, STAGING_BUF_NUM) ||
         (static_cast<size_t>(n) << 20) < kStagingFloorBytes) {
       fprintf(stderr,
               "[gpu-cr-config] WARNING: GPU_CR_STAGING_MB=%s unparsable, "

--- a/third_party/gpu-cr/src/gpu_cr_config.cpp
+++ b/third_party/gpu-cr/src/gpu_cr_config.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace gpu_cr {
+
+// Single definition of the KEP-0002 config singleton. Function-local
+// static: initialized on first call (init() calls it first thing, so
+// signal handlers only ever see cached values), thread-safe per C++11.
+const BufConfig& Config() {
+  static BufConfig cfg =
+      internal::Load(kShmDefaultBytes, kStagingDefaultBytes);
+  return cfg;
+}
+
+}  // namespace gpu_cr

--- a/third_party/gpu-cr/src/gpu_cr_config.h
+++ b/third_party/gpu-cr/src/gpu_cr_config.h
@@ -5,11 +5,12 @@
 //
 // Buffer sizes come from the environment, read once and cached; the
 // compile-time macros (SHM_SIZE_GB build arg, 1GiB staging) are the
-// DEFAULTS, not literals — an env-unset SHM8-built image behaves exactly
-// like today's SHM8 image (the fleet-default rule: rolling this code out
-// must never change a deployment's footprint by itself).
+// DEFAULTS, not literals — an env-unset SHM8-built image keeps the same
+// buffer footprint as today's SHM8 image (the fleet-default rule: rolling
+// this code out must never change a deployment's footprint by itself).
 //
-//   GPU_CR_SHM_MB / GPU_CR_SHM_GB   dump buffer (MB wins if both set)
+//   GPU_CR_SHM_MB / GPU_CR_SHM_GB   dump buffer (MB wins if both set;
+//                                   an empty value counts as unset)
 //       0  = deferred: no dump-buffer mapping until a buffer-path op
 //            first needs it; it then materializes at the 64MiB floor
 //            (covers the shared_mem_fs header + IPC scratch blocks).
@@ -17,28 +18,25 @@
 //            Σ destination files.
 //   GPU_CR_STAGING_MB               each of the two DMA staging buffers
 //
+// The coordinator maps worker buffers at its own SHM_SIZE, so the
+// coordinator and its workers must run with identical GPU_CR_* env.
+//
 // No upper clamp: the hugepage pool is the real bound and mmap reports
 // ENOMEM honestly. Floors: 64MiB dump (2MiB-aligned), 128MiB staging.
-// Unparsable or below-floor values warn and fall back to the default —
-// never a silent clamp.
+// Unparsable, out-of-range, or below-floor values warn and fall back to
+// the default — never a silent clamp.
 //
 // This is a function-local-static singleton, NOT a second ELF
-// constructor: cross-TU constructor order vs init() is
-// unspecified, so init() invokes gpu_cr::Config() as its first statement
-// and the signal handlers only ever consume cached values.
+// constructor: cross-TU constructor order vs init() is unspecified, so
+// init() warms the cache before registering any signal handler, and the
+// handlers only ever consume cached values.
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <cstddef>
 
 namespace gpu_cr {
 
 inline constexpr size_t kShmFloorBytes = 64UL << 20;
 inline constexpr size_t kStagingFloorBytes = 128UL << 20;
-
-constexpr size_t AlignUp2MB(size_t x) {
-  return (x + (2UL << 20) - 1) & ~((2UL << 20) - 1);
-}
 
 struct BufConfig {
   size_t shm_size;      // dump-buffer size when (or if) materialized
@@ -48,80 +46,14 @@ struct BufConfig {
 
 namespace internal {
 
-inline long long ParseNonNegative(const char* value, bool* ok) {
-  char* end = nullptr;
-  long long n = strtoll(value, &end, 10);
-  *ok = (end && *end == '\0' && end != value && n >= 0);
-  return n;
-}
+// strtoll semantics on the front of the string: leading whitespace and an
+// optional '+' are tolerated (" 8" parses); anything after the digits is
+// rejected ("8 " is not ok). Out-of-range values (ERANGE) are not ok.
+long long ParseNonNegative(const char* value, bool* ok);
 
-inline BufConfig Load(size_t shm_default, size_t staging_default) {
-  BufConfig cfg;
-  cfg.shm_size = shm_default;
-  cfg.staging_size = staging_default;
-  cfg.shm_deferred = false;
-
-  // Legacy names were shipped in manifests for years but never read by
-  // any code; honoring them retroactively would break working
-  // deployments, so they warn instead.
-  if (getenv("GPUCR_SHM_GB") || getenv("GPUCR_STAGING_MB")) {
-    fprintf(stderr,
-            "[gpu-cr-config] WARNING: GPUCR_SHM_GB/GPUCR_STAGING_MB were "
-            "never read by any GPU-CR version and remain ignored; use "
-            "GPU_CR_SHM_GB / GPU_CR_SHM_MB / GPU_CR_STAGING_MB\n");
-  }
-
-  const char* src = "build default";
-  const char* mb = getenv("GPU_CR_SHM_MB");
-  const char* gb = getenv("GPU_CR_SHM_GB");
-  const char* val = (mb && mb[0]) ? mb : ((gb && gb[0]) ? gb : nullptr);
-  if (val) {
-    bool ok = false;
-    long long n = ParseNonNegative(val, &ok);
-    size_t bytes = ok ? static_cast<size_t>(n) << ((mb && mb[0]) ? 20 : 30) : 0;
-    if (!ok) {
-      fprintf(stderr,
-              "[gpu-cr-config] WARNING: unparsable GPU_CR_SHM_%s=%s; using "
-              "build default\n",
-              (mb && mb[0]) ? "MB" : "GB", val);
-    } else if (n == 0) {
-      cfg.shm_deferred = true;
-      // Creation size if a buffer-path op forces materialization.
-      cfg.shm_size = kShmFloorBytes;
-      src = "env (deferred)";
-    } else if (bytes < kShmFloorBytes) {
-      fprintf(stderr,
-              "[gpu-cr-config] WARNING: GPU_CR_SHM below the 64MiB floor "
-              "(%s); using build default\n",
-              val);
-    } else {
-      cfg.shm_size = AlignUp2MB(bytes);
-      src = (mb && mb[0]) ? "env GPU_CR_SHM_MB" : "env GPU_CR_SHM_GB";
-    }
-  }
-
-  const char* smb = getenv("GPU_CR_STAGING_MB");
-  if (smb && smb[0]) {
-    bool ok = false;
-    long long n = ParseNonNegative(smb, &ok);
-    size_t bytes = ok ? static_cast<size_t>(n) << 20 : 0;
-    if (!ok || bytes < kStagingFloorBytes) {
-      fprintf(stderr,
-              "[gpu-cr-config] WARNING: GPU_CR_STAGING_MB=%s unparsable or "
-              "below the 128MiB floor; using default\n",
-              smb);
-    } else {
-      cfg.staging_size = AlignUp2MB(bytes);
-    }
-  }
-
-  fprintf(stderr,
-          "[gpu-cr-config] dump buffer %zu MiB (%s)%s, staging 2 x %zu MiB\n",
-          cfg.shm_size >> 20, src,
-          cfg.shm_deferred ? " [deferred until first buffer-path op]" : "",
-          cfg.staging_size >> 20);
-  return cfg;
-}
+// Exposed for tests: a pure function of (defaults, environment), so each
+// test case gets a fresh parse. Production reads the cached Config().
+BufConfig Load(size_t shm_default, size_t staging_default);
 
 }  // namespace internal
 

--- a/third_party/gpu-cr/src/gpu_cr_config.h
+++ b/third_party/gpu-cr/src/gpu_cr_config.h
@@ -1,7 +1,7 @@
 #ifndef GPU_CR_SRC_GPU_CR_CONFIG_H_
 #define GPU_CR_SRC_GPU_CR_CONFIG_H_
 
-// KEP-0002: runtime-sizable checkpoint buffers.
+// Runtime-sizable checkpoint buffers.
 //
 // Buffer sizes come from the environment, read once and cached; the
 // compile-time macros (SHM_SIZE_GB build arg, 1GiB staging) are the
@@ -23,7 +23,7 @@
 // never a silent clamp.
 //
 // This is a function-local-static singleton, NOT a second ELF
-// constructor: cross-TU constructor order vs the GEP-0006 init() is
+// constructor: cross-TU constructor order vs init() is
 // unspecified, so init() invokes gpu_cr::Config() as its first statement
 // and the signal handlers only ever consume cached values.
 
@@ -63,7 +63,7 @@ inline BufConfig Load(size_t shm_default, size_t staging_default) {
 
   // Legacy names were shipped in manifests for years but never read by
   // any code; honoring them retroactively would break working
-  // deployments (KEP-0002 Drawback 3), so they warn instead.
+  // deployments, so they warn instead.
   if (getenv("GPUCR_SHM_GB") || getenv("GPUCR_STAGING_MB")) {
     fprintf(stderr,
             "[gpu-cr-config] WARNING: GPUCR_SHM_GB/GPUCR_STAGING_MB were "

--- a/third_party/gpu-cr/src/gpu_cr_config.h
+++ b/third_party/gpu-cr/src/gpu_cr_config.h
@@ -1,0 +1,135 @@
+#ifndef GPU_CR_SRC_GPU_CR_CONFIG_H_
+#define GPU_CR_SRC_GPU_CR_CONFIG_H_
+
+// KEP-0002: runtime-sizable checkpoint buffers.
+//
+// Buffer sizes come from the environment, read once and cached; the
+// compile-time macros (SHM_SIZE_GB build arg, 1GiB staging) are the
+// DEFAULTS, not literals — an env-unset SHM8-built image behaves exactly
+// like today's SHM8 image (the fleet-default rule: rolling this code out
+// must never change a deployment's footprint by itself).
+//
+//   GPU_CR_SHM_MB / GPU_CR_SHM_GB   dump buffer (MB wins if both set)
+//       0  = deferred: no dump-buffer mapping until a buffer-path op
+//            first needs it; it then materializes at the 64MiB floor
+//            (covers the shared_mem_fs header + IPC scratch blocks).
+//            For -o-only deployments; pool rule: 2×staging + 64MiB +
+//            Σ destination files.
+//   GPU_CR_STAGING_MB               each of the two DMA staging buffers
+//
+// No upper clamp: the hugepage pool is the real bound and mmap reports
+// ENOMEM honestly. Floors: 64MiB dump (2MiB-aligned), 128MiB staging.
+// Unparsable or below-floor values warn and fall back to the default —
+// never a silent clamp.
+//
+// This is a function-local-static singleton, NOT a second ELF
+// constructor: cross-TU constructor order vs the GEP-0006 init() is
+// unspecified, so init() invokes gpu_cr::Config() as its first statement
+// and the signal handlers only ever consume cached values.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+namespace gpu_cr {
+
+inline constexpr size_t kShmFloorBytes = 64UL << 20;
+inline constexpr size_t kStagingFloorBytes = 128UL << 20;
+
+constexpr size_t AlignUp2MB(size_t x) {
+  return (x + (2UL << 20) - 1) & ~((2UL << 20) - 1);
+}
+
+struct BufConfig {
+  size_t shm_size;      // dump-buffer size when (or if) materialized
+  size_t staging_size;  // per staging buffer (two are allocated)
+  bool shm_deferred;    // GPU_CR_SHM_*=0: create only on first use
+};
+
+namespace internal {
+
+inline long long ParseNonNegative(const char* value, bool* ok) {
+  char* end = nullptr;
+  long long n = strtoll(value, &end, 10);
+  *ok = (end && *end == '\0' && end != value && n >= 0);
+  return n;
+}
+
+inline BufConfig Load(size_t shm_default, size_t staging_default) {
+  BufConfig cfg;
+  cfg.shm_size = shm_default;
+  cfg.staging_size = staging_default;
+  cfg.shm_deferred = false;
+
+  // Legacy names were shipped in manifests for years but never read by
+  // any code; honoring them retroactively would break working
+  // deployments (KEP-0002 Drawback 3), so they warn instead.
+  if (getenv("GPUCR_SHM_GB") || getenv("GPUCR_STAGING_MB")) {
+    fprintf(stderr,
+            "[gpu-cr-config] WARNING: GPUCR_SHM_GB/GPUCR_STAGING_MB were "
+            "never read by any GPU-CR version and remain ignored; use "
+            "GPU_CR_SHM_GB / GPU_CR_SHM_MB / GPU_CR_STAGING_MB\n");
+  }
+
+  const char* src = "build default";
+  const char* mb = getenv("GPU_CR_SHM_MB");
+  const char* gb = getenv("GPU_CR_SHM_GB");
+  const char* val = (mb && mb[0]) ? mb : ((gb && gb[0]) ? gb : nullptr);
+  if (val) {
+    bool ok = false;
+    long long n = ParseNonNegative(val, &ok);
+    size_t bytes = ok ? static_cast<size_t>(n) << ((mb && mb[0]) ? 20 : 30) : 0;
+    if (!ok) {
+      fprintf(stderr,
+              "[gpu-cr-config] WARNING: unparsable GPU_CR_SHM_%s=%s; using "
+              "build default\n",
+              (mb && mb[0]) ? "MB" : "GB", val);
+    } else if (n == 0) {
+      cfg.shm_deferred = true;
+      // Creation size if a buffer-path op forces materialization.
+      cfg.shm_size = kShmFloorBytes;
+      src = "env (deferred)";
+    } else if (bytes < kShmFloorBytes) {
+      fprintf(stderr,
+              "[gpu-cr-config] WARNING: GPU_CR_SHM below the 64MiB floor "
+              "(%s); using build default\n",
+              val);
+    } else {
+      cfg.shm_size = AlignUp2MB(bytes);
+      src = (mb && mb[0]) ? "env GPU_CR_SHM_MB" : "env GPU_CR_SHM_GB";
+    }
+  }
+
+  const char* smb = getenv("GPU_CR_STAGING_MB");
+  if (smb && smb[0]) {
+    bool ok = false;
+    long long n = ParseNonNegative(smb, &ok);
+    size_t bytes = ok ? static_cast<size_t>(n) << 20 : 0;
+    if (!ok || bytes < kStagingFloorBytes) {
+      fprintf(stderr,
+              "[gpu-cr-config] WARNING: GPU_CR_STAGING_MB=%s unparsable or "
+              "below the 128MiB floor; using default\n",
+              smb);
+    } else {
+      cfg.staging_size = AlignUp2MB(bytes);
+    }
+  }
+
+  fprintf(stderr,
+          "[gpu-cr-config] dump buffer %zu MiB (%s)%s, staging 2 x %zu MiB\n",
+          cfg.shm_size >> 20, src,
+          cfg.shm_deferred ? " [deferred until first buffer-path op]" : "",
+          cfg.staging_size >> 20);
+  return cfg;
+}
+
+}  // namespace internal
+
+// Cached singleton; defaults come from the including translation unit's
+// build configuration (common.h) so this header stays macro-order
+// independent.
+const BufConfig& Config();
+
+}  // namespace gpu_cr
+
+#endif  // GPU_CR_SRC_GPU_CR_CONFIG_H_

--- a/third_party/gpu-cr/src/gpu_cr_config.h
+++ b/third_party/gpu-cr/src/gpu_cr_config.h
@@ -22,7 +22,11 @@
 // coordinator and its workers must run with identical GPU_CR_* env.
 //
 // No upper clamp: the hugepage pool is the real bound and mmap reports
-// ENOMEM honestly. Floors: 64MiB dump (2MiB-aligned), 128MiB staging.
+// ENOMEM honestly. The only "too big" that is rejected at parse time is
+// a size the platform cannot represent at all — beyond signed off_t
+// (ftruncate's extent type), or a staging size whose x2 buffer total
+// would wrap size_t; such values could never be honored on any pool.
+// Floors: 64MiB dump (2MiB-aligned), 128MiB staging.
 // Unparsable, out-of-range, or below-floor values warn and fall back to
 // the default — never a silent clamp.
 //

--- a/third_party/gpu-cr/src/vGPU.cpp
+++ b/third_party/gpu-cr/src/vGPU.cpp
@@ -729,6 +729,11 @@ void cr_ipc_signal_handler(int signum) {
 // Library constructor: register all signal handlers
 // ---------------------------------------------------------------------------
 __attribute__((constructor)) void init() {
+    // Resolve buffer config FIRST — a function-local-static
+    // singleton invoked here (not a second ELF constructor, whose order vs
+    // this one would be unspecified). Signal handlers only read the cache.
+    gpu_cr::Config();
+
     fprintf(stderr, "[vGPU] Library loaded! Registering signal handlers...\n");
     fprintf(stderr, "[vGPU] Multi-GPU CR support enabled (IPC hook mode)\n");
     fflush(stderr);

--- a/third_party/gpu-cr/tests/e2e/run_e2e.sh
+++ b/third_party/gpu-cr/tests/e2e/run_e2e.sh
@@ -3,13 +3,19 @@
 #
 # Drives a real CUDA workload under LD_PRELOAD through the checkpoint/
 # restore surface, gating on byte-identical GPU memory after every restore:
+#   G0  runtime buffer config honored: provenance line printed at library
+#       load (before any CR signal exists) + the dump buffer's physical
+#       extent matches the env-requested size
 #   G1  baseline pattern verify
 #   G2  full checkpoint/restore data plane + verify (stubbed toggle unless
 #       E2E_FULL_TOGGLE=1 and a real cuda-checkpoint is on PATH)
+#   G3  below-floor GPU_CR_SHM_MB warns at load and falls back to the
+#       build default; the workload stays healthy
 #
 # Required env: CR_CLIENT, WORKLOAD, VGPU_SO, STORE.
-# Optional env: E2E_NUM_BUFFERS, E2E_BUFFER_MB, CR_TIMEOUT (seconds per
-# cr_client call, default 120).
+# Optional env: E2E_NUM_BUFFERS, E2E_BUFFER_MB,
+#               GPU_CR_SHM_MB (defaults to a size fitting the buffers),
+#               CR_TIMEOUT (seconds per cr_client call, default 120).
 set -u
 HERE=$(dirname "$(readlink -f "$0")")
 . "$HERE/e2e_lib.sh"
@@ -17,6 +23,12 @@ HERE=$(dirname "$(readlink -f "$0")")
 : "${CR_CLIENT:?}" "${WORKLOAD:?}" "${VGPU_SO:?}" "${STORE:?}"
 NUM_BUFFERS=${E2E_NUM_BUFFERS:-4}
 BUFFER_MB=${E2E_BUFFER_MB:-64}
+# Dump buffer: extents + 2MiB header + slack.
+SHM_MB=${GPU_CR_SHM_MB:-$((NUM_BUFFERS * BUFFER_MB + 128))}
+# What the library must actually allocate: the env value rounded up to the
+# 2MiB hugepage granule. G0b compares the dump file's real extent to this.
+SHM_BYTES=$(( (SHM_MB * 1048576 + 2097151) / 2097152 * 2097152 ))
+SHM_MIB=$((SHM_BYTES / 1048576))
 
 PASS=0; FAIL=0
 gate() {
@@ -26,20 +38,59 @@ gate() {
 }
 cr() { env EXPORT_FILE_PATH="$STORE" timeout "${CR_TIMEOUT:-120}" "$CR_CLIENT" "$@"; }
 
+# The dump buffer is the one ckpt-<id>.data under $STORE that is not the
+# -host staging file; its extent is the ftruncate the workload performed
+# from the cached env config.
+dump_extent_ok() {
+    local f sz
+    for f in "$STORE"/ckpt-*.data; do
+        case "$f" in *-host.data) continue ;; esac
+        sz=$(stat -c %s "$f" 2>/dev/null) || continue
+        [ "$sz" -eq "$SHM_BYTES" ] && return 0
+        echo "dump file $f: $sz bytes, expected $SHM_BYTES" >&2
+        return 1
+    done
+    echo "no dump-buffer file under $STORE" >&2
+    return 1
+}
+
 trap 'stop_workload' EXIT
 if [ "${E2E_FULL_TOGGLE:-0}" != "1" ]; then stub_cuda_checkpoint; fi
 
 start_workload "$VGPU_SO" \
-    E2E_NUM_BUFFERS="$NUM_BUFFERS" E2E_BUFFER_MB="$BUFFER_MB" || exit 1
+    E2E_NUM_BUFFERS="$NUM_BUFFERS" E2E_BUFFER_MB="$BUFFER_MB" \
+    GPU_CR_SHM_MB="$SHM_MB" || exit 1
 echo "workload up: pid=$WL_PID (run dir $RUN)"
+
+# G0a runs BEFORE any cr_client call on purpose: the provenance line must
+# come from library load, not from the first CR signal.
+gate "G0a env config parsed at load" \
+    grep -qF "[gpu-cr-config] dump buffer ${SHM_MIB} MiB (env GPU_CR_SHM_MB)" \
+    "$RUN/workload.stderr"
 
 cr -i -p "$WL_PID" || { echo "FATAL: init failed ($?)"; exit 1; }
 
+gate "G0b dump buffer extent matches env" dump_extent_ok
 gate "G1 baseline verify" wl_cmd verify
 
 gate "G2a full ckpt" cr -c -p "$WL_PID"
 gate "G2b full restore" cr -r -p "$WL_PID"
 gate "G2c verify after full restore" wl_cmd verify
+
+# G3: a below-floor value must warn and fall back at library load. No CR
+# signal is ever sent to this workload, so a parse deferred to the signal
+# path would produce neither line — and since init never runs, the
+# build-default-sized buffer is never allocated (the banner alone is
+# asserted; the hugepage pool stays untouched).
+stop_workload
+start_workload "$VGPU_SO" \
+    E2E_NUM_BUFFERS="$NUM_BUFFERS" E2E_BUFFER_MB="$BUFFER_MB" \
+    GPU_CR_SHM_MB=10 || exit 1
+gate "G3a below-floor value warns" \
+    grep -qF "WARNING: GPU_CR_SHM below the 64MiB floor (10)" "$RUN/workload.stderr"
+gate "G3b falls back to build default" \
+    grep -qF "MiB (build default)" "$RUN/workload.stderr"
+gate "G3c workload healthy after fallback" wl_cmd verify
 
 stop_workload
 echo

--- a/third_party/gpu-cr/tests/e2e/run_e2e.sh
+++ b/third_party/gpu-cr/tests/e2e/run_e2e.sh
@@ -44,7 +44,22 @@ cr() { env EXPORT_FILE_PATH="$STORE" timeout "${CR_TIMEOUT:-120}" "$CR_CLIENT" "
 # from earlier runs, so the check is bound to THIS workload: snapshot the
 # store before init and judge only files that appeared after — exactly one
 # must, and its extent must match.
-record_store_files() { ls "$STORE"/ckpt-*.data > "$RUN/store-pre" 2>/dev/null || :; }
+#
+# The snapshot itself fails CLOSED: an empty store is a legitimate empty
+# snapshot, but an unreadable $STORE or unwritable snapshot file aborts
+# the run — with a missing snapshot every pre-existing file would look
+# new to dump_extent_ok, and a stale file could satisfy (or wrongly
+# fail) the extent gate.
+record_store_files() {
+    : > "$RUN/store-pre" || { echo "FATAL: cannot write $RUN/store-pre" >&2; exit 1; }
+    [ -r "$STORE" ] && [ -x "$STORE" ] || { echo "FATAL: cannot read $STORE" >&2; exit 1; }
+    local f
+    for f in "$STORE"/ckpt-*.data; do
+        [ -e "$f" ] || continue    # unmatched glob literal
+        printf '%s\n' "$f" >> "$RUN/store-pre" \
+            || { echo "FATAL: cannot write $RUN/store-pre" >&2; exit 1; }
+    done
+}
 dump_extent_ok() {
     local f sz found=""
     for f in "$STORE"/ckpt-*.data; do

--- a/third_party/gpu-cr/tests/e2e/run_e2e.sh
+++ b/third_party/gpu-cr/tests/e2e/run_e2e.sh
@@ -40,17 +40,27 @@ cr() { env EXPORT_FILE_PATH="$STORE" timeout "${CR_TIMEOUT:-120}" "$CR_CLIENT" "
 
 # The dump buffer is the one ckpt-<id>.data under $STORE that is not the
 # -host staging file; its extent is the ftruncate the workload performed
-# from the cached env config.
+# from the cached env config. A shared/dirty $STORE may hold dump files
+# from earlier runs, so the check is bound to THIS workload: snapshot the
+# store before init and judge only files that appeared after — exactly one
+# must, and its extent must match.
+record_store_files() { ls "$STORE"/ckpt-*.data > "$RUN/store-pre" 2>/dev/null || :; }
 dump_extent_ok() {
-    local f sz
+    local f sz found=""
     for f in "$STORE"/ckpt-*.data; do
         case "$f" in *-host.data) continue ;; esac
-        sz=$(stat -c %s "$f" 2>/dev/null) || continue
-        [ "$sz" -eq "$SHM_BYTES" ] && return 0
-        echo "dump file $f: $sz bytes, expected $SHM_BYTES" >&2
-        return 1
+        [ -e "$f" ] || continue
+        grep -qxF "$f" "$RUN/store-pre" 2>/dev/null && continue
+        if [ -n "$found" ]; then
+            echo "multiple new dump files: $found, $f" >&2
+            return 1
+        fi
+        found=$f
     done
-    echo "no dump-buffer file under $STORE" >&2
+    [ -n "$found" ] || { echo "no new dump-buffer file under $STORE" >&2; return 1; }
+    sz=$(stat -c %s "$found" 2>/dev/null) || { echo "stat $found failed" >&2; return 1; }
+    [ "$sz" -eq "$SHM_BYTES" ] && return 0
+    echo "dump file $found: $sz bytes, expected $SHM_BYTES" >&2
     return 1
 }
 
@@ -68,6 +78,7 @@ gate "G0a env config parsed at load" \
     grep -qF "[gpu-cr-config] dump buffer ${SHM_MIB} MiB (env GPU_CR_SHM_MB)" \
     "$RUN/workload.stderr"
 
+record_store_files
 cr -i -p "$WL_PID" || { echo "FATAL: init failed ($?)"; exit 1; }
 
 gate "G0b dump buffer extent matches env" dump_extent_ok

--- a/third_party/gpu-cr/tests/unit/gpu_cr_config_test.cpp
+++ b/third_party/gpu-cr/tests/unit/gpu_cr_config_test.cpp
@@ -1,4 +1,4 @@
-// KEP-0002 unit matrix: env parsing, bounds, defaults, legacy warnings.
+// Buffer-config unit matrix: env parsing, bounds, defaults, legacy warnings.
 // Host-only (no CUDA); exercises gpu_cr::internal::Load() directly so each
 // case gets a fresh parse (the production singleton caches, by design).
 

--- a/third_party/gpu-cr/tests/unit/gpu_cr_config_test.cpp
+++ b/third_party/gpu-cr/tests/unit/gpu_cr_config_test.cpp
@@ -26,7 +26,7 @@ class ConfigLoadTest : public ::testing::Test {
   BufConfig Load() { return internal::Load(kShm8, kStg1); }
 };
 
-// Fleet-default rule (F1): env unset => the BUILD's default, exactly.
+// Fleet-default rule: env unset => the BUILD's default, exactly.
 TEST_F(ConfigLoadTest, UnsetEnvUsesBuildDefaults) {
   BufConfig c = Load();
   EXPECT_EQ(c.shm_size, kShm8);
@@ -45,13 +45,20 @@ TEST_F(ConfigLoadTest, ShmMbWinsOverGb) {
   EXPECT_EQ(Load().shm_size, 300UL << 20);
 }
 
-// No upper clamp (F5): values above the old 25GiB literal are honored.
+// An empty value counts as unset: MB="" must not shadow GB.
+TEST_F(ConfigLoadTest, EmptyMbFallsThroughToGb) {
+  setenv("GPU_CR_SHM_MB", "", 1);
+  setenv("GPU_CR_SHM_GB", "12", 1);
+  EXPECT_EQ(Load().shm_size, 12UL << 30);
+}
+
+// No upper clamp: values above the old 25GiB literal are honored.
 TEST_F(ConfigLoadTest, NoUpperClamp) {
   setenv("GPU_CR_SHM_GB", "40", 1);
   EXPECT_EQ(Load().shm_size, 40UL << 30);
 }
 
-// Floor (F5): below 64MiB -> default with warning, never a clamp.
+// Floor: below 64MiB -> default with warning, never a clamp.
 TEST_F(ConfigLoadTest, BelowFloorFallsBackToDefault) {
   setenv("GPU_CR_SHM_MB", "10", 1);
   BufConfig c = Load();
@@ -59,9 +66,24 @@ TEST_F(ConfigLoadTest, BelowFloorFallsBackToDefault) {
   EXPECT_FALSE(c.shm_deferred);
 }
 
+// The floor itself is accepted: 64MiB is valid, not "below 64MiB".
+TEST_F(ConfigLoadTest, ExactShmFloorAccepted) {
+  setenv("GPU_CR_SHM_MB", "64", 1);
+  EXPECT_EQ(Load().shm_size, kShmFloorBytes);
+}
+
 // Deferred mode (=0) stays special: not subsumed by the floor.
 TEST_F(ConfigLoadTest, ZeroMeansDeferredAtFloor) {
   setenv("GPU_CR_SHM_GB", "0", 1);
+  BufConfig c = Load();
+  EXPECT_TRUE(c.shm_deferred);
+  EXPECT_EQ(c.shm_size, kShmFloorBytes);
+}
+
+// The MB spelling takes the other arm of the var selection; 0 must mean
+// deferred there too.
+TEST_F(ConfigLoadTest, ShmMbZeroAlsoDeferred) {
+  setenv("GPU_CR_SHM_MB", "0", 1);
   BufConfig c = Load();
   EXPECT_TRUE(c.shm_deferred);
   EXPECT_EQ(c.shm_size, kShmFloorBytes);
@@ -76,6 +98,35 @@ TEST_F(ConfigLoadTest, UnparsableFallsBackToDefault) {
 
 TEST_F(ConfigLoadTest, NegativeFallsBackToDefault) {
   setenv("GPU_CR_SHM_GB", "-3", 1);
+  EXPECT_EQ(Load().shm_size, kShm8);
+}
+
+// Overflow is never silent. 2^34+1 GB would wrap the size_t shift to
+// exactly 1GiB and sail past the floor if unchecked.
+TEST_F(ConfigLoadTest, ShmGbShiftOverflowFallsBackToDefault) {
+  setenv("GPU_CR_SHM_GB", "17179869185", 1);
+  BufConfig c = Load();
+  EXPECT_EQ(c.shm_size, kShm8);
+  EXPECT_FALSE(c.shm_deferred);
+}
+
+// Beyond LLONG_MAX: strtoll saturates with ERANGE; must be rejected, not
+// accepted as LLONG_MAX.
+TEST_F(ConfigLoadTest, ShmGbErangeFallsBackToDefault) {
+  setenv("GPU_CR_SHM_GB", "99999999999999999999", 1);
+  EXPECT_EQ(Load().shm_size, kShm8);
+}
+
+// MB path wraps at n >= 2^44.
+TEST_F(ConfigLoadTest, ShmMbShiftOverflowFallsBackToDefault) {
+  setenv("GPU_CR_SHM_MB", "17592186044416", 1);
+  EXPECT_EQ(Load().shm_size, kShm8);
+}
+
+// MB within 2MiB-1 of SIZE_MAX>>20: the shift itself fits but the 2MiB
+// round-up would wrap. Must reject, not silently produce a tiny buffer.
+TEST_F(ConfigLoadTest, ShmMbAlignmentWrapFallsBackToDefault) {
+  setenv("GPU_CR_SHM_MB", "17592186044415", 1);
   EXPECT_EQ(Load().shm_size, kShm8);
 }
 
@@ -94,15 +145,37 @@ TEST_F(ConfigLoadTest, StagingBelowFloorFallsBackToDefault) {
   EXPECT_EQ(Load().staging_size, kStg1);
 }
 
+TEST_F(ConfigLoadTest, ExactStagingFloorAccepted) {
+  setenv("GPU_CR_STAGING_MB", "128", 1);
+  EXPECT_EQ(Load().staging_size, kStagingFloorBytes);
+}
+
+TEST_F(ConfigLoadTest, StagingAlignsUpTo2MiB) {
+  setenv("GPU_CR_STAGING_MB", "129", 1);
+  EXPECT_EQ(Load().staging_size, 130UL << 20);
+}
+
 TEST_F(ConfigLoadTest, StagingNoUpperBound) {
   setenv("GPU_CR_STAGING_MB", "2048", 1);
   EXPECT_EQ(Load().staging_size, 2048UL << 20);
 }
 
-// Legacy names: never honored (values ignored), only warned about.
-TEST_F(ConfigLoadTest, LegacyNamesIgnored) {
+TEST_F(ConfigLoadTest, StagingOverflowFallsBackToDefault) {
+  setenv("GPU_CR_STAGING_MB", "17592186044416", 1);
+  EXPECT_EQ(Load().staging_size, kStg1);
+}
+
+// Legacy names: never honored (values ignored) for either field, and the
+// warning that says so actually fires.
+TEST_F(ConfigLoadTest, LegacyNamesIgnoredAndWarned) {
   setenv("GPUCR_SHM_GB", "60", 1);
-  EXPECT_EQ(Load().shm_size, kShm8);
+  setenv("GPUCR_STAGING_MB", "999", 1);
+  testing::internal::CaptureStderr();
+  BufConfig c = Load();
+  std::string err = testing::internal::GetCapturedStderr();
+  EXPECT_EQ(c.shm_size, kShm8);
+  EXPECT_EQ(c.staging_size, kStg1);
+  EXPECT_NE(err.find("never read by any GPU-CR version"), std::string::npos);
 }
 
 TEST_F(ConfigLoadTest, ParseNonNegativeRejectsTrailingGarbage) {
@@ -117,12 +190,14 @@ TEST_F(ConfigLoadTest, ParseNonNegativeRejectsTrailingGarbage) {
   EXPECT_FALSE(ok);
 }
 
-TEST(AlignUp2MBTest, Boundaries) {
-  constexpr size_t k2MB = 2UL << 20;
-  EXPECT_EQ(AlignUp2MB(0), 0u);
-  EXPECT_EQ(AlignUp2MB(1), k2MB);
-  EXPECT_EQ(AlignUp2MB(k2MB), k2MB);
-  EXPECT_EQ(AlignUp2MB(k2MB + 1), 2 * k2MB);
+// Pins the documented strtoll asymmetry: leading whitespace parses,
+// trailing whitespace does not.
+TEST_F(ConfigLoadTest, ParseNonNegativeStrtollFrontTolerance) {
+  bool ok = false;
+  EXPECT_EQ(internal::ParseNonNegative(" 8", &ok), 8);
+  EXPECT_TRUE(ok);
+  internal::ParseNonNegative("8 ", &ok);
+  EXPECT_FALSE(ok);
 }
 
 }  // namespace

--- a/third_party/gpu-cr/tests/unit/gpu_cr_config_test.cpp
+++ b/third_party/gpu-cr/tests/unit/gpu_cr_config_test.cpp
@@ -1,0 +1,129 @@
+// KEP-0002 unit matrix: env parsing, bounds, defaults, legacy warnings.
+// Host-only (no CUDA); exercises gpu_cr::internal::Load() directly so each
+// case gets a fresh parse (the production singleton caches, by design).
+
+#include "gpu_cr_config.h"
+
+#include <stdlib.h>
+
+#include "gtest/gtest.h"
+
+namespace gpu_cr {
+namespace {
+
+constexpr size_t kShm8 = 8UL << 30;  // an "SHM8 fleet build" default
+constexpr size_t kStg1 = 1UL << 30;
+
+class ConfigLoadTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    unsetenv("GPU_CR_SHM_GB");
+    unsetenv("GPU_CR_SHM_MB");
+    unsetenv("GPU_CR_STAGING_MB");
+    unsetenv("GPUCR_SHM_GB");
+    unsetenv("GPUCR_STAGING_MB");
+  }
+  BufConfig Load() { return internal::Load(kShm8, kStg1); }
+};
+
+// Fleet-default rule (F1): env unset => the BUILD's default, exactly.
+TEST_F(ConfigLoadTest, UnsetEnvUsesBuildDefaults) {
+  BufConfig c = Load();
+  EXPECT_EQ(c.shm_size, kShm8);
+  EXPECT_EQ(c.staging_size, kStg1);
+  EXPECT_FALSE(c.shm_deferred);
+}
+
+TEST_F(ConfigLoadTest, ShmGbHonored) {
+  setenv("GPU_CR_SHM_GB", "12", 1);
+  EXPECT_EQ(Load().shm_size, 12UL << 30);
+}
+
+TEST_F(ConfigLoadTest, ShmMbWinsOverGb) {
+  setenv("GPU_CR_SHM_MB", "300", 1);
+  setenv("GPU_CR_SHM_GB", "12", 1);
+  EXPECT_EQ(Load().shm_size, 300UL << 20);
+}
+
+// No upper clamp (F5): values above the old 25GiB literal are honored.
+TEST_F(ConfigLoadTest, NoUpperClamp) {
+  setenv("GPU_CR_SHM_GB", "40", 1);
+  EXPECT_EQ(Load().shm_size, 40UL << 30);
+}
+
+// Floor (F5): below 64MiB -> default with warning, never a clamp.
+TEST_F(ConfigLoadTest, BelowFloorFallsBackToDefault) {
+  setenv("GPU_CR_SHM_MB", "10", 1);
+  BufConfig c = Load();
+  EXPECT_EQ(c.shm_size, kShm8);
+  EXPECT_FALSE(c.shm_deferred);
+}
+
+// Deferred mode (=0) stays special: not subsumed by the floor.
+TEST_F(ConfigLoadTest, ZeroMeansDeferredAtFloor) {
+  setenv("GPU_CR_SHM_GB", "0", 1);
+  BufConfig c = Load();
+  EXPECT_TRUE(c.shm_deferred);
+  EXPECT_EQ(c.shm_size, kShmFloorBytes);
+}
+
+TEST_F(ConfigLoadTest, UnparsableFallsBackToDefault) {
+  setenv("GPU_CR_SHM_GB", "8x", 1);
+  BufConfig c = Load();
+  EXPECT_EQ(c.shm_size, kShm8);
+  EXPECT_FALSE(c.shm_deferred);
+}
+
+TEST_F(ConfigLoadTest, NegativeFallsBackToDefault) {
+  setenv("GPU_CR_SHM_GB", "-3", 1);
+  EXPECT_EQ(Load().shm_size, kShm8);
+}
+
+TEST_F(ConfigLoadTest, ShmAlignsUpTo2MiB) {
+  setenv("GPU_CR_SHM_MB", "129", 1);
+  EXPECT_EQ(Load().shm_size, 130UL << 20);
+}
+
+TEST_F(ConfigLoadTest, StagingHonored) {
+  setenv("GPU_CR_STAGING_MB", "256", 1);
+  EXPECT_EQ(Load().staging_size, 256UL << 20);
+}
+
+TEST_F(ConfigLoadTest, StagingBelowFloorFallsBackToDefault) {
+  setenv("GPU_CR_STAGING_MB", "64", 1);
+  EXPECT_EQ(Load().staging_size, kStg1);
+}
+
+TEST_F(ConfigLoadTest, StagingNoUpperBound) {
+  setenv("GPU_CR_STAGING_MB", "2048", 1);
+  EXPECT_EQ(Load().staging_size, 2048UL << 20);
+}
+
+// Legacy names: never honored (values ignored), only warned about.
+TEST_F(ConfigLoadTest, LegacyNamesIgnored) {
+  setenv("GPUCR_SHM_GB", "60", 1);
+  EXPECT_EQ(Load().shm_size, kShm8);
+}
+
+TEST_F(ConfigLoadTest, ParseNonNegativeRejectsTrailingGarbage) {
+  bool ok = true;
+  internal::ParseNonNegative("12abc", &ok);
+  EXPECT_FALSE(ok);
+  EXPECT_EQ(internal::ParseNonNegative("12", &ok), 12);
+  EXPECT_TRUE(ok);
+  internal::ParseNonNegative("", &ok);
+  EXPECT_FALSE(ok);
+  internal::ParseNonNegative("-1", &ok);
+  EXPECT_FALSE(ok);
+}
+
+TEST(AlignUp2MBTest, Boundaries) {
+  constexpr size_t k2MB = 2UL << 20;
+  EXPECT_EQ(AlignUp2MB(0), 0u);
+  EXPECT_EQ(AlignUp2MB(1), k2MB);
+  EXPECT_EQ(AlignUp2MB(k2MB), k2MB);
+  EXPECT_EQ(AlignUp2MB(k2MB + 1), 2 * k2MB);
+}
+
+}  // namespace
+}  // namespace gpu_cr

--- a/third_party/gpu-cr/tests/unit/gpu_cr_config_test.cpp
+++ b/third_party/gpu-cr/tests/unit/gpu_cr_config_test.cpp
@@ -130,6 +130,21 @@ TEST_F(ConfigLoadTest, ShmMbAlignmentWrapFallsBackToDefault) {
   EXPECT_EQ(Load().shm_size, kShm8);
 }
 
+// Fits size_t but not signed off_t: 2^33 GB resolves to 2^63 bytes, which
+// ftruncate() cannot represent. Must be rejected at parse, not crash the
+// workload at init.
+TEST_F(ConfigLoadTest, ShmGbOffTOverflowFallsBackToDefault) {
+  setenv("GPU_CR_SHM_GB", "8589934592", 1);  // 2^33
+  EXPECT_EQ(Load().shm_size, kShm8);
+}
+
+// The exact off_t boundary: 2^33-1 GB resolves to 2^63-2^30, the largest
+// 2MiB-aligned extent a signed 64-bit off_t can carry after round-up.
+TEST_F(ConfigLoadTest, ShmGbAtOffTBoundAccepted) {
+  setenv("GPU_CR_SHM_GB", "8589934591", 1);  // 2^33 - 1
+  EXPECT_EQ(Load().shm_size, (8589934591ULL << 30));
+}
+
 TEST_F(ConfigLoadTest, ShmAlignsUpTo2MiB) {
   setenv("GPU_CR_SHM_MB", "129", 1);
   EXPECT_EQ(Load().shm_size, 130UL << 20);
@@ -162,6 +177,28 @@ TEST_F(ConfigLoadTest, StagingNoUpperBound) {
 
 TEST_F(ConfigLoadTest, StagingOverflowFallsBackToDefault) {
   setenv("GPU_CR_STAGING_MB", "17592186044416", 1);
+  EXPECT_EQ(Load().staging_size, kStg1);
+}
+
+// The two staging buffers are ftruncate'd/mmap'd as ONE file of
+// staging x 2 bytes: 2^43 MB resolves to 2^63 per buffer, so the total
+// wraps size_t to 0 (and each buffer alone already exceeds off_t). Must
+// be rejected at parse, not discovered as a zero-extent mapping.
+TEST_F(ConfigLoadTest, StagingTotalWrapFallsBackToDefault) {
+  setenv("GPU_CR_STAGING_MB", "8796093022208", 1);  // 2^43
+  EXPECT_EQ(Load().staging_size, kStg1);
+}
+
+// The exact total-representability boundary: 2^42-2 MB rounds to
+// 2^62-2^21 per buffer; the x2 total is 2^63-2^22, still within off_t.
+// One MB more would round the total past the off_t ceiling.
+TEST_F(ConfigLoadTest, StagingAtTotalBoundAccepted) {
+  setenv("GPU_CR_STAGING_MB", "4398046511102", 1);  // 2^42 - 2
+  EXPECT_EQ(Load().staging_size, (4398046511102ULL << 20));
+}
+
+TEST_F(ConfigLoadTest, StagingJustPastTotalBoundFallsBackToDefault) {
+  setenv("GPU_CR_STAGING_MB", "4398046511103", 1);  // 2^42 - 1
   EXPECT_EQ(Load().staging_size, kStg1);
 }
 


### PR DESCRIPTION
## What does this PR do?

  GPU-CR checkpoints a workload's GPU state by `LD_PRELOAD`ing `vGPU.so` into the
  inference process; the checkpoint is staged through buffers the library allocates
  on hugepages (one large dump buffer + two DMA staging buffers per GPU worker).
  Until now those buffer sizes were compile-time constants (cmake `-DSHM_SIZE_GB=40`)
  baked into the .so.

  This PR makes them runtime-configurable via environment variables, read once when
  the library loads:

  - `GPU_CR_SHM_GB / GPU_CR_SHM_MB` — dump buffer size (0 = deferred: skip the mapping
    entirely until first use, for export-to-file-only deployments)
  - `GPU_CR_STAGING_MB` — size of each staging buffer

  Env unset → the compile-time default. Invalid or below-floor values warn and fall back to the
  default

Adds  a GPU-free unit suite (25 cases) over the parsing/fallback logic.

Adds e2e gates on a real GPU: `G0a` asserts the config provenance line is printed at
    library load, before any CR signal exists; `G0b` asserts the dump buffer's
    physical file extent equals the env-requested size; `G3` starts a workload with a
    below-floor value and asserts the warning plus build-default fallback without
    ever sending a CR signal.

<!-- Describe the changes and their purpose -->

## Why is this change needed?

For a Snapshot-Agent user, the journey today is: deploy a workload pod with
  `vGPU.so` preloaded, and the Snapshot-Agent parks/restores it on demand. The
  checkpoint buffer must be sized to the model, but since size was baked in at
  build time, switching to a differently-sized model meant rebuilding and
  republishing the `vGPU.so` image.

  With this PR, buffer size becomes a per-workload setting in the pod manifest, next
  to the hugepages resource request it must match. One image serves every model
  size; the Snapshot-Agent itself needs no change and no redeploy, it is size-blind
  (its `cr_client` trigger never reads these values). 
  

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

### Design Note
Why a self-initializing `Config() `instead of an explicit` init_CR()` call

  An alternative was a new `init_CR()` function that `vGPU.so`'s constructor calls to
  fetch the env vars into globals. We went with a cached, self-initializing
  singleton (`Config()`, a C++ function-local static, with `internal::Load()` as the
  pure parse function) for the following reason: 
  
  Initialization order is unenforceable with `init_CR()`. `SHM_SIZE/STAGING_BUF_SIZE`
     are used from multiple translation units and multiple binaries, and C++ leaves
     the initialization order of globals (and ELF constructors) across translation
     units unspecified: see the [static initialization order fiasco](https://isocpp.org/wiki/faq/ctors#static-init-order). Any use
     site reached before `init_CR()` ran would silently read stale globals. `Config()`
     is the ISO C++ FAQ's own recommended fix: https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [X] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added runtime configuration for shared-memory and staging-buffer sizes through environment variables.
  * Added safeguards including minimum-size enforcement, alignment, overflow protection, and deferred shared-memory allocation.
  * Invalid or legacy settings now produce warnings and safely fall back to default values.
  * Coordinator tools now use the configured shared-memory size consistently.

* **Tests**
  * Added unit and end-to-end coverage for configuration parsing, overrides, validation, fallback behavior, and checkpoint buffer sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->