### PR TITLE
[GPU-CR Selective Checkpoint 1/N]: Make vGPU.so safe to run inside a live process

### DIFF
--- a/third_party/gpu-cr/src/GPUs/GPU.h
+++ b/third_party/gpu-cr/src/GPUs/GPU.h
@@ -73,6 +73,9 @@ public:
     
     virtual int externalRestore(int pid) = 0;
     
+    virtual int pushContext() { return 0; }
+    virtual int popContext() { return 0; }
+    
     virtual GPUVendor getVendor() const = 0;
     
     virtual std::string getVendorName() const = 0;

--- a/third_party/gpu-cr/src/GPUs/NVIDIA/nv.cpp
+++ b/third_party/gpu-cr/src/GPUs/NVIDIA/nv.cpp
@@ -1,6 +1,8 @@
 #include "nv.h"
 #include "../../common.h"
 #include <dlfcn.h>
+#include <pthread.h>
+#include <csignal>
 #include <cstdio>
 #include <cstdlib>
 #include <stdexcept>
@@ -13,8 +15,48 @@
 std::map<void*, size_t> allocated_memory;
 std::map<void*, int> allocated_memory_type;  // 0=cudaMalloc, 1=VMM
 
+// Guards the tracking maps against concurrent hook calls; declared extern
+// in common.h.
+std::mutex gpu_mem_mutex;
+
 // Global handle map for all VMM allocations (both from hook and nv::allocate)
 static std::map<void*, CUmemGenericAllocationHandle> global_handle_map;
+// External linkage is intentional: the IPC hooks consume this via extern.
+CUcontext g_pytorch_context = nullptr;
+
+namespace {
+
+// Blocks the CR control signals for the guard's lifetime. The CR signal
+// handlers take gpu_mem_mutex, so a process-directed CR signal delivered to
+// a thread holding the mutex would self-deadlock; masking the holding thread
+// routes delivery to a non-holding thread instead. Construct immediately
+// before the lock so reverse destruction unlocks before unmasking.
+class ScopedBlockCrSignals {
+public:
+    ScopedBlockCrSignals() {
+        sigset_t block;
+        sigemptyset(&block);
+        sigaddset(&block, CR_INIT_SIGNAL);
+        sigaddset(&block, CR_CKPT_SIGNAL);
+        sigaddset(&block, CR_RESTORE_SIGNAL);
+        sigaddset(&block, CR_IPC_TEARDOWN_SIGNAL);
+        sigaddset(&block, CR_IPC_REBUILD_SIGNAL);
+        sigaddset(&block, CR_IPC_VALIDATE_SIGNAL);
+        pthread_sigmask(SIG_BLOCK, &block, &old_mask_);
+    }
+    ~ScopedBlockCrSignals() {
+        // SIG_SETMASK with the saved set: SIG_UNBLOCK would wrongly unmask
+        // signals the caller had already blocked.
+        pthread_sigmask(SIG_SETMASK, &old_mask_, nullptr);
+    }
+    ScopedBlockCrSignals(const ScopedBlockCrSignals&) = delete;
+    ScopedBlockCrSignals& operator=(const ScopedBlockCrSignals&) = delete;
+
+private:
+    sigset_t old_mask_;
+};
+
+}  // namespace
 
 // P2P peer access hooks and helpers live in src/ipc_hooks.cpp (canonical).
 
@@ -42,7 +84,7 @@ static cudaFree_func_t real_cudaFree = nullptr;
         } \
     }
 
-nv::nv() : device_(-1), context_(nullptr), cuda_initialized_(false) {
+nv::nv() : device_(-1), context_(nullptr), cuda_initialized_(false), pushed_context_(nullptr) {
     fprintf(stderr, "[NVIDIA] Initializing NVIDIA GPU backend\n");
 }
 
@@ -150,6 +192,7 @@ int nv::registerHostMemory(void* ptr, size_t size) {
     if (err != cudaSuccess) {
         fprintf(stderr, "[NVIDIA] cudaHostRegister failed: %s\n", cudaGetErrorString(err));
         fprintf(stderr, "[NVIDIA] This is expected for hugepage-backed memory, continuing without pinned memory\n");
+        cudaGetLastError(); // Clear the error so it doesn't pollute the runtime state
         return -1;  // Return error but don't exit - non-pinned memory will still work
     }
     return 0;
@@ -207,6 +250,41 @@ int nv::remapPhysicalMemory(void* ptr, size_t size) {
         return -1;
     }
     
+    // If it is already mapped, release the old physical memory first
+    auto handle_it = global_handle_map.find(ptr);
+    if (handle_it != global_handle_map.end()) {
+        fprintf(stderr, "[NVIDIA] Pointer %p is already mapped, releasing old physical memory first...\n", ptr);
+        size_t old_size = it->second;
+        size_t old_aligned_size = ROUND_UP_2MB(old_size);
+        CUdeviceptr cuptr = reinterpret_cast<CUdeviceptr>(ptr);
+        CUresult res = cuMemUnmap(cuptr, old_aligned_size);
+        if (res != CUDA_SUCCESS) {
+            const char* error_str;
+            cuGetErrorString(res, &error_str);
+            fprintf(stderr, "[NVIDIA] cuMemUnmap failed during remap: %s\n", error_str);
+            return -1;
+        }
+        res = cuMemRelease(handle_it->second);
+        if (res != CUDA_SUCCESS) {
+            const char* error_str;
+            cuGetErrorString(res, &error_str);
+            fprintf(stderr, "[NVIDIA] cuMemRelease failed during remap: %s\n", error_str);
+            // The range is already unmapped: drop the stale handle (leaking
+            // it) so the tracking stays consistent and a retry can proceed.
+            global_handle_map.erase(handle_it);
+            return -1;
+        }
+        global_handle_map.erase(handle_it);
+    }
+
+    // The virtual reservation was sized for the tracked allocation, so a
+    // differing request cannot be honored safely.
+    if (size != it->second) {
+        fprintf(stderr, "[NVIDIA] Remap size %zu differs from tracked size %zu for %p, using tracked size\n",
+                size, it->second, ptr);
+        size = it->second;
+    }
+
     // All allocations now use VMM, so we can remap for all
     size_t aligned_size = ROUND_UP_2MB(size);
     CUdeviceptr cuptr = (CUdeviceptr)ptr;
@@ -263,11 +341,84 @@ int nv::externalRestore(int pid) {
     return externalCheckpoint(pid);
 }
 
+int nv::pushContext() {
+    ensureCudaInitialized();
+    // Snapshot under the allocation lock: the hooks write g_pytorch_context
+    // while application threads may still be allocating. Release before the
+    // driver call. The signal guard also covers handler context: a handler
+    // only auto-blocks its own signum, so a different CR signal nesting here
+    // would otherwise deadlock on the same mutex.
+    CUcontext captured = nullptr;
+    {
+        ScopedBlockCrSignals signal_block;
+        std::lock_guard<std::mutex> lock(gpu_mem_mutex);
+        captured = g_pytorch_context;
+    }
+    CUcontext target_context = context_;
+    if (captured != nullptr) {
+        target_context = captured;
+        fprintf(stderr, "[NVIDIA] Pushing captured PyTorch context: %p\n", target_context);
+    } else {
+        fprintf(stderr, "[NVIDIA] Pushing default context: %p\n", target_context);
+    }
+    CUresult res = cuCtxPushCurrent(target_context);
+    if (res != CUDA_SUCCESS) {
+        const char* error_str;
+        cuGetErrorString(res, &error_str);
+        fprintf(stderr, "[NVIDIA] cuCtxPushCurrent failed: %s\n", error_str);
+        return -1;
+    }
+    pushed_context_ = target_context;
+    return 0;
+}
+
+int nv::popContext() {
+    // Only pop what pushContext pushed: an unpaired pop (e.g. after a failed
+    // push) would detach the application's context from the thread.
+    if (pushed_context_ == nullptr) {
+        fprintf(stderr, "[NVIDIA] popContext called without an outstanding pushContext, skipping pop\n");
+        return -1;
+    }
+    CUcontext popped;
+    CUresult res = cuCtxPopCurrent(&popped);
+    if (res != CUDA_SUCCESS) {
+        const char* error_str;
+        cuGetErrorString(res, &error_str);
+        fprintf(stderr, "[NVIDIA] cuCtxPopCurrent failed: %s\n", error_str);
+        return -1;  // The push is still outstanding; keep pushed_context_ set.
+    }
+    if (popped != pushed_context_) {
+        fprintf(stderr, "[NVIDIA] Popped context %p does not match pushed context %p, restoring it\n",
+                popped, pushed_context_);
+        cuCtxPushCurrent(popped);
+        return -1;
+    }
+    pushed_context_ = nullptr;
+    fprintf(stderr, "[NVIDIA] Popped context: %p\n", popped);
+    return 0;
+}
+
 // ========== hook functions implementation ==========
 
 extern "C" cudaError_t cudaMalloc(void **devPtr, size_t size) {
-    fprintf(stderr, "[HOOK] cudaMalloc called! size=%zu\n", size);
+    ScopedBlockCrSignals signal_block;
+    std::lock_guard<std::mutex> lock(gpu_mem_mutex);
+    CUcontext curr_ctx = nullptr;
+    (void)cuCtxGetCurrent(&curr_ctx);  // Best-effort: curr_ctx stays null on failure.
+    fprintf(stderr, "[HOOK] cudaMalloc called! size=%zu, current ctx=%p\n", size, curr_ctx);
     fflush(stderr);
+
+    if (g_pytorch_context == nullptr && curr_ctx != nullptr) {
+        g_pytorch_context = curr_ctx;
+        fprintf(stderr, "[HOOK] Captured PyTorch CUDA context (fallback): %p\n", g_pytorch_context);
+        fflush(stderr);
+    }
+
+    if (size == 0) {
+        fprintf(stderr, "[HOOK] cudaMalloc(0) -> returning nullptr and cudaSuccess\n");
+        *devPtr = nullptr;
+        return cudaSuccess;
+    }
 
     nv* gpu_instance = nullptr;
 
@@ -303,6 +454,7 @@ extern "C" cudaError_t cudaMalloc(void **devPtr, size_t size) {
                 return cudaErrorInitializationError;
             }
             fprintf(stderr, "[HOOK] Using existing context, device=%d\n", device);
+            g_pytorch_context = context;
         } else {
             res = cuDeviceGet(&device, 0);
             if (res != CUDA_SUCCESS) {
@@ -319,6 +471,7 @@ extern "C" cudaError_t cudaMalloc(void **devPtr, size_t size) {
                 return cudaErrorInitializationError;
             }
             fprintf(stderr, "[HOOK] Created new context, device=%d\n", device);
+            g_pytorch_context = context;
         }
     }
     
@@ -383,11 +536,13 @@ extern "C" cudaError_t cudaMalloc(void **devPtr, size_t size) {
     
     fprintf(stderr, "[HOOK] cudaMalloc(%zu) => %p (VMM, aligned to %zu)\n", size, ptr, aligned_size);
     fflush(stderr);
-    
+
     return cudaSuccess;
 }
 
 extern "C" cudaError_t cudaFree(void* ptr) {
+    ScopedBlockCrSignals signal_block;
+    std::lock_guard<std::mutex> lock(gpu_mem_mutex);
     fprintf(stderr, "[HOOK] cudaFree(%p)\n", ptr);
     fflush(stderr);
     

--- a/third_party/gpu-cr/src/GPUs/NVIDIA/nv.cpp
+++ b/third_party/gpu-cr/src/GPUs/NVIDIA/nv.cpp
@@ -21,8 +21,10 @@ std::mutex gpu_mem_mutex;
 
 // Global handle map for all VMM allocations (both from hook and nv::allocate)
 static std::map<void*, CUmemGenericAllocationHandle> global_handle_map;
-// External linkage is intentional: the IPC hooks consume this via extern.
-CUcontext g_pytorch_context = nullptr;
+// The application's CUDA context, captured at first allocation (PyTorch's,
+// in our deployments). External linkage is intentional: the IPC hooks
+// consume this via extern.
+CUcontext g_application_context = nullptr;
 
 namespace {
 
@@ -343,7 +345,7 @@ int nv::externalRestore(int pid) {
 
 int nv::pushContext() {
     ensureCudaInitialized();
-    // Snapshot under the allocation lock: the hooks write g_pytorch_context
+    // Snapshot under the allocation lock: the hooks write g_application_context
     // while application threads may still be allocating. Release before the
     // driver call. The signal guard also covers handler context: a handler
     // only auto-blocks its own signum, so a different CR signal nesting here
@@ -352,12 +354,12 @@ int nv::pushContext() {
     {
         ScopedBlockCrSignals signal_block;
         std::lock_guard<std::mutex> lock(gpu_mem_mutex);
-        captured = g_pytorch_context;
+        captured = g_application_context;
     }
     CUcontext target_context = context_;
     if (captured != nullptr) {
         target_context = captured;
-        fprintf(stderr, "[NVIDIA] Pushing captured PyTorch context: %p\n", target_context);
+        fprintf(stderr, "[NVIDIA] Pushing captured application context: %p\n", target_context);
     } else {
         fprintf(stderr, "[NVIDIA] Pushing default context: %p\n", target_context);
     }
@@ -408,9 +410,9 @@ extern "C" cudaError_t cudaMalloc(void **devPtr, size_t size) {
     fprintf(stderr, "[HOOK] cudaMalloc called! size=%zu, current ctx=%p\n", size, curr_ctx);
     fflush(stderr);
 
-    if (g_pytorch_context == nullptr && curr_ctx != nullptr) {
-        g_pytorch_context = curr_ctx;
-        fprintf(stderr, "[HOOK] Captured PyTorch CUDA context (fallback): %p\n", g_pytorch_context);
+    if (g_application_context == nullptr && curr_ctx != nullptr) {
+        g_application_context = curr_ctx;
+        fprintf(stderr, "[HOOK] Captured application CUDA context (fallback): %p\n", g_application_context);
         fflush(stderr);
     }
 
@@ -454,7 +456,7 @@ extern "C" cudaError_t cudaMalloc(void **devPtr, size_t size) {
                 return cudaErrorInitializationError;
             }
             fprintf(stderr, "[HOOK] Using existing context, device=%d\n", device);
-            g_pytorch_context = context;
+            g_application_context = context;
         } else {
             res = cuDeviceGet(&device, 0);
             if (res != CUDA_SUCCESS) {
@@ -471,7 +473,7 @@ extern "C" cudaError_t cudaMalloc(void **devPtr, size_t size) {
                 return cudaErrorInitializationError;
             }
             fprintf(stderr, "[HOOK] Created new context, device=%d\n", device);
-            g_pytorch_context = context;
+            g_application_context = context;
         }
     }
     

--- a/third_party/gpu-cr/src/GPUs/NVIDIA/nv.cpp
+++ b/third_party/gpu-cr/src/GPUs/NVIDIA/nv.cpp
@@ -203,6 +203,8 @@ int nv::registerHostMemory(void* ptr, size_t size) {
 // ========== Checkpoint/Restore memory management implementation ==========
 
 int nv::releasePhysicalMemory(void* ptr) {
+    // Same locking contract as remapPhysicalMemory: called with gpu_mem_mutex
+    // held at operation scope by the CR handler paths; do not lock here.
     auto it = allocated_memory.find(ptr);
     if (it == allocated_memory.end()) {
         fprintf(stderr, "[NVIDIA] Warning: Pointer %p not found in allocated_memory\n", ptr);
@@ -245,6 +247,11 @@ int nv::releasePhysicalMemory(void* ptr) {
 
 
 int nv::remapPhysicalMemory(void* ptr, size_t size) {
+    // Locking contract: the caller serializes against the allocation hooks
+    // (which erase these same map entries under gpu_mem_mutex) by holding
+    // gpu_mem_mutex for the whole checkpoint/restore operation — op scope,
+    // not per pointer, because the dump path also iterates allocated_memory.
+    // Do NOT lock here: a nested lock would self-deadlock those callers.
     // Check if this pointer is in our tracking
     auto it = allocated_memory.find(ptr);
     if (it == allocated_memory.end()) {

--- a/third_party/gpu-cr/src/GPUs/NVIDIA/nv.h
+++ b/third_party/gpu-cr/src/GPUs/NVIDIA/nv.h
@@ -11,6 +11,9 @@ private:
     CUdevice device_;
     CUcontext context_;
     bool cuda_initialized_;
+    // Context pushed by the last successful pushContext(), cleared by its
+    // matching popContext(). Single slot: nested pushes are unsupported.
+    CUcontext pushed_context_;
     
     void ensureCudaInitialized();
     
@@ -43,6 +46,9 @@ public:
     // ========== external tool interfaces ==========
     int externalCheckpoint(int pid) override;
     int externalRestore(int pid) override;
+    
+    int pushContext() override;
+    int popContext() override;
     
     GPUVendor getVendor() const override { return GPUVendor::NVIDIA; }
     std::string getVendorName() const override { return "NVIDIA"; }


### PR DESCRIPTION
## What does this PR do?

- Captures the application's CUDA context once, at the first hooked `cudaMalloc (g_application_context)`.
  - Adds `pushContext()`/`popContext()` so checkpoint/restore driver work runs in that context, with strict pairing (single slot, mismatch detection) so the interrupted thread gets its context stack back exactly as it was.
  - Hardens `remapPhysicalMemory()`: releases the old physical backing when the pointer is already mapped, and clamps the request to the tracked reservation size.
  - Guards the hooks with gpu_mem_mutex plus a mask of all six CR signals, so a checkpoint signal can never be delivered to a thread holding the lock.
   - `cudaMalloc(0)` short-circuit: a zero-size request must not create a zero-size VMM reservation that later checkpoint bookkeeping trips over.
  - Clearing the `cudaHostRegister` error: the failure is expected (hugepage-backed staging memory), but the error state is sticky — without the clear, the application's next `cudaGetLastError()` reports a failure it never caused.
  - Lock + signal mask in the hooks: this is the deadlock fix itself; the only observable effect is that CR signal delivery is deferred past the critical section instead of interrupting it.

Since tests require usage of GPUs, no tests were added. However, the push/pop entry points are inert until the preloader slice calls them, there is no behavior change for now.



<!-- Describe the changes and their purpose -->

## Why is this change needed?

  Selective checkpointing dumps and restores GPU memory while the process keeps running, there is no freeze. That breaks three assumptions a normal one-shot checkpoint gets for free:

  1. The signal handler runs on some arbitrary application thread, which may not have the right CUDA context current. Driver calls made there would target the wrong context.
  2. Groups are swapped out and back in repeatedly, so restore can hit a pointer that is already mapped. Without cleanup, every swap leaks physical GPU memory or fails the map.
  3. Application threads keep allocating while a checkpoint signal can arrive at any moment. A signal landing on a thread that holds the allocation lock deadlocks the process.

  Later PRs build the selective protocol on top of these guarantees; without this layer, the selective flow is only safe on an idle process.


<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved NVIDIA GPU context handling during memory operations.
  - Added safer synchronization for GPU memory tracking.
  - Prevented potential deadlocks during control-signal handling.
  - Improved cleanup when remapping memory.
  - Cleared stale CUDA error states after unsuccessful host-memory registration.
  - Added validation for matching context push and pop operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->