### PR TITLE
Add llm-d-timeslice-verl integration package

### DIFF
--- a/pkg/integrations/verl/pyproject.toml
+++ b/pkg/integrations/verl/pyproject.toml
@@ -1,0 +1,23 @@
+[build-system]
+requires = ["setuptools>=64"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "llm-d-timeslice-verl"
+version = "0.1.0"
+description = "GPU time-slicing integration for verl fully-async RL training"
+requires-python = ">=3.10"
+dependencies = []
+
+# `import verl` auto-loads every module in the verl.plugins entry-point group;
+# importing timeslice_verl.trainer registers TimesliceFullyAsyncTrainer under
+# the trainer name "timeslice" (select it with the hydra override
+# async_training.trainer_name=timeslice; requires verl with fully-async
+# lifecycle hooks + trainer registry). The hooks are env-gated: inert unless
+# TIMESLICE_FULLY_ASYNC=1, so the same image works with and without the
+# time-slicing platform.
+[project.entry-points."verl.plugins"]
+timeslice = "timeslice_verl.trainer"
+
+[tool.setuptools]
+packages = ["timeslice_verl"]

--- a/pkg/integrations/verl/tests/test_hooks.py
+++ b/pkg/integrations/verl/tests/test_hooks.py
@@ -1,0 +1,541 @@
+"""Unit tests for timeslice_verl (pure python: no GPU, no verl, no grpc, no ray).
+
+Run:  python3 -m pytest tests/ -v
+
+What is covered:
+  * inert-without-env: every hook is a no-op unless TIMESLICE_FULLY_ASYNC=1
+  * lock transition order across the hook sequence the fully-async trainer
+    fires (init_workers -> initial param sync -> N x (sample_end ->
+    update_weights)):
+      - on_init_workers_begin acquires, on_init_workers_end yields
+      - on_sample_end acquires (per-step resume point)
+      - on_update_weights_begin is an ensure-held no-op in steady state and a
+        real acquire on the pre-fit initial-param-sync path
+      - on_update_weights_end yields only when synced=True
+      - on_save_checkpoint vetoes (returns False) when save_freq > 0
+      - on_exception releases the lock (crash-release)
+  * acquire timeout: PhaseLocks.ensure passes timeout_sec to the client
+    (default DEFAULT_ACQUIRE_TIMEOUT_SEC=600); a client TimeoutError propagates
+  * client-rename compat (OrchestratorClient -> TimeSliceOrchestratorClient)
+  * experimental TIMESLICE_EMPTY_CACHE_BEFORE_YIELD (inert by default)
+  * timeslice_verl.trainer registers under "timeslice" and wraps
+    _fit_update_weights with crash-release (against a stubbed verl trainer)
+"""
+
+import asyncio
+import importlib
+import inspect
+import os
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import timeslice_verl.hooks as hooks_mod  # noqa: E402
+import timeslice_verl.locks as locks_mod  # noqa: E402
+from timeslice_verl.hooks import TimesliceHooksMixin  # noqa: E402
+
+JOB = "job-a"
+ADDR = "orch:50051"
+GROUP = "trainers"
+
+
+class FakeAcquireResult:
+    def __init__(self, waited_ms=7, context_restored=True):
+        self.success = True
+        self.waited_ms = waited_ms
+        self.context_restored = context_restored
+
+
+class FakeYieldResult:
+    success = True
+    pending_waiters = 1
+    snapshot_deferred = False
+
+
+class FakeClient:
+    """Records acquire/release into a shared event log."""
+
+    def __init__(self, events, job_id, group_id):
+        self.events = events
+        self.job_id = job_id
+        self.group_id = group_id
+        self.closed = False
+
+    def acquire(self, group_id, timeout_sec=None):
+        assert group_id == self.group_id
+        self.last_timeout_sec = timeout_sec
+        self.events.append(("acquire", group_id))
+        return FakeAcquireResult()
+
+    def release(self, group_id):
+        assert group_id == self.group_id
+        self.events.append(("release", group_id))
+        return FakeYieldResult()
+
+    def close(self):
+        self.closed = True
+
+
+class FakeTrainer(TimesliceHooksMixin):
+    """The hooks mixin over a stand-in for verl's FullyAsyncTrainer state."""
+
+    def __init__(self, save_freq=-1, client_factory=None):
+        super().__init__(client_factory=client_factory)
+        self.current_param_version = 3
+        self.metrics = {}
+        self.config = SimpleNamespace(trainer=SimpleNamespace(save_freq=save_freq))
+
+
+@pytest.fixture
+def events():
+    return []
+
+
+@pytest.fixture
+def ts_env(monkeypatch, events):
+    """Full fully-async env + injected grpc-free client factory."""
+    monkeypatch.setenv("TIMESLICE_FULLY_ASYNC", "1")
+    monkeypatch.setenv("TIMESLICE_JOB_ID", JOB)
+    monkeypatch.setenv("TIMESLICE_ORCH_ADDR", ADDR)
+    monkeypatch.setenv("TIMESLICE_GROUP", GROUP)
+    monkeypatch.delenv(hooks_mod.ENV_EMPTY_CACHE, raising=False)
+    return SimpleNamespace(events=events)
+
+
+def make_trainer(events, save_freq=-1):
+    return FakeTrainer(
+        save_freq=save_freq,
+        client_factory=lambda target, job_id, group_id: FakeClient(events, job_id, group_id),
+    )
+
+
+# Hook sequences exactly as the fully-async trainer fires them ---------------
+# (the trainer awaits awaitable hook results; on_save_checkpoint is sync)
+
+
+def run_init_workers(t, events, fail=False):
+    async def seq():
+        await t.on_init_workers_begin()
+        events.append("orig_init_workers")
+        if fail:
+            exc = RuntimeError("init failed")
+            await t.on_exception("init_workers", exc)
+            raise exc
+        await t.on_init_workers_end()
+
+    asyncio.run(seq())
+
+
+def run_sample_end(t, events, batch_arrived=True):
+    async def seq():
+        events.append("orig_get_samples")
+        if batch_arrived:
+            # verl fires on_sample_end only after a real batch was assembled
+            # (the queue-termination shutdown path raises before the hook).
+            await t.on_sample_end()
+
+    asyncio.run(seq())
+
+
+def run_update_weights(t, events, result):
+    async def seq():
+        await t.on_update_weights_begin()
+        events.append("orig_update_weights")
+        await t.on_update_weights_end(synced=result is not None)
+
+    asyncio.run(seq())
+
+
+# ======================================================================
+# inertness
+# ======================================================================
+
+
+class TestInert:
+    def test_all_hooks_noop_without_gate(self, monkeypatch, events):
+        monkeypatch.delenv("TIMESLICE_FULLY_ASYNC", raising=False)
+        monkeypatch.setenv("TIMESLICE_JOB_ID", JOB)
+        monkeypatch.setenv("TIMESLICE_ORCH_ADDR", ADDR)
+        monkeypatch.setenv("TIMESLICE_GROUP", GROUP)
+        t = make_trainer(events)
+        run_init_workers(t, events)
+        run_sample_end(t, events)
+        run_update_weights(t, events, {"timing": 1.0})
+        # matches the base trainer's default (proceed with the save)
+        assert t.on_save_checkpoint(force=True) is True
+        asyncio.run(t.on_exception("update_weights", RuntimeError()))
+        assert [e for e in events if isinstance(e, tuple)] == []
+        assert t._locks is None  # never even built the lock layer
+
+    def test_gate_on_but_no_lock_env_is_noop_locks(self, ts_env, events, monkeypatch):
+        monkeypatch.delenv("TIMESLICE_JOB_ID")
+        t = make_trainer(events)
+        run_init_workers(t, events)
+        run_sample_end(t, events)
+        run_update_weights(t, events, {"timing": 1.0})
+        assert [e for e in events if isinstance(e, tuple)] == []
+
+
+# ======================================================================
+# lock transition order
+# ======================================================================
+
+
+class TestLockOrder:
+    def test_init_workers_acquire_then_yield(self, ts_env, events):
+        t = make_trainer(events)
+        run_init_workers(t, events)
+        assert events == [("acquire", GROUP), "orig_init_workers", ("release", GROUP)]
+
+    def test_init_workers_failure_releases(self, ts_env, events):
+        t = make_trainer(events)
+        with pytest.raises(RuntimeError):
+            run_init_workers(t, events, fail=True)
+        assert events == [("acquire", GROUP), "orig_init_workers", ("release", GROUP)]
+
+    def test_sample_end_acquires(self, ts_env, events):
+        t = make_trainer(events)
+        run_sample_end(t, events)
+        assert events == ["orig_get_samples", ("acquire", GROUP)]
+
+    def test_shutdown_no_acquire(self, ts_env, events):
+        t = make_trainer(events)
+        run_sample_end(t, events, batch_arrived=False)  # queue termination path
+        assert events == ["orig_get_samples"]
+
+    def test_update_weights_yields_only_on_real_sync(self, ts_env, events):
+        t = make_trainer(events)
+        run_sample_end(t, events)
+        del events[:]
+        run_update_weights(t, events, {"timing": 1.0})
+        # ensure-held no-op, yield after synced=True
+        assert events == ["orig_update_weights", ("release", GROUP)]
+
+    def test_update_weights_unsynced_keeps_lock(self, ts_env, events):
+        t = make_trainer(events)
+        run_sample_end(t, events)
+        del events[:]
+        run_update_weights(t, events, None)
+        assert events == ["orig_update_weights"]  # no release
+        assert "trigger_gt_1" in t._warned
+
+    def test_initial_param_sync_acquires_when_not_held(self, ts_env, events):
+        # fully_async_main calls _fit_update_weights between init_workers
+        # (after which we yielded) and fit(): ensure-held must acquire.
+        t = make_trainer(events)
+        run_init_workers(t, events)
+        del events[:]
+        run_update_weights(t, events, {"timing": 1.0})
+        assert events == [("acquire", GROUP), "orig_update_weights", ("release", GROUP)]
+
+    def test_full_step_sequence_alternates(self, ts_env, events):
+        t = make_trainer(events)
+        run_init_workers(t, events)
+        run_update_weights(t, events, {"t": 1})  # initial param sync
+        for _ in range(2):
+            run_sample_end(t, events)
+            run_update_weights(t, events, {"t": 1})
+        lock_events = [e for e in events if isinstance(e, tuple)]
+        held = False
+        for op, group in lock_events:
+            assert group == GROUP
+            if op == "acquire":
+                assert not held, f"double acquire: {lock_events}"
+                held = True
+            else:
+                assert held, f"release while not held: {lock_events}"
+                held = False
+        assert not held, f"lock leaked at end: {lock_events}"
+        assert len(lock_events) == 2 * 4  # init, initial sync, 2 steps
+
+    def test_save_checkpoint_vetoed_when_save_freq_positive(self, ts_env, events):
+        t = make_trainer(events, save_freq=5)
+        assert t.on_save_checkpoint(force=True) is False
+        assert events == []  # no lock traffic
+        assert "save_checkpoint" in t._warned
+
+    def test_save_checkpoint_allowed_when_disabled(self, ts_env, events):
+        t = make_trainer(events, save_freq=-1)
+        assert t.on_save_checkpoint(force=True) is True
+
+
+# ======================================================================
+# crash release
+# ======================================================================
+
+
+class TestCrashRelease:
+    def test_releases_held_lock(self, ts_env, events):
+        t = make_trainer(events)
+        run_sample_end(t, events)
+        exc = RuntimeError("NcclError: unhandled cuda error")
+        asyncio.run(t.on_exception("update_weights", exc))
+        assert events == ["orig_get_samples", ("acquire", GROUP), ("release", GROUP)]
+        assert not t._locks.held
+
+    def test_idempotent_when_not_held(self, ts_env, events):
+        t = make_trainer(events)
+        run_init_workers(t, events)  # ends released
+        del events[:]
+        asyncio.run(t.on_exception("fit", RuntimeError("boom")))
+        assert events == []  # nothing held -> drop_all releases nothing
+
+    def test_never_raises(self, ts_env, events):
+        t = make_trainer(events)
+        run_sample_end(t, events)
+
+        def bad_release(group_id):
+            raise ConnectionError("orchestrator gone")
+
+        t._locks._client.release = bad_release
+        asyncio.run(t.on_exception("fit", RuntimeError("orig")))  # must not raise
+        assert not t._locks.held  # still marked released locally
+
+
+# ======================================================================
+# acquire timeout
+# ======================================================================
+
+
+def make_locks(events):
+    return locks_mod.PhaseLocks(
+        job_id=JOB,
+        orch_addr=ADDR,
+        group=GROUP,
+        client_factory=lambda target, job_id, group_id: FakeClient(events, job_id, group_id),
+    )
+
+
+class TestAcquireTimeout:
+    def test_default_timeout_passed_to_client(self, events):
+        pl = make_locks(events)
+        pl.ensure()
+        assert pl._client.last_timeout_sec == locks_mod.PhaseLocks.DEFAULT_ACQUIRE_TIMEOUT_SEC == 600
+
+    def test_explicit_timeout_passed_to_client(self, events):
+        pl = make_locks(events)
+        pl.ensure(timeout_sec=42)
+        assert pl._client.last_timeout_sec == 42
+
+    def test_already_held_skips_client_call(self, events):
+        pl = make_locks(events)
+        pl.ensure()
+        pl.ensure(timeout_sec=1)  # held: no second acquire, timeout untouched
+        assert events == [("acquire", GROUP)]
+        assert pl._client.last_timeout_sec == 600
+
+    def test_client_timeout_error_propagates(self, events):
+        pl = make_locks(events)
+
+        def timed_out_acquire(group_id, timeout_sec=None):
+            raise TimeoutError(f"lock not granted within {timeout_sec}s")
+
+        pl._client.acquire = timed_out_acquire
+        with pytest.raises(TimeoutError):
+            pl.ensure()
+        assert not pl.held  # never marked held on a failed acquire
+
+    def test_timeout_error_propagates_through_hooks(self, ts_env, events):
+        t = make_trainer(events)
+
+        def timed_out_acquire(group_id, timeout_sec=None):
+            raise TimeoutError("lock not granted within 600s")
+
+        # Build the lock layer, then make the next acquire time out.
+        run_init_workers(t, events)
+        t._locks._client.acquire = timed_out_acquire
+        with pytest.raises(TimeoutError):
+            asyncio.run(t.on_sample_end())
+
+
+# ======================================================================
+# client-rename compat (PhaseLocks lazy import fallback)
+# ======================================================================
+
+
+def _fake_timeslice_module(class_name):
+    mod = types.ModuleType("timeslice")
+
+    class Client:
+        def __init__(self, target, job_id, group_id):
+            self.target = target
+            self.job_id = job_id
+            self.group_id = group_id
+
+        def acquire(self, group_id, timeout_sec=None):
+            return FakeAcquireResult()
+
+        def release(self, group_id):
+            return FakeYieldResult()
+
+        def close(self):
+            pass
+
+    Client.__name__ = class_name
+    setattr(mod, class_name, Client)
+    return mod, Client
+
+
+class TestClientRenameCompat:
+    def test_new_client_name_only(self, monkeypatch):
+        mod, cls = _fake_timeslice_module("TimeSliceOrchestratorClient")
+        assert not hasattr(mod, "OrchestratorClient")
+        monkeypatch.setitem(sys.modules, "timeslice", mod)
+        pl = locks_mod.PhaseLocks(job_id=JOB, orch_addr=ADDR, group=GROUP)
+        assert pl.enabled and isinstance(pl._client, cls)
+        assert (pl._client.target, pl._client.job_id, pl._client.group_id) == (ADDR, JOB, GROUP)
+        pl.ensure()
+        assert pl.held
+
+    def test_old_client_name_still_works(self, monkeypatch):
+        mod, cls = _fake_timeslice_module("OrchestratorClient")
+        monkeypatch.setitem(sys.modules, "timeslice", mod)
+        pl = locks_mod.PhaseLocks(job_id=JOB, orch_addr=ADDR, group=GROUP)
+        assert pl.enabled and isinstance(pl._client, cls)
+
+
+# ======================================================================
+# experimental TIMESLICE_EMPTY_CACHE_BEFORE_YIELD (inert by default)
+# ======================================================================
+
+
+def _fake_torch(events, raise_on_call=False):
+    mod = types.ModuleType("torch")
+
+    def empty_cache():
+        if raise_on_call:
+            raise RuntimeError("no CUDA context")
+        events.append("empty_cache")
+
+    mod.cuda = SimpleNamespace(empty_cache=empty_cache)
+    return mod
+
+
+class TestEmptyCacheBeforeYield:
+    def test_inert_by_default(self, ts_env, events, monkeypatch):
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch(events))
+        t = make_trainer(events)
+        run_init_workers(t, events)
+        run_sample_end(t, events)
+        run_update_weights(t, events, {"t": 1})
+        assert "empty_cache" not in events
+
+    def test_enabled_calls_before_each_yields_release(self, ts_env, events, monkeypatch):
+        monkeypatch.setenv(hooks_mod.ENV_EMPTY_CACHE, "1")
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch(events))
+        t = make_trainer(events)
+        run_init_workers(t, events)
+        assert events == [("acquire", GROUP), "orig_init_workers", "empty_cache", ("release", GROUP)]
+        del events[:]
+        run_sample_end(t, events)
+        run_update_weights(t, events, {"t": 1})
+        assert events == [
+            "orig_get_samples",
+            ("acquire", GROUP),
+            "orig_update_weights",
+            "empty_cache",
+            ("release", GROUP),
+        ]
+
+    def test_enabled_without_torch_is_safe(self, ts_env, events, monkeypatch):
+        monkeypatch.setenv(hooks_mod.ENV_EMPTY_CACHE, "1")
+        monkeypatch.setitem(sys.modules, "torch", None)  # import torch -> ImportError
+        t = make_trainer(events)
+        run_init_workers(t, events)
+        assert events == [("acquire", GROUP), "orig_init_workers", ("release", GROUP)]
+
+    def test_empty_cache_failure_never_breaks_yield(self, ts_env, events, monkeypatch):
+        monkeypatch.setenv(hooks_mod.ENV_EMPTY_CACHE, "1")
+        monkeypatch.setitem(sys.modules, "torch", _fake_torch(events, raise_on_call=True))
+        t = make_trainer(events)
+        run_init_workers(t, events)
+        assert events == [("acquire", GROUP), "orig_init_workers", ("release", GROUP)]
+
+
+# ======================================================================
+# timeslice_verl.trainer (against a stubbed verl trainer module)
+# ======================================================================
+
+
+@pytest.fixture
+def stub_verl_trainer_module(monkeypatch):
+    """Install a stub verl fully_async_trainer module and (re)import
+    timeslice_verl.trainer against it."""
+    registered = {}
+
+    class FakeFullyAsyncTrainer:
+        def __init__(self, **kwargs):
+            self.init_kwargs = kwargs
+
+        async def _fit_update_weights(self):
+            raise RuntimeError("param sync blew up")
+
+        async def _dispatch_on_exception(self, point, exc):
+            # mirror verl's helper: fire on_exception once, awaiting coroutines
+            if exc is getattr(self, "_last_on_exception_exc", None):
+                return
+            self._last_on_exception_exc = exc
+            result = self.on_exception(point, exc)
+            if inspect.isawaitable(result):
+                await result
+
+        def on_exception(self, point, exc):
+            return None
+
+    def register_trainer(name):
+        def decorator(cls):
+            registered[name] = cls
+            return cls
+
+        return decorator
+
+    for name in ("verl", "verl.experimental", "verl.experimental.fully_async_policy"):
+        mod = types.ModuleType(name)
+        mod.__path__ = []
+        monkeypatch.setitem(sys.modules, name, mod)
+    fat = types.ModuleType("verl.experimental.fully_async_policy.fully_async_trainer")
+    fat.FullyAsyncTrainer = FakeFullyAsyncTrainer
+    fat.register_trainer = register_trainer
+    monkeypatch.setitem(sys.modules, "verl.experimental.fully_async_policy.fully_async_trainer", fat)
+
+    sys.modules.pop("timeslice_verl.trainer", None)
+    trainer_mod = importlib.import_module("timeslice_verl.trainer")
+    yield SimpleNamespace(module=trainer_mod, registered=registered, base=FakeFullyAsyncTrainer)
+    sys.modules.pop("timeslice_verl.trainer", None)
+
+
+class TestTrainerRegistration:
+    def test_import_registers_timeslice_trainer(self, stub_verl_trainer_module):
+        cls = stub_verl_trainer_module.registered.get("timeslice")
+        assert cls is stub_verl_trainer_module.module.TimesliceFullyAsyncTrainer
+        assert issubclass(cls, TimesliceHooksMixin)
+        assert issubclass(cls, stub_verl_trainer_module.base)
+        # mixin first in the MRO: its hook overrides win
+        mro = cls.__mro__
+        assert mro.index(TimesliceHooksMixin) < mro.index(stub_verl_trainer_module.base)
+
+    def test_init_forwards_kwargs_and_sets_up_hooks_state(self, stub_verl_trainer_module):
+        t = stub_verl_trainer_module.registered["timeslice"](config="cfg", tokenizer="tok")
+        assert t.init_kwargs == {"config": "cfg", "tokenizer": "tok"}
+        assert t._locks is None and t._warned == set()
+
+    def test_update_weights_crash_fires_crash_release(self, stub_verl_trainer_module, ts_env, events):
+        cls = stub_verl_trainer_module.registered["timeslice"]
+        t = cls()
+        t.current_param_version = 1
+        t.metrics = {}
+        t._client_factory = lambda target, job_id, group_id: FakeClient(events, job_id, group_id)
+        # take the lock the way the pre-fit path does, then crash the sync
+        asyncio.run(t.on_update_weights_begin())
+        assert events == [("acquire", GROUP)]
+        with pytest.raises(RuntimeError, match="param sync blew up"):
+            asyncio.run(t._fit_update_weights())
+        assert events == [("acquire", GROUP), ("release", GROUP)]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/pkg/integrations/verl/timeslice_verl/__init__.py
+++ b/pkg/integrations/verl/timeslice_verl/__init__.py
@@ -1,0 +1,25 @@
+"""timeslice_verl: verl <-> llm-d-rl-time-slicing integration (fully-async).
+
+TimesliceFullyAsyncTrainer (``timeslice_verl.trainer``) subclasses verl's
+FullyAsyncTrainer, overriding its empty ``on_*`` lifecycle hooks to map the
+trainer's phase transitions onto orchestrator group-lock acquire/release, so
+two RL jobs can time-slice one shared trainer GPU. It registers under the
+trainer name ``timeslice`` via verl's fully-async trainer registry
+(``register_trainer``); the ``verl.plugins`` entry point declared in this
+package's pyproject.toml makes ``import verl`` load the registering module
+automatically. Select it with the hydra override
+``async_training.trainer_name=timeslice`` — no verl source changes and no
+monkey-patching.
+
+This module deliberately imports only the verl-free parts (the lock protocol
+lives in :class:`TimesliceHooksMixin`), so the package is importable and
+testable without verl/ray/grpc/GPU.
+
+Env-gated: the hooks are fully inert unless TIMESLICE_FULLY_ASYNC=1 (see
+hooks.py for the complete environment contract).
+"""
+
+from timeslice_verl.hooks import TimesliceHooksMixin
+from timeslice_verl.locks import PhaseLocks
+
+__all__ = ["TimesliceHooksMixin", "PhaseLocks"]

--- a/pkg/integrations/verl/timeslice_verl/hooks.py
+++ b/pkg/integrations/verl/timeslice_verl/hooks.py
@@ -1,0 +1,224 @@
+"""TimesliceHooksMixin: verl fully-async lifecycle hooks for GPU time-slicing.
+
+Maps the phase transitions of verl's fully_async_policy trainer onto a single
+orchestrator group lock (the trainers pool), so multiple RL jobs can share one
+trainer GPU via checkpoint/restore. The mixin overrides the empty ``on_*``
+template methods that verl's FullyAsyncTrainer exposes (same convention as
+the v1 trainers); ``timeslice_verl.trainer.TimesliceFullyAsyncTrainer``
+combines it with the real trainer and registers itself under the name
+``timeslice`` via verl's fully-async trainer registry. Select it with the
+hydra override ``async_training.trainer_name=timeslice``. Requires a verl
+build with fully-async lifecycle hooks + trainer registry and per-pool
+placement-group bundle resources (``ray_pg_extra_resources``).
+
+The mixin itself imports nothing from verl, so the lock protocol is testable
+without verl/ray/grpc/GPU (see tests/).
+
+Lock protocol (single trainers-pool group lock):
+
+  on_init_workers_begin        ACQUIRE (worker groups + model load touch the GPU)
+  on_init_workers_end          YIELD (trainer is checkpointed off until resumed)
+  on_sample_end                ACQUIRE (per-step resume point: a full batch was
+                               dequeued and assembled; the queue wait itself is
+                               CPU-only and runs unlocked)
+  on_update_weights_begin      ensure-held ACQUIRE (idempotent; a real acquire
+                               only for the pre-fit initial param sync, which
+                               fully_async_main runs after init_workers)
+  on_update_weights_end        YIELD iff synced (update_actor + NCCL param sync
+                               + reset_staleness complete)
+  on_save_checkpoint           veto (return False) when trainer.save_freq > 0:
+                               saving RPCs the FSDP worker, which may be
+                               checkpointed off; run with trainer.save_freq=-1
+  on_exception                 crash-release: never die holding the group lock
+
+All lock RPCs run in the CPU-only trainer driver actor (never checkpointed)
+via ``asyncio.to_thread``, so a minutes-long acquire never stalls the actor's
+event loop. Acquire failures propagate (a job must not run unlocked); release
+failures are swallowed.
+
+Environment contract:
+
+  TIMESLICE_FULLY_ASYNC=1      activation gate; the hooks are fully inert
+                               otherwise (safe to bake into images and to keep
+                               async_training.trainer_name=timeslice in shared
+                               manifests)
+  TIMESLICE_JOB_ID             unique job identifier (e.g. "job-a")
+  TIMESLICE_ORCH_ADDR          orchestrator gRPC address (e.g. "127.0.0.1:50051")
+  TIMESLICE_GROUP              trainers-pool group id (e.g. "trainers")
+                               (gate on + these missing => warn-once no-op locks)
+  TIMESLICE_EMPTY_CACHE_BEFORE_YIELD=1
+                               experimental: torch.cuda.empty_cache() right
+                               before each yield's release (best-effort probe
+                               for smaller cuda-checkpoint snapshots)
+
+Config this module depends on directly: async_training.trainer_name=timeslice
+selects the subclass (see trainer.py); trainer.save_freq=-1 is enforced by the
+on_save_checkpoint veto; ray_pg_extra_resources.* feeds placement-group
+pinning. The full required-overrides list for time-sliced runs lives in the
+verl integration guide (guides/rl-frameworks/verl/).
+"""
+
+import asyncio
+import os
+import threading
+
+from timeslice_verl.locks import PhaseLocks, _log
+
+ENV_ENABLE = "TIMESLICE_FULLY_ASYNC"
+# EXPERIMENTAL: when "1", call torch.cuda.empty_cache() immediately before each
+# yield's drop_all, to probe whether releasing cached allocator blocks shrinks
+# the cuda-checkpoint snapshot. Inert by default; never breaks training.
+ENV_EMPTY_CACHE = "TIMESLICE_EMPTY_CACHE_BEFORE_YIELD"
+
+
+def _flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes")
+
+
+def enabled() -> bool:
+    return _flag(ENV_ENABLE)
+
+
+class TimesliceHooksMixin:
+    """Lifecycle-hook overrides implementing the lock protocol above.
+
+    Mixed into verl's FullyAsyncTrainer by
+    ``timeslice_verl.trainer.TimesliceFullyAsyncTrainer`` (mixin first in the
+    MRO, so these overrides win over the trainer's empty template methods).
+    Every hook runs inside the trainer driver actor. `client_factory(target,
+    job_id, group_id)` is injectable for grpc-free tests.
+    """
+
+    def __init__(self, client_factory=None):
+        self._client_factory = client_factory
+        self._state_lock = threading.Lock()
+        self._locks: PhaseLocks | None = None
+        self._warned: set = set()
+        if enabled():
+            _log("fully_async: timeslice lifecycle hooks active (TIMESLICE_FULLY_ASYNC=1)")
+
+    # ------------------------------------------------------------ lifecycle hooks
+
+    async def on_init_workers_begin(self) -> None:
+        if not enabled():
+            return
+        await self._ensure_lock(point="init_workers")
+
+    async def on_init_workers_end(self) -> None:
+        if not enabled():
+            return
+        await self._yield_lock(point="init_workers")
+
+    async def on_sample_end(self) -> None:
+        if not enabled():
+            return
+        await self._ensure_lock(point="samples_ready")
+
+    async def on_update_weights_begin(self) -> None:
+        if not enabled():
+            return
+        # Idempotent ensure-held: a real acquire only happens for the pre-fit
+        # initial param sync (fully_async_main calls _fit_update_weights after
+        # init_workers, where we yielded). In steady state the lock is already
+        # held from on_sample_end, so this is a no-op.
+        await self._ensure_lock(point="update_weights")
+
+    async def on_update_weights_end(self, synced: bool) -> None:
+        if not enabled():
+            return
+        if synced:
+            await self._yield_lock(point="update_weights")
+        else:
+            self._warn_once(
+                "trigger_gt_1",
+                "_fit_update_weights did not sync (trigger_parameter_sync_step > 1?): "
+                "no yield this step — the trainer lock stays held across the next "
+                "queue wait. Time-slicing is designed for trigger_parameter_sync_step=1.",
+            )
+
+    def on_save_checkpoint(self, force: bool) -> bool:
+        if not enabled():
+            return True
+        save_freq = None
+        try:
+            save_freq = self.config.trainer.save_freq
+        except Exception:  # noqa: BLE001
+            save_freq = None
+        if save_freq is not None and save_freq > 0:
+            self._warn_once(
+                "save_checkpoint",
+                f"vetoing checkpoint save (save_freq={save_freq}, force={force}): "
+                "checkpoint saving is disabled under fully-async time-slicing "
+                "(the trainer worker may be checkpointed off). Set trainer.save_freq=-1.",
+            )
+            return False
+        return True
+
+    async def on_exception(self, point: str, exc: BaseException) -> None:
+        """Best-effort lock release on a crash path: a job must never die
+        holding the group lock (the orchestrator would stay pinned to it).
+        Never raises — crash hygiene must not mask the real error (the
+        trainer additionally logs and suppresses on_exception hook errors)."""
+        if not enabled():
+            return
+        try:
+            locks = self._locks
+            if locks is None or not locks.enabled:
+                return
+            _log(f"crash-release at point={point}: {exc!r:.500}")
+            await asyncio.to_thread(locks.drop_all)  # idempotent; RPC errors swallowed
+        except Exception as release_err:  # noqa: BLE001
+            # Crash hygiene must never mask the original error.
+            _log(f"crash-release failed (ignored): {release_err!r}")
+
+    # ------------------------------------------------------------ lock plumbing
+
+    def _get_locks(self) -> PhaseLocks:
+        """Lazily build the per-process lock singleton (may open a gRPC
+        channel: only call off the event loop)."""
+        if self._locks is None:
+            with self._state_lock:
+                if self._locks is None:
+                    self._locks = PhaseLocks.from_env(client_factory=self._client_factory)
+        return self._locks
+
+    async def _ensure_lock(self, point: str) -> None:
+        """Idempotent blocking acquire, run in a worker thread so the actor's
+        event loop stays free (the wait can be minutes while the other job
+        holds the group). Acquire errors propagate."""
+        locks = await asyncio.to_thread(self._get_locks)
+        await asyncio.to_thread(locks.ensure)
+
+    async def _yield_lock(self, point: str) -> None:
+        """Idempotent release (PhaseLocks.drop_all: errors logged, never
+        raised), run in a worker thread."""
+        locks = self._locks
+        if locks is None or not locks.enabled or not locks.held:
+            return
+        await asyncio.to_thread(self._maybe_empty_cache, point)  # experimental, inert by default
+        await asyncio.to_thread(locks.drop_all)
+
+    # ------------------------------------------------------------ misc
+
+    def _warn_once(self, key: str, msg: str) -> None:
+        if key not in self._warned:
+            self._warned.add(key)
+            _log(f"WARNING: {msg}")
+
+    def _maybe_empty_cache(self, point: str) -> None:
+        """EXPERIMENTAL, env-gated: best-effort torch.cuda.empty_cache() right
+        before a yield's drop_all. Never raises; no-op when disabled, when
+        torch is not importable, or when empty_cache itself fails (e.g. no
+        CUDA context — the hooks run in the CPU-only driver actor)."""
+        if not _flag(ENV_EMPTY_CACHE):
+            return
+        try:
+            import torch  # noqa: PLC0415 - only touch torch when the experiment is on
+        except Exception:  # noqa: BLE001
+            self._warn_once("empty_cache_no_torch", f"{ENV_EMPTY_CACHE}=1 but torch is not importable; skipping")
+            return
+        try:
+            torch.cuda.empty_cache()
+            _log(f"empty_cache before yield point={point} (experimental {ENV_EMPTY_CACHE}=1)")
+        except Exception as e:  # noqa: BLE001
+            self._warn_once("empty_cache_failed", f"torch.cuda.empty_cache() failed ({e!r}); continuing")

--- a/pkg/integrations/verl/timeslice_verl/locks.py
+++ b/pkg/integrations/verl/timeslice_verl/locks.py
@@ -1,0 +1,164 @@
+"""PhaseLocks: idempotent group-lock helper around the timeslice client.
+
+Configuration comes from the environment:
+  TIMESLICE_JOB_ID    unique job identifier (e.g. "job-a")
+  TIMESLICE_ORCH_ADDR node-local timeslice-orchestrator gRPC address (e.g. "127.0.0.1:50051")
+  TIMESLICE_GROUP     time-slice group id shared by the co-scheduled jobs (e.g. "trainers")
+
+If any variable is missing the helper runs in NO-OP mode (with a one-time warning)
+so the same image works without the time-slicing platform.
+"""
+
+import atexit
+import os
+import sys
+import time
+from collections.abc import Iterable
+
+ENV_JOB_ID = "TIMESLICE_JOB_ID"
+ENV_ORCH_ADDR = "TIMESLICE_ORCH_ADDR"
+ENV_GROUP = "TIMESLICE_GROUP"
+
+
+def _log(msg: str) -> None:
+    # print+flush: verl configures the root logger at WARNING, and these lines
+    # must always be visible in job logs for timeline analysis.
+    print(f"[timeslice] {msg}", flush=True)
+
+
+def _import_client():
+    """Resolve the orchestrator client class (renamed upstream at some point:
+    OrchestratorClient -> TimeSliceOrchestratorClient, API identical)."""
+    try:
+        from timeslice import OrchestratorClient  # lazy: keep import-safe without client
+
+        return OrchestratorClient
+    except ImportError:
+        from timeslice import TimeSliceOrchestratorClient
+
+        return TimeSliceOrchestratorClient
+
+
+class PhaseLocks:
+    """Idempotent acquire/release of orchestrator group locks.
+
+    ensure(groups)  - blocking-acquire every group not already held (idempotent).
+    drop_all()      - release every held group (idempotent, safe to call anytime).
+    close()         - drop_all + close the gRPC channel.
+
+    `client_factory(target, job_id, group_id)` is injectable for grpc-free tests.
+    """
+
+    def __init__(
+        self,
+        job_id: str | None,
+        orch_addr: str | None,
+        group: str | None,
+        client_factory=None,
+    ):
+        self.job_id = job_id
+        self.orch_addr = orch_addr
+        self.group = group
+        self.enabled = bool(job_id and orch_addr and group)
+        self._held: set = set()
+        self._client = None
+        self._closed = False
+
+        if not self.enabled:
+            _log(
+                "WARNING: time-slicing lock disabled (missing one of "
+                f"{ENV_JOB_ID}/{ENV_ORCH_ADDR}/{ENV_GROUP}); PhaseLocks is a no-op."
+            )
+            return
+
+        if client_factory is None:
+            client_cls = _import_client()
+
+            def client_factory(target, job_id, group_id):
+                return client_cls(target=target, job_id=job_id, group_id=group_id)
+
+        self._client = client_factory(self.orch_addr, self.job_id, self.group)
+        _log(f"job={self.job_id} connected orchestrator={self.orch_addr} group={self.group}")
+        # Best-effort safety net: never exit holding the group lock.
+        atexit.register(self._atexit_cleanup)
+
+    @classmethod
+    def from_env(cls, client_factory=None) -> "PhaseLocks":
+        return cls(
+            job_id=os.environ.get(ENV_JOB_ID),
+            orch_addr=os.environ.get(ENV_ORCH_ADDR),
+            group=os.environ.get(ENV_GROUP),
+            client_factory=client_factory,
+        )
+
+    # ------------------------------------------------------------------ core
+    @property
+    def held(self) -> bool:
+        return self.group in self._held
+
+    DEFAULT_ACQUIRE_TIMEOUT_SEC = 600
+
+    def ensure(self, groups: Iterable[str] | None = None, timeout_sec: float | None = None) -> None:
+        """Blocking-acquire each group in `groups` (default: the configured group).
+
+        Already-held groups are skipped, so calling this every step is cheap.
+        Blocks until the orchestrator grants the lock. Acquire errors propagate
+        (a job must not run unlocked because the orchestrator is unreachable).
+        Raises TimeoutError if a lock is not granted within `timeout_sec`
+        seconds (default: 600).
+        """
+        if not self.enabled:
+            return
+        if timeout_sec is None:
+            timeout_sec = self.DEFAULT_ACQUIRE_TIMEOUT_SEC
+        for g in groups if groups is not None else (self.group,):
+            if g in self._held:
+                continue
+            t0 = time.monotonic()
+            result = self._client.acquire(group_id=g, timeout_sec=timeout_sec)
+            waited_ms = getattr(result, "waited_ms", None)
+            if waited_ms is None:
+                waited_ms = int((time.monotonic() - t0) * 1000)
+            self._held.add(g)
+            _log(
+                f"job={self.job_id} ACQUIRE group={g} waited={waited_ms}ms "
+                f"context_restored={getattr(result, 'context_restored', '?')}"
+            )
+
+    def drop_all(self) -> None:
+        """Release every held group. Idempotent; release errors are logged, not raised."""
+        if not self.enabled:
+            return
+        for g in list(self._held):
+            try:
+                result = self._client.release(group_id=g)
+                _log(
+                    f"job={self.job_id} RELEASE group={g} "
+                    f"pending_waiters={getattr(result, 'pending_waiters', '?')} "
+                    f"snapshot_deferred={getattr(result, 'snapshot_deferred', '?')}"
+                )
+            except Exception as e:  # noqa: BLE001 - never let a release error kill the job
+                _log(f"job={self.job_id} RELEASE group={g} FAILED: {e}")
+            finally:
+                self._held.discard(g)
+
+    def close(self) -> None:
+        """Release everything and close the gRPC channel."""
+        if not self.enabled or self._closed:
+            return
+        self.drop_all()
+        try:
+            self._client.close()
+        except Exception as e:  # noqa: BLE001
+            _log(f"job={self.job_id} client close FAILED: {e}")
+        self._closed = True
+
+    # ------------------------------------------------------------- internals
+    def _atexit_cleanup(self) -> None:
+        if self._closed or not self._held:
+            return
+        _log(f"job={self.job_id} atexit: releasing held groups {sorted(self._held)}")
+        try:
+            self.close()
+        except Exception as e:  # noqa: BLE001
+            print(f"[timeslice] atexit cleanup failed: {e}", file=sys.stderr, flush=True)

--- a/pkg/integrations/verl/timeslice_verl/trainer.py
+++ b/pkg/integrations/verl/timeslice_verl/trainer.py
@@ -1,0 +1,49 @@
+"""TimesliceFullyAsyncTrainer: verl FullyAsyncTrainer subclass for time-slicing.
+
+Combines :class:`timeslice_verl.hooks.TimesliceHooksMixin` (the lock
+protocol; pure python) with verl's FullyAsyncTrainer, and registers the
+result under the trainer name ``timeslice``. Importing this module is all
+that is needed for registration; the package's ``verl.plugins`` entry point
+(see pyproject.toml) makes ``import verl`` do that automatically in every
+process where the package is installed.
+
+Select the trainer with the hydra override:
+
+    async_training.trainer_name=timeslice
+
+The hooks stay env-gated (inert unless TIMESLICE_FULLY_ASYNC=1), so with the
+gate off this trainer behaves exactly like the built-in FullyAsyncTrainer.
+"""
+
+from verl.experimental.fully_async_policy.fully_async_trainer import (
+    FullyAsyncTrainer,
+    register_trainer,
+)
+
+from timeslice_verl.hooks import TimesliceHooksMixin
+
+
+@register_trainer("timeslice")
+class TimesliceFullyAsyncTrainer(TimesliceHooksMixin, FullyAsyncTrainer):
+    """FullyAsyncTrainer whose lifecycle hooks drive the timeslice group lock."""
+
+    def __init__(self, **kwargs):
+        TimesliceHooksMixin.__init__(self)
+        FullyAsyncTrainer.__init__(self, **kwargs)
+
+    async def _fit_update_weights(self) -> dict | None:
+        """Crash-release coverage for the pre-fit initial param sync.
+
+        fully_async_main invokes _fit_update_weights directly (outside
+        fit(), whose catch-all fires on_exception), right after
+        init_workers — where the hooks yielded the group lock and
+        on_update_weights_begin re-acquires it. A crash in that window must
+        still release the lock. _dispatch_on_exception fires on_exception at
+        most once per escaping exception, so this never double-fires with
+        fit()'s handler during training.
+        """
+        try:
+            return await super()._fit_update_weights()
+        except BaseException as e:
+            await self._dispatch_on_exception("update_weights", e)
+            raise


### PR DESCRIPTION
Proposal: https://docs.google.com/document/d/1-JzdzHJ77fZCjgcBVfnANz1z8dipmJWA2vtJ4AzIq2w/edit?tab=t.0#heading=h.dzy9irmry6l

## Summary

Adds the timeslice-verl pip package (pkg/integrations/verl/): a thin callback consumer of verl's fully-async lifecycle hooks that maps trainer phase transitions to orchestrator lock acquire/release, so multiple RL jobs can time-slice one shared trainer GPU.

## What is included

| File | Purpose |
|------|---------|
| timeslice_verl/hooks.py | TimesliceHooksMixin: overrides the fully-async trainer's on_* lifecycle hooks with the lock protocol (acquire on init/samples-ready, yield after weight sync, crash-release) |
| timeslice_verl/locks.py | PhaseLocks: idempotent group-lock helper with acquire timeout (DEFAULT_ACQUIRE_TIMEOUT_SEC=600, raises TimeoutError), env-gated no-op |
| timeslice_verl/trainer.py | TimesliceFullyAsyncTrainer: registers under the trainer name "timeslice" via verl's fully-async trainer registry |
| timeslice_verl/__init__.py | Package root |
| pyproject.toml | Package metadata + verl.plugins entry point (import verl auto-registers the trainer) |
| tests/test_hooks.py | 29 lock protocol tests (inertness, transition order, crash release, acquire timeout, client-rename compat, trainer registration) |

## How it works

The verl fork (aishukamal/verl@feat/fully-async-lifecycle-hooks) adds empty on_* lifecycle hooks and a trainer registry to the fully-async trainer. This package is a thin consumer of those hooks: users select it with the hydra override async_training.trainer_name=timeslice, with no other verl code changes needed. The hooks are env-gated (TIMESLICE_FULLY_ASYNC=1), so the same image works without the time-slicing platform.

## Test plan

- [x] 29 lock protocol tests pass (python -m pytest tests/)
- [x] Tests exercise the real `TimesliceHooksMixin` / `TimesliceFullyAsyncTrainer` classes (verl stubbed in `sys.modules`; fakes only at the client boundary) — same methodology as #172, no logic copies
- [x] E2E validated: two fully-async RL jobs time-slicing one trainer GPU on H100 cluster

