### PR TITLE
Remove node group labels

### DIFF
--- a/guides/rl-frameworks/slime/README.md
+++ b/guides/rl-frameworks/slime/README.md
@@ -40,22 +40,18 @@ Before deploying cooperative time-slicing for Slime, ensure your Kubernetes clus
 * GPU memory capacity must be sufficient to hold the active working set of a single Slime job's trainer or sampler at any one time (since inactive jobs will have their GPU memory checkpointed and evicted).
 * Sampler/trainer node host memory capacity must be sufficient to hold the GPU memory footprint of the trainers/samplers needed for the number of parallel Slime jobs. Worker pod memory limits must account for cuda-checkpoint saving GPU state to host memory — set the pod memory limit to at least 2× the GPU memory footprint of the workload (e.g., 128Gi for a sampler using ~33GB GPU memory with two time-sliced jobs).
 
-### Node Labeling and Tainting for Time-Slice Pools
-The `timeslice` platform relies on node labels and taints to identify resource pools (groups) and isolate time-sliced workloads. For disaggregated Slime executions, label and taint your GPU nodes accordingly:
+### Node Tainting for Time-Slice Pools
+The `timeslice` platform uses a node taint to keep non-time-sliced workloads off shared accelerator nodes:
 
-* **Enable Time-Slicing & Taint Nodes**:
+* **Taint the time-slicing nodes** (prefer node-pool-level taints — hand-applied node metadata does not survive node recreation by auto-repair/upgrade):
   ```bash
-  kubectl label nodes <node-name> timeslice.io/enabled=true
   kubectl taint nodes <node-name> timeslice.io/shared=true:NoSchedule
   ```
-* **Trainer Nodes**:
-  ```bash
-  kubectl label nodes <trainer-node> group.timeslice.io/trainers=true
-  ```
-* **Sampler Nodes**:
-  ```bash
-  kubectl label nodes <sampler-node> group.timeslice.io/samplers=true
-  ```
+
+**No group node labels are needed.** Groups (`samplers`, `trainers`) are created automatically when a job first acquires their lock, and each group's node membership is discovered from where its pods are scheduled. Pod placement itself is driven by the shared DRA `ResourceClaim`s: all jobs' sampler pods reference the samplers claim and therefore co-locate on the claim's allocated GPU (and likewise for trainers), while the scheduler keeps different claims on different devices.
+
+> [!NOTE]
+> `group.timeslice.io/<group>` node labels from older setups are ignored by the platform and can be removed. If your pod templates still carry the matching `nodeSelector`s, ensure the labels exist on nodes or drop the selectors — otherwise the pods will be unschedulable.
 
 ### Shared DRA Resource Claims
 Cooperative time-slicing leverages Kubernetes **Dynamic Resource Allocation (DRA)** so multiple jobs' worker pods can share physical GPU hardware without scheduler blocking. Before submitting jobs, create shared `ResourceClaim` manifests for both the trainer and sampler pools in your target namespace:
@@ -214,7 +210,7 @@ When deploying Slime across independent Ray clusters, use KubeRay `RayJob` manif
 
 A complete disaggregated Slime workload requires defining **two separate worker groups** under `workerGroupSpecs`: one for trainers and one for rollouts (samplers). For each group:
 * **Custom Ray Resources**: Include custom resource counts in `rayStartParams` (`"{\"trainers\": 1}"` for trainers and `"{\"samplers\": 1}"` for rollouts) so that Ray placement groups can bind tasks to the appropriate worker pool.
-* **Pool-Specific Identifiers**: Ensure each worker group is configured with its corresponding node selector (`group.timeslice.io/trainers: "true"` vs. `samplers: "true"`), pod labels (`timeslice.io/group: trainers` vs. `samplers`), and shared DRA claim (`shared-trainers-gpu-claim` vs. `shared-samplers-gpu-claim`).
+* **Pool-Specific Identifiers**: Ensure each worker group is configured with its corresponding pod labels (`timeslice.io/group: trainers` vs. `samplers`) and shared DRA claim (`shared-trainers-gpu-claim` vs. `shared-samplers-gpu-claim`). The claim determines placement — no node selector is required.
 * **Time-Slicing Environment Variables**: Set `TIMESLICE_JOB_ID`, `TIMESLICE_ORCH_ADDR`, `TIMESLICE_TRAINER_GROUP`, `TIMESLICE_SAMPLER_GROUP`, and NCCL env vars in `runtimeEnvYAML`.
 
 For **async RL**, set `TIMESLICE_SAMPLER_GROUP` to a per-job value (e.g., `samplers-${JOB_NAME}`) so each job gets its own sampler group with no contention.

--- a/guides/rl-frameworks/slime/examples/async/README.md
+++ b/guides/rl-frameworks/slime/examples/async/README.md
@@ -17,16 +17,13 @@ In async mode, generation N+1 runs concurrently with training N. Sampler GPUs ar
 
 All files (launch script, RayJob template, setup script, resource claims) are shared with the sync example — only `SLIME_MODE` differs.
 
-**Note:** For async mode, the sampler node needs per-job group labels so the orchestrator can discover each job's sampler group:
-```bash
-kubectl label nodes <sampler-node> group.timeslice.io/samplers-slime-async-1=true group.timeslice.io/samplers-slime-async-2=true
-```
+**Note:** No node labels are needed for the per-job sampler groups — each group (`samplers-${JOB_NAME}`) is created automatically when the job first acquires its lock, and its node membership is discovered from where the job's sampler pods are scheduled (placement follows the shared sampler `ResourceClaim`).
 
 ---
 
 ## Quick Start
 
-Assumes the time-slicing platform is deployed ([deployment guide](../../../../deploy/)) and GPU nodes are labeled ([main guide](../../README.md)).
+Assumes the time-slicing platform is deployed ([deployment guide](../../../../deploy/)) and GPU nodes are tainted ([main guide](../../README.md)).
 
 ### 1. Apply DRA Resource Claims
 
@@ -34,15 +31,7 @@ Assumes the time-slicing platform is deployed ([deployment guide](../../../../de
 kubectl apply -f guides/rl-frameworks/slime/examples/resource-claims.yaml
 ```
 
-### 2. Label Sampler Node for Per-Job Groups
-
-```bash
-kubectl label nodes <sampler-node> \
-  group.timeslice.io/samplers-slime-async-1=true \
-  group.timeslice.io/samplers-slime-async-2=true
-```
-
-### 3. Create the ConfigMap
+### 2. Create the ConfigMap
 
 ```bash
 kubectl create configmap slime-job-script \
@@ -51,7 +40,7 @@ kubectl create configmap slime-job-script \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-### 4. Submit Two Jobs
+### 3. Submit Two Jobs
 
 ```bash
 # Job 1
@@ -66,7 +55,7 @@ sed 's/${JOB_NAME}/slime-async-2/g; s/${SLIME_MODE}/async/g; s/${SAMPLER_TS_GROU
 
 Each job gets its own sampler group (`samplers-slime-async-1`, `samplers-slime-async-2`) while sharing the `trainers` group.
 
-### 5. Monitor
+### 4. Monitor
 
 ```bash
 kubectl get rayjobs
@@ -75,14 +64,10 @@ kubectl logs <submitter-pod> | grep "\[timeslice\]"
 
 Expected: trainer lock handoffs between jobs (`ACQUIRE role=trainer waited=Xms`). Sampler acquires return immediately (~1s, no contention).
 
-### 6. Cleanup
+### 5. Cleanup
 
 ```bash
 kubectl delete rayjob slime-async-1 slime-async-2
 kubectl delete -f guides/rl-frameworks/slime/examples/resource-claims.yaml
 kubectl delete configmap slime-job-script
-# Remove per-job sampler labels
-kubectl label nodes <sampler-node> \
-  group.timeslice.io/samplers-slime-async-1- \
-  group.timeslice.io/samplers-slime-async-2-
 ```

--- a/guides/rl-frameworks/slime/examples/ray-job.yaml.template
+++ b/guides/rl-frameworks/slime/examples/ray-job.yaml.template
@@ -86,8 +86,6 @@ spec:
             timeslice.io/job-id: "${JOB_NAME}"
             timeslice.io/group: "trainers"
         spec:
-          nodeSelector:
-            group.timeslice.io/trainers: "true"
           tolerations:
           - key: "nvidia.com/gpu"
             operator: "Exists"
@@ -145,8 +143,6 @@ spec:
             timeslice.io/job-id: "${JOB_NAME}"
             timeslice.io/group: "${SAMPLER_TS_GROUP}"
         spec:
-          nodeSelector:
-            group.timeslice.io/samplers: "true"
           tolerations:
           - key: "nvidia.com/gpu"
             operator: "Exists"

--- a/guides/timeslice-orchestrator/README.md
+++ b/guides/timeslice-orchestrator/README.md
@@ -72,9 +72,9 @@ To enable time-slicing, the cluster must be configured with:
 - **Kubernetes Version:** 1.34 or later (required for DRA v1).
 - **At least one GPU node with:**
   - **NVIDIA Driver:** 565 or later (required for DRA Driver).
-  - **Labels & Taints:** `timeslice.io/enabled=true` and tainted with `timeslice.io/shared=true:NoSchedule` to isolate time-slicing workloads.
-  - **Group Labels:** `group.timeslice.io/<group-id>=true` (e.g., `group.timeslice.io/group-ab-sampler=true`) to schedule grouped pods together.
-- **Deployment Ordering:** Nodes for a group must be active and labeled **before** workloads attempt to acquire the lock. The orchestrator uses these labels for topology discovery; for now, empty groups cannot be managed.
+  - **Taint:** `timeslice.io/shared=true:NoSchedule` to isolate time-slicing workloads. Prefer applying taints at the node-pool level (e.g., `gcloud container node-pools ... --node-taints`) — hand-applied node metadata is lost when the cloud provider recreates a node (auto-repair/upgrade).
+- **Group membership is automatic:** groups are created when a job first calls `acquire()`, and each group's node membership is derived from where its member pods (labeled `timeslice.io/group=<group-id>`) are actually scheduled. Physical placement is driven by the shared DRA `ResourceClaim` (see below): all pods referencing a group's claim co-locate on the claim's allocated device(s), and other claims are excluded from those devices. No node labeling is required, and there is no deployment-ordering constraint — a group may be acquired before any of its pods exist.
+- **Node group labels are ignored:** `group.timeslice.io/<group-id>` node labels from older deployments have no effect and can be removed. (Pod templates that still carry matching `nodeSelector`s continue to schedule normally — the selector is then plain Kubernetes scheduling, not a platform mechanism.)
 
 ### Installation via Helm
 The TimeSlice Orchestrator is co-deployed with the Snapshot Agent using the parent Timeslice Helm chart.
@@ -126,18 +126,9 @@ spec:
     resourceClaimName: group-ab-sampler-claim # References the ResourceClaim above
 ```
 
-#### Required Node Selectors & Tolerations
+#### Required Tolerations
 
-To ensure work pods are scheduled on the correct isolated accelerator nodes, you must configure both `nodeSelector` and `tolerations` in the pod specification.
-
-##### Node Selectors
-Work pods must target nodes that are enabled for time-slicing and belong to their specific resource Group:
-
-```yaml
-spec:
-  nodeSelector:
-    group.timeslice.io/group-ab-sampler: "true" # Matches the node Group label
-```
+Work pod placement is handled by the scheduler through the shared DRA `ResourceClaim` — pods referencing the same claim automatically co-locate on the claim's devices, so **no `nodeSelector` is needed**. (Legacy deployments using `group.timeslice.io/*` node labels may keep their `nodeSelector`s; they are compatible but not required.)
 
 ##### Tolerations
 Because time-slicing nodes are tainted to prevent regular workloads from scheduling on them, work pods must explicitly tolerate the time-slicing taint:
@@ -172,9 +163,7 @@ spec:
       - name: accelerator
   resourceClaims:
   - name: accelerator
-    resourceClaimName: group-ab-sampler-claim # References an external ResourceClaim
-  nodeSelector:
-    group.timeslice.io/group-ab-sampler: "true" # Matches the node Group label
+    resourceClaimName: group-ab-sampler-claim # References an external ResourceClaim (placement follows the claim)
   tolerations:
   - key: "timeslice.io/shared"
     operator: "Equal"

--- a/pkg/timeslice-orchestrator/controller/controller.go
+++ b/pkg/timeslice-orchestrator/controller/controller.go
@@ -359,6 +359,15 @@ func (c *Controller) tryDeduceActiveJob(ctx context.Context, group *store.Group)
 		return nil
 	}
 
+	// isJobLoaded treats a zero-node group as vacuously loaded, which would
+	// make every job of such a group look loaded here and lead to a spurious
+	// deduction (e.g. while all member pods are still Pending). Deduction
+	// recovers on-hardware state after a restart; with no member nodes there
+	// is nothing to recover, so skip it.
+	if len(group.Status().Nodes()) == 0 {
+		return nil
+	}
+
 	jobs, err := c.jobStore.ListByGroup(ctx, group.ID())
 	if err != nil {
 		return fmt.Errorf("failed to list jobs for group %s: %w", group.ID(), err)
@@ -404,7 +413,12 @@ func (c *Controller) isJobLoaded(ctx context.Context, group *store.Group, jobID 
 
 	nodes := group.Status().Nodes()
 	if len(nodes) == 0 {
-		return false, nil
+		// A group legitimately has zero nodes between its creation (first
+		// Acquire) and the deployment of its first pods (lock-then-deploy).
+		// With no member nodes there is no accelerator context to restore,
+		// so the job is vacuously loaded; returning false would make the
+		// initial Acquire wait forever for a load that cannot happen.
+		return true, nil
 	}
 
 	// Map of node -> jobID of the job running on it.

--- a/pkg/timeslice-orchestrator/controller/controller_internal_test.go
+++ b/pkg/timeslice-orchestrator/controller/controller_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	agentpb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/timeslice-orchestrator/store"
 )
 
 func TestController_WaitForOperation(t *testing.T) {
@@ -119,5 +120,62 @@ func TestController_WaitForOperation(t *testing.T) {
 				tc.verify(t, duration, mockAgent)
 			}
 		})
+	}
+}
+
+// TestIsJobLoaded_EmptyGroupVacuouslyLoaded verifies that a group with zero
+// member nodes (created by a first Acquire before any pods are deployed) has
+// nothing to restore, so its locking job counts as loaded — otherwise the
+// initial Acquire of the lock-then-deploy pattern would wait forever.
+func TestIsJobLoaded_EmptyGroupVacuouslyLoaded(t *testing.T) {
+	ctx := context.Background()
+	groupStore := store.NewGroupStore(store.NewMemLockStore())
+	jobStore := store.NewJobStore()
+	c := NewController(groupStore, jobStore, nil, nil, nil)
+
+	g, _, err := groupStore.GetOrCreate(ctx, "empty-group")
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+
+	loaded, err := c.isJobLoaded(ctx, g, "job-1")
+	if err != nil {
+		t.Fatalf("isJobLoaded failed: %v", err)
+	}
+	if !loaded {
+		t.Errorf("expected job to be vacuously loaded on a zero-node group")
+	}
+
+	// Sanity check: the empty-jobID short-circuit is unaffected.
+	loaded, err = c.isJobLoaded(ctx, g, "")
+	if err != nil || loaded {
+		t.Errorf("expected empty jobID to be not loaded, got loaded=%v err=%v", loaded, err)
+	}
+}
+
+// TestTryDeduceActiveJob_SkipsEmptyGroup verifies that active-job deduction
+// does nothing for a zero-node group: with isJobLoaded vacuously true on
+// empty groups, deduction would otherwise pick an arbitrary job as active
+// while its pods are still Pending.
+func TestTryDeduceActiveJob_SkipsEmptyGroup(t *testing.T) {
+	ctx := context.Background()
+	groupStore := store.NewGroupStore(store.NewMemLockStore())
+	jobStore := store.NewJobStore()
+	c := NewController(groupStore, jobStore, nil, nil, nil)
+
+	g, _, err := groupStore.GetOrCreate(ctx, "empty-group")
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	// A known job with unscheduled pods only (no context state anywhere).
+	if err := jobStore.Put(ctx, store.NewJob("empty-group", "job-1")); err != nil {
+		t.Fatalf("failed to put job: %v", err)
+	}
+
+	if err := c.tryDeduceActiveJob(ctx, g); err != nil {
+		t.Fatalf("tryDeduceActiveJob failed: %v", err)
+	}
+	if got := g.Spec().ActiveJob(); got != "" {
+		t.Errorf("expected no active job deduced for zero-node group, got %q", got)
 	}
 }

--- a/pkg/timeslice-orchestrator/infrastructure/kubernetes.go
+++ b/pkg/timeslice-orchestrator/infrastructure/kubernetes.go
@@ -19,13 +19,13 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/logging"
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/timeslice-orchestrator/controller"
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/timeslice-orchestrator/store"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	corev1informers "k8s.io/client-go/informers/core/v1"
 	corev1listers "k8s.io/client-go/listers/core/v1"
@@ -33,6 +33,9 @@ import (
 )
 
 const (
+	// NodeLabelPrefix is deprecated: node labels no longer define group
+	// membership and are ignored by the orchestrator. Kept only until the
+	// rlts CLI diagnostics are migrated to the orchestrator API.
 	NodeLabelPrefix = "group.timeslice.io/"
 	PodLabelKey     = "timeslice.io/group"
 	JobLabelKey     = "timeslice.io/job-id"
@@ -86,21 +89,52 @@ func (k *KubernetesOrchestrator) Init(ctx context.Context) error {
 	return nil
 }
 
-// getNodesForGroup returns the names of the nodes that belong to the given group.
+// isTerminalPod reports whether the pod has run to completion (successfully
+// or not). Terminal pods no longer host accelerator processes, so both group
+// node membership and job/pod bookkeeping must ignore them; the pod objects
+// themselves may linger until Kubernetes garbage-collects them.
+func isTerminalPod(pod *corev1.Pod) bool {
+	return pod.Status.Phase == corev1.PodSucceeded || pod.Status.Phase == corev1.PodFailed
+}
+
+// getNodesForGroup returns the names of the nodes that belong to the given
+// group: a node is a member iff a live pod labeled timeslice.io/group=<group>
+// is bound to it. Placement is the scheduler's decision (shared DRA claims);
+// the orchestrator observes the outcome. Node labels are not consulted.
 func (k *KubernetesOrchestrator) getNodesForGroup(groupID string) ([]string, error) {
-	selector := labels.SelectorFromSet(labels.Set{NodeLabelPrefix + groupID: "true"})
-	nodes, err := k.nodeLister.List(selector)
+	selector := labels.SelectorFromSet(labels.Set{PodLabelKey: groupID})
+	pods, err := k.podLister.List(selector)
 	if err != nil {
 		return nil, err
 	}
+	nodeSet := make(map[string]bool)
 	var groupNodes []string
-	for _, node := range nodes {
-		groupNodes = append(groupNodes, node.Name)
+	for _, pod := range pods {
+		// Skip pods that are not scheduled yet: they contribute no hardware
+		// to the group until the scheduler binds them to a node.
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+		// Skip terminal pods: their accelerator processes are gone, so the
+		// node no longer hosts this group's context through them.
+		if isTerminalPod(pod) {
+			continue
+		}
+		if !nodeSet[pod.Spec.NodeName] {
+			nodeSet[pod.Spec.NodeName] = true
+			groupNodes = append(groupNodes, pod.Spec.NodeName)
+		}
 	}
 	return groupNodes, nil
 }
 
-// getPodsForGroup returns the pods that are tied to the given group.
+// getPodsForGroup returns the live pods that are tied to the given group.
+// It applies the same liveness rule as getNodesForGroup: terminal pods are
+// excluded, so a job whose pods have all finished drops out of the store and
+// a group whose pods have all finished becomes eligible for cleanup instead
+// of lingering until Kubernetes garbage-collects the pod objects. (Unscheduled
+// pods ARE included: a pending pod is a live member whose job must be
+// tracked; it just contributes no node yet.)
 func (k *KubernetesOrchestrator) getPodsForGroup(groupID string) ([]PodInfo, error) {
 	selector := labels.SelectorFromSet(labels.Set{PodLabelKey: groupID})
 	pods, err := k.podLister.List(selector)
@@ -109,6 +143,9 @@ func (k *KubernetesOrchestrator) getPodsForGroup(groupID string) ([]PodInfo, err
 	}
 	var podInfos []PodInfo
 	for _, pod := range pods {
+		if isTerminalPod(pod) {
+			continue
+		}
 		jobID := pod.Labels[JobLabelKey]
 		if jobID == "" {
 			continue
@@ -137,8 +174,22 @@ func (k *KubernetesOrchestrator) ObserveGroupState(ctx context.Context, groupID 
 		return fmt.Errorf("failed to get pods for group %s: %w", groupID, err)
 	}
 
-	// If no nodes and no pods, we clean up the group and its jobs and return early.
+	// If no nodes and no pods, clean up the group and its jobs — unless the
+	// group has lock activity. Groups are created on demand by the first
+	// Acquire, which in the lock-then-deploy pattern happens BEFORE any
+	// member pods exist; deleting such a group would pull it out from under
+	// its lock holder.
 	if len(groupNodes) == 0 && len(pods) == 0 {
+		if g, err := k.groupStore.Get(ctx, groupID); err == nil && g != nil {
+			snap := g.Snapshot()
+			if snap.LockingJob != "" || snap.ActiveJob != "" || snap.WaiterQueueDepth > 0 {
+				slog.InfoContext(ctx, "Group has no nodes or pods but has lock activity; skipping cleanup",
+					"lockingJob", snap.LockingJob, "activeJob", snap.ActiveJob, "waiters", snap.WaiterQueueDepth)
+				// Still record the (empty) node membership so reconciliation
+				// sees an up-to-date view.
+				return k.updateGroupNodes(ctx, groupID, groupNodes)
+			}
+		}
 		if err := k.cleanupGroup(ctx, groupID); err != nil {
 			return fmt.Errorf("failed to cleanup group %s: %w", groupID, err)
 		}
@@ -296,14 +347,31 @@ func (k *KubernetesOrchestrator) enqueueNode(ctx context.Context, obj interface{
 	}
 }
 
+// getGroupsFromNode returns the groups that have member pods bound to the
+// node, so node events (e.g. deletion) requeue exactly the groups whose
+// membership they affect.
 func (k *KubernetesOrchestrator) getGroupsFromNode(node *corev1.Node) []string {
+	// List all pods carrying the timeslice group label, then filter to this node.
+	req, err := labels.NewRequirement(PodLabelKey, selection.Exists, nil)
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to build pod label requirement: %w", err))
+		return nil
+	}
+	pods, err := k.podLister.List(labels.NewSelector().Add(*req))
+	if err != nil {
+		utilruntime.HandleError(fmt.Errorf("failed to list timeslice pods for node %s: %w", node.Name, err))
+		return nil
+	}
+	groupSet := make(map[string]bool)
 	var groups []string
-	for k := range node.Labels {
-		if strings.HasPrefix(k, NodeLabelPrefix) {
-			group := strings.TrimPrefix(k, NodeLabelPrefix)
-			if group != "" {
-				groups = append(groups, group)
-			}
+	for _, pod := range pods {
+		if pod.Spec.NodeName != node.Name {
+			continue
+		}
+		group := pod.Labels[PodLabelKey]
+		if group != "" && !groupSet[group] {
+			groupSet[group] = true
+			groups = append(groups, group)
 		}
 	}
 	return groups

--- a/pkg/timeslice-orchestrator/infrastructure/kubernetes_test.go
+++ b/pkg/timeslice-orchestrator/infrastructure/kubernetes_test.go
@@ -12,6 +12,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
@@ -118,65 +119,198 @@ func TestObserveGroupState_Cleanup(t *testing.T) {
 	}
 }
 
-func TestObserveGroupState_UpdateNodes(t *testing.T) {
-	clientset := fake.NewClientset()
+// newInfra builds a KubernetesOrchestrator wired to a fake clientset with the
+// given objects, with informer caches synced. Shared by the membership tests.
+func newInfra(
+	t *testing.T, ctx context.Context, groupStore *store.GroupStore, jobStore *store.JobStore, objs ...runtime.Object,
+) *infrastructure.KubernetesOrchestrator {
+	t.Helper()
+	clientset := fake.NewClientset(objs...)
 	informerFactory := informers.NewSharedInformerFactory(clientset, 0)
 	nodeInformer := informerFactory.Core().V1().Nodes()
 	podInformer := informerFactory.Core().V1().Pods()
-
-	lockStore := store.NewMemLockStore()
-	groupStore := store.NewGroupStore(lockStore)
-	jobStore := store.NewJobStore()
-	fakeAgentStore := &fakeSnapshotAgentStore{}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	infraOrch := infrastructure.NewKubernetesOrchestrator(nodeInformer, podInformer, groupStore, jobStore, fakeAgentStore)
-
-	// Start informers
+	infraOrch := infrastructure.NewKubernetesOrchestrator(
+		nodeInformer, podInformer, groupStore, jobStore, &fakeSnapshotAgentStore{})
 	informerFactory.Start(ctx.Done())
 	if err := infraOrch.Init(ctx); err != nil {
 		t.Fatalf("Failed to initialize infra orchestrator: %v", err)
 	}
+	return infraOrch
+}
 
-	// Add node to fake clientset
-	node := &corev1.Node{
+func groupPod(name, group, job, nodeName string, phase corev1.PodPhase) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+			Labels: map[string]string{
+				"timeslice.io/group":  group,
+				"timeslice.io/job-id": job,
+			},
+		},
+		Spec:   corev1.PodSpec{NodeName: nodeName},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+// TestObserveGroupState_NodesFromPods verifies that a group's nodes are
+// exactly the distinct nodes of its live, scheduled member pods. Unscheduled pods contribute nothing (no node
+// yet); terminal pods contribute nothing (their accelerator processes are
+// gone); duplicates collapse.
+func TestObserveGroupState_NodesFromPods(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	groupStore := store.NewGroupStore(store.NewMemLockStore())
+	jobStore := store.NewJobStore()
+
+	infraOrch := newInfra(t, ctx, groupStore, jobStore,
+		groupPod("pod-running-1", "group-1", "job-a", "node-1", corev1.PodRunning),
+		groupPod("pod-running-2", "group-1", "job-b", "node-1", corev1.PodRunning), // same node: dedup
+		groupPod("pod-pending", "group-1", "job-a", "", corev1.PodPending),         // unscheduled: ignored
+		groupPod("pod-done", "group-1", "job-a", "node-2", corev1.PodSucceeded),    // terminal: ignored
+		groupPod("pod-other-group", "group-2", "job-c", "node-3", corev1.PodRunning),
+	)
+
+	if err := infraOrch.ObserveGroupState(ctx, "group-1"); err != nil {
+		t.Fatalf("ObserveGroupState failed: %v", err)
+	}
+	g, err := groupStore.Get(ctx, "group-1")
+	if err != nil {
+		t.Fatalf("Expected group-1 to exist in store: %v", err)
+	}
+	if nodes := g.Status().Nodes(); len(nodes) != 1 || nodes[0] != "node-1" {
+		t.Errorf("Expected group-1 nodes to be [node-1], got %v", nodes)
+	}
+}
+
+// TestObserveGroupState_AllPodsTerminal_Cleanup verifies that terminal pods
+// count as absent for the cleanup decision too: when every member pod has
+// succeeded or failed (and there is no lock activity), the group and its jobs
+// are removed from the store instead of lingering until Kubernetes
+// garbage-collects the finished pod objects.
+func TestObserveGroupState_AllPodsTerminal_Cleanup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	groupStore := store.NewGroupStore(store.NewMemLockStore())
+	jobStore := store.NewJobStore()
+
+	infraOrch := newInfra(t, ctx, groupStore, jobStore,
+		groupPod("pod-done-1", "group-a", "job-1", "node-1", corev1.PodSucceeded),
+		groupPod("pod-done-2", "group-a", "job-1", "node-2", corev1.PodFailed),
+	)
+
+	// Pre-populate the store as if the group and job had been observed live.
+	g, _, err := groupStore.GetOrCreate(ctx, "group-a")
+	if err != nil {
+		t.Fatalf("Failed to create group: %v", err)
+	}
+	g.Status().SetNodes([]string{"node-1", "node-2"})
+	if err := jobStore.Put(ctx, store.NewJob("group-a", "job-1")); err != nil {
+		t.Fatalf("Failed to put job: %v", err)
+	}
+
+	if err := infraOrch.ObserveGroupState(ctx, "group-a"); err != nil {
+		t.Fatalf("ObserveGroupState failed: %v", err)
+	}
+
+	if _, err := groupStore.Get(ctx, "group-a"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("Expected group-a to be cleaned up when all pods are terminal, got: %v", err)
+	}
+	if _, err := jobStore.Get(ctx, "group-a", "job-1"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("Expected job-1 to be cleaned up when all pods are terminal, got: %v", err)
+	}
+}
+
+// TestObserveGroupState_TerminalJobRemoved verifies the per-job consequence of
+// the liveness rule: a job whose pods have all finished is dropped from the
+// store (so stale context state, e.g. FAULTED, cannot outlive its pods),
+// while jobs with live pods are retained.
+func TestObserveGroupState_TerminalJobRemoved(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	groupStore := store.NewGroupStore(store.NewMemLockStore())
+	jobStore := store.NewJobStore()
+
+	infraOrch := newInfra(t, ctx, groupStore, jobStore,
+		groupPod("pod-live", "group-a", "job-live", "node-1", corev1.PodRunning),
+		groupPod("pod-done", "group-a", "job-done", "node-2", corev1.PodSucceeded),
+	)
+
+	if err := jobStore.Put(ctx, store.NewJob("group-a", "job-done")); err != nil {
+		t.Fatalf("Failed to put job: %v", err)
+	}
+
+	if err := infraOrch.ObserveGroupState(ctx, "group-a"); err != nil {
+		t.Fatalf("ObserveGroupState failed: %v", err)
+	}
+
+	g, err := groupStore.Get(ctx, "group-a")
+	if err != nil {
+		t.Fatalf("Expected group-a to exist: %v", err)
+	}
+	if nodes := g.Status().Nodes(); len(nodes) != 1 || nodes[0] != "node-1" {
+		t.Errorf("Expected group-a nodes to be [node-1], got %v", nodes)
+	}
+	if _, err := jobStore.Get(ctx, "group-a", "job-live"); err != nil {
+		t.Errorf("Expected job-live to be retained, got: %v", err)
+	}
+	if _, err := jobStore.Get(ctx, "group-a", "job-done"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("Expected job-done to be removed once its pods are terminal, got: %v", err)
+	}
+}
+
+// TestObserveGroupState_NodeLabelsIgnored verifies that group.timeslice.io/*
+// node labels have no effect: a labeled node with no member pods must NOT
+// create or populate a group.
+func TestObserveGroupState_NodeLabelsIgnored(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	groupStore := store.NewGroupStore(store.NewMemLockStore())
+	jobStore := store.NewJobStore()
+
+	labeledNode := &corev1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node-1",
 			Labels: map[string]string{"group.timeslice.io/group-1": "true"},
 		},
 	}
-	_, err := clientset.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Failed to create node: %v", err)
-	}
+	infraOrch := newInfra(t, ctx, groupStore, jobStore, labeledNode)
 
-	// Wait for caches to sync
-	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 3*time.Second, true, func(ctx context.Context) (bool, error) {
-		nodes, err := nodeInformer.Lister().List(labels.Everything())
-		if err != nil {
-			return false, err
-		}
-		return len(nodes) == 1, nil
-	})
-	if err != nil {
-		t.Fatalf("Timed out waiting for caches to sync: %v", err)
-	}
-
-	// Call ObserveGroupState
-	err = infraOrch.ObserveGroupState(ctx, "group-1")
-	if err != nil {
+	if err := infraOrch.ObserveGroupState(ctx, "group-1"); err != nil {
 		t.Fatalf("ObserveGroupState failed: %v", err)
 	}
-
-	// Verify group is created in store with correct nodes
-	g, err := groupStore.Get(ctx, "group-1")
-	if err != nil {
-		t.Fatalf("Expected group-1 to exist in store: %v", err)
+	if _, err := groupStore.Get(ctx, "group-1"); !errors.Is(err, store.ErrNotFound) {
+		t.Errorf("Expected group-1 to not exist (labels are ignored), got: %v", err)
 	}
-	if len(g.Status().Nodes()) != 1 || g.Status().Nodes()[0] != "node-1" {
-		t.Errorf("Expected group-1 to have node-1, got %v", g.Status().Nodes())
+}
+
+// TestObserveGroupState_GCGuard verifies that a group with lock activity but
+// no pods yet is NOT garbage-collected: in the lock-then-deploy pattern,
+// Acquire creates the group before any pods exist, and cleanup must not
+// delete it out from under the lock holder.
+func TestObserveGroupState_GCGuard(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	groupStore := store.NewGroupStore(store.NewMemLockStore())
+	jobStore := store.NewJobStore()
+
+	infraOrch := newInfra(t, ctx, groupStore, jobStore)
+
+	g, _, err := groupStore.GetOrCreate(ctx, "group-a")
+	if err != nil {
+		t.Fatalf("Failed to create group: %v", err)
+	}
+	// Simulate a job that acquired the (empty) group and holds the lock.
+	g.Spec().RequestLock("job-1")
+	if _, err := g.Spec().TryPromote(ctx); err != nil {
+		t.Fatalf("TryPromote failed: %v", err)
+	}
+
+	if err := infraOrch.ObserveGroupState(ctx, "group-a"); err != nil {
+		t.Fatalf("ObserveGroupState failed: %v", err)
+	}
+	if _, err := groupStore.Get(ctx, "group-a"); err != nil {
+		t.Errorf("Expected group-a to survive cleanup while lock is held, got: %v", err)
 	}
 }
 
@@ -203,18 +337,7 @@ func TestObserveGroupState_UpdateJobsAndPods(t *testing.T) {
 		t.Fatalf("Failed to initialize infra orchestrator: %v", err)
 	}
 
-	// Add node and pod to fake clientset
-	node := &corev1.Node{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "node-1",
-			Labels: map[string]string{"group.timeslice.io/group-1": "true"},
-		},
-	}
-	_, err := clientset.CoreV1().Nodes().Create(ctx, node, metav1.CreateOptions{})
-	if err != nil {
-		t.Fatalf("Failed to create node: %v", err)
-	}
-
+	// Add pod to fake clientset (jobs are tracked from labeled pods alone).
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pod-1",
@@ -225,22 +348,18 @@ func TestObserveGroupState_UpdateJobsAndPods(t *testing.T) {
 			},
 		},
 	}
-	_, err = clientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
+	_, err := clientset.CoreV1().Pods(pod.Namespace).Create(ctx, pod, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatalf("Failed to create pod: %v", err)
 	}
 
 	// Wait for caches to sync
 	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 3*time.Second, true, func(ctx context.Context) (bool, error) {
-		nodes, err := nodeInformer.Lister().List(labels.Everything())
-		if err != nil {
-			return false, err
-		}
 		pods, err := podInformer.Lister().List(labels.Everything())
 		if err != nil {
 			return false, err
 		}
-		return len(nodes) == 1 && len(pods) == 1, nil
+		return len(pods) == 1, nil
 	})
 	if err != nil {
 		t.Fatalf("Timed out waiting for caches to sync: %v", err)

--- a/pkg/timeslice-orchestrator/server/server.go
+++ b/pkg/timeslice-orchestrator/server/server.go
@@ -24,6 +24,7 @@ import (
 // GroupStore defines the interface for group store operations needed by the server.
 type GroupStore interface {
 	Get(ctx context.Context, id string) (*store.Group, error)
+	GetOrCreate(ctx context.Context, id string) (*store.Group, bool, error)
 	List(ctx context.Context) ([]*store.Group, error)
 }
 
@@ -69,13 +70,15 @@ func (s *Server) Acquire(ctx context.Context, req *pb.AcquireRequest) (*pb.Acqui
 	jobID := req.GetJobId()
 	startTime := time.Now()
 
-	// 1. Get Group
-	group, err := s.groupStore.Get(ctx, groupID)
+	// 1. Get or create the group. Groups come into being at first Acquire:
+	// in the lock-then-deploy pattern the first Acquire happens before any
+	// member pods exist, so the group cannot be discovered from pods yet.
+	group, created, err := s.groupStore.GetOrCreate(ctx, groupID)
 	if err != nil {
-		if errors.Is(err, store.ErrNotFound) {
-			return nil, status.Errorf(codes.NotFound, "group %s not found", groupID)
-		}
-		return nil, status.Errorf(codes.Internal, "failed to get group: %v", err)
+		return nil, status.Errorf(codes.Internal, "failed to get or create group: %v", err)
+	}
+	if created {
+		slog.InfoContext(ctx, "Group created on first Acquire")
 	}
 
 	// 2. Request Lock

--- a/pkg/timeslice-orchestrator/server/server_internal_test.go
+++ b/pkg/timeslice-orchestrator/server/server_internal_test.go
@@ -79,9 +79,20 @@ func (m *MockWorkQueue) ShutDown()                     {}
 
 // MockGroupStore is exported for external tests.
 type MockGroupStore struct {
-	GetFunc  func(ctx context.Context, id string) (*store.Group, error)
-	ListFunc func(ctx context.Context) ([]*store.Group, error)
-	SetGroup func(g *store.Group)
+	GetFunc         func(ctx context.Context, id string) (*store.Group, error)
+	GetOrCreateFunc func(ctx context.Context, id string) (*store.Group, bool, error)
+	ListFunc        func(ctx context.Context) ([]*store.Group, error)
+	SetGroup        func(g *store.Group)
+}
+
+// GetOrCreate defaults to delegating to GetFunc so existing tests keep
+// their view of the store.
+func (m *MockGroupStore) GetOrCreate(ctx context.Context, id string) (*store.Group, bool, error) {
+	if m.GetOrCreateFunc != nil {
+		return m.GetOrCreateFunc(ctx, id)
+	}
+	g, err := m.Get(ctx, id)
+	return g, false, err
 }
 
 func (m *MockGroupStore) Get(ctx context.Context, id string) (*store.Group, error) {

--- a/pkg/timeslice-orchestrator/server/server_test.go
+++ b/pkg/timeslice-orchestrator/server/server_test.go
@@ -29,14 +29,21 @@ func TestServer_Acquire(t *testing.T) {
 		verify        func(t *testing.T, resp *pb.AcquireResponse, err error)
 	}{
 		{
-			name: "group not found",
+			// An unknown group on Acquire is not an error: Acquire creates the
+			// group and queues the lock request. With no controller running
+			// here the request never completes, so the client deadline is the
+			// expected outcome. Group creation itself is asserted in
+			// TestServer_AcquireCreatesGroup.
+			name: "unknown group is created, not rejected",
 			setupStores: func(t *testing.T, ctx context.Context) (server.GroupStore, server.JobStore) {
 				t.Helper()
 				return store.NewGroupStore(store.NewMemLockStore()), store.NewJobStore()
 			},
-			groupID:      "unknown-group",
-			jobID:        "job-1",
-			expectedCode: codes.NotFound,
+			groupID:       "unknown-group",
+			jobID:         "job-1",
+			timeout:       1500 * time.Millisecond,
+			expectedCode:  codes.DeadlineExceeded,
+			expectEnqueue: true,
 		},
 		{
 			name: "group faulted",
@@ -672,5 +679,49 @@ func TestServer_GetGroupStatus(t *testing.T) {
 				tc.verify(t, resp)
 			}
 		})
+	}
+}
+
+// TestServer_AcquireCreatesGroup verifies that Acquire on a group that does
+// not exist yet creates it and records the lock request on the new group.
+func TestServer_AcquireCreatesGroup(t *testing.T) {
+	ctx := context.Background()
+	gs := store.NewGroupStore(store.NewMemLockStore())
+	js := store.NewJobStore()
+
+	_, mq, cleanup := server.InitGRPCServer(gs, js)
+	defer cleanup()
+	conn, err := grpc.NewClient(
+		"passthrough:///bufnet",
+		grpc.WithContextDialer(server.BufDialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()),
+	)
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewTimeSliceOrchestratorServiceClient(conn)
+
+	// No controller runs here, so the acquire cannot complete; a short client
+	// deadline bounds the call.
+	clientCtx, cancel := context.WithTimeout(ctx, 1500*time.Millisecond)
+	defer cancel()
+	_, err = client.Acquire(clientCtx, &pb.AcquireRequest{GroupId: "brand-new-group", JobId: "job-1"})
+	if status.Code(err) != codes.DeadlineExceeded {
+		t.Fatalf("Expected DeadlineExceeded while waiting for load, got: %v", err)
+	}
+
+	// The group must now exist with the lock request recorded.
+	g, err := gs.Get(ctx, "brand-new-group")
+	if err != nil {
+		t.Fatalf("Expected group to be created by Acquire, got: %v", err)
+	}
+	snap := g.Snapshot()
+	if snap.LockingJob != "job-1" && snap.WaiterQueueDepth == 0 {
+		t.Errorf("Expected job-1 to hold or wait for the lock, got locking=%q waiters=%d",
+			snap.LockingJob, snap.WaiterQueueDepth)
+	}
+	if added := mq.GetAdded(); len(added) == 0 || added[0] != "brand-new-group" {
+		t.Errorf("Expected brand-new-group to be enqueued for reconciliation, got %v", added)
 	}
 }

--- a/tests/integration/orchestrator/harness.go
+++ b/tests/integration/orchestrator/harness.go
@@ -110,9 +110,16 @@ func NewComposedHarness(t *testing.T) *ComposedHarness {
 		t.Logf("snapshot-agent chart pod ready at %s:%d on %s", ip, agentPort, node)
 	}
 
-	// Label each group node exclusively.
-	h.exclusiveLabel(t, samplerNode, integSamplers)
-	h.exclusiveLabel(t, trainerNode, integTrainers)
+	// Label each group node exclusively — unless the run validates label-free
+	// membership (INTEG_EMERGENT set), in which case NO node labels may
+	// exist: the orchestrator must create groups on first Acquire and
+	// discover their nodes from scheduled pods.
+	if os.Getenv("INTEG_EMERGENT") == "" {
+		h.exclusiveLabel(t, samplerNode, integSamplers)
+		h.exclusiveLabel(t, trainerNode, integTrainers)
+	} else {
+		t.Log("INTEG_EMERGENT set: skipping group node labeling (label-free membership mode)")
+	}
 
 	// Pre-clean: remove any leaked pods from a previous failed run.
 	h.cleanLeakedPods(t)

--- a/tests/integration/orchestrator/scenarios/fake_rl_job.go
+++ b/tests/integration/orchestrator/scenarios/fake_rl_job.go
@@ -40,6 +40,13 @@ type FakeRLJob struct {
 	samplerSharedClaimName string
 	trainerSharedClaimName string
 
+	// EmergentNodes, when non-empty, runs the job in label-free mode: it maps
+	// groupID -> the node the group's pods should land on. Pods are pinned
+	// via the kubernetes.io/hostname selector (NOT Spec.NodeName, which would
+	// bypass the scheduler and break DRA claim allocation), and the
+	// orchestrator must discover membership from the scheduled pods alone.
+	EmergentNodes map[string]string
+
 	// Callbacks to control sampling/training behavior/duration
 	OnSampling func(ctx context.Context)
 	OnTraining func(ctx context.Context)
@@ -269,18 +276,33 @@ func (f *FakeRLJob) cleanup(ctx context.Context) error {
 }
 
 func (f *FakeRLJob) deployPods(ctx context.Context, groupID string) error {
-	// Find nodes for group
-	selector := fmt.Sprintf("group.timeslice.io/%s=true", groupID)
-	nodes, err := f.clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: selector})
-	if err != nil {
-		return fmt.Errorf("failed to list nodes: %w", err)
+	// Find the target nodes for the group: configured directly in label-free
+	// mode (no node labels exist to list by), from node labels otherwise.
+	var err error
+	var expectedNodes []string
+	if len(f.EmergentNodes) > 0 {
+		node, ok := f.EmergentNodes[groupID]
+		if !ok || node == "" {
+			return fmt.Errorf("emergent mode: no target node configured for group %s", groupID)
+		}
+		expectedNodes = []string{node}
+	} else {
+		selector := fmt.Sprintf("group.timeslice.io/%s=true", groupID)
+		var nodes *corev1.NodeList
+		nodes, err = f.clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{LabelSelector: selector})
+		if err != nil {
+			return fmt.Errorf("failed to list nodes: %w", err)
+		}
+		for i := range nodes.Items {
+			expectedNodes = append(expectedNodes, nodes.Items[i].Name)
+		}
 	}
 
-	if len(nodes.Items) == 0 {
+	if len(expectedNodes) == 0 {
 		return fmt.Errorf("no nodes found for group %s", groupID)
 	}
 
-	for range nodes.Items {
+	for _, targetNode := range expectedNodes {
 		podName := fmt.Sprintf("pod-%s-%s-%s", f.name, groupID, uuid.NewString()[:8])
 
 		var sharedClaimName string
@@ -306,11 +328,18 @@ func (f *FakeRLJob) deployPods(ctx context.Context, groupID string) error {
 		pod.Namespace = "default"
 		pod.Spec.NodeName = "" // Let scheduler handle it
 
-		// Set NodeSelector to target the group
 		if pod.Spec.NodeSelector == nil {
 			pod.Spec.NodeSelector = make(map[string]string)
 		}
-		pod.Spec.NodeSelector[fmt.Sprintf("group.timeslice.io/%s", groupID)] = "true"
+		if len(f.EmergentNodes) > 0 {
+			// Emergent mode: pin to the chosen node by hostname. The
+			// scheduler still runs (required for DRA claim allocation);
+			// no group node labels are involved.
+			pod.Spec.NodeSelector["kubernetes.io/hostname"] = targetNode
+		} else {
+			// Legacy mode: target the group's labeled nodes.
+			pod.Spec.NodeSelector[fmt.Sprintf("group.timeslice.io/%s", groupID)] = "true"
+		}
 
 		// Add tolerations for timeslice.io/shared and default GKE GPU taints
 		pod.Spec.Tolerations = append(pod.Spec.Tolerations,
@@ -373,8 +402,8 @@ func (f *FakeRLJob) deployPods(ctx context.Context, groupID string) error {
 
 				// Verify it is one of the expected nodes for the group
 				isExpectedNode := false
-				for j := range nodes.Items {
-					if pod.Spec.NodeName == nodes.Items[j].Name {
+				for _, n := range expectedNodes {
+					if pod.Spec.NodeName == n {
 						isExpectedNode = true
 						break
 					}

--- a/tests/integration/orchestrator/scenarios/scenarios.go
+++ b/tests/integration/orchestrator/scenarios/scenarios.go
@@ -17,6 +17,7 @@ package scenarios
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -29,6 +30,22 @@ import (
 )
 
 // RunSingleRLJobScenario runs the single RL job E2E scenario.
+
+// emergentNodesFromEnv returns the groupID->node mapping for label-free runs
+// (INTEG_EMERGENT set), or nil for label-mode runs. With INTEG_EMERGENT=true
+// the harness skips node labeling entirely and scenario pods are pinned by
+// hostname instead, so the run validates that groups are created on first
+// Acquire and membership is discovered from scheduled pods.
+func emergentNodesFromEnv() map[string]string {
+	if os.Getenv("INTEG_EMERGENT") == "" {
+		return nil
+	}
+	return map[string]string{
+		"samplers": os.Getenv("TEST_NODE_SAMPLERS"),
+		"trainers": os.Getenv("TEST_NODE_TRAINERS"),
+	}
+}
+
 func RunSingleRLJobScenario(
 	ctx context.Context,
 	clientset kubernetes.Interface,
@@ -66,6 +83,7 @@ func RunSingleRLJobScenario(
 		samplerTemplateKey, trainerTemplateKey,
 		samplerClaim, trainerClaim,
 	)
+	job.EmergentNodes = emergentNodesFromEnv()
 
 	// Set custom work durations
 	job.OnSampling = func(ctx context.Context) {
@@ -142,6 +160,8 @@ func RunQueuedRLJobsScenario(
 		samplerTemplateKey, trainerTemplateKey,
 		samplerClaim, trainerClaim,
 	)
+	jobA.EmergentNodes = emergentNodesFromEnv()
+	jobB.EmergentNodes = emergentNodesFromEnv()
 
 	// Channels for coordination
 	jobASampling := make(chan struct{})

--- a/tests/integration/orchestrator/simulate/orchestrator_simulated_test.go
+++ b/tests/integration/orchestrator/simulate/orchestrator_simulated_test.go
@@ -20,10 +20,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -132,25 +132,15 @@ func TestE2E_SingleRLJob(t *testing.T) {
 	defer conn.Close()
 	client := pb.NewTimeSliceOrchestratorServiceClient(conn)
 
-	// Nodes already populated at startup
-
-	// Wait for K8s caches to sync and infra orchestrator to populate stores
-	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-		gs, err := groupStore.Get(ctx, "samplers")
-		if err != nil {
-			return false, nil //nolint:nilerr // Intentional to allow polling to retry on transient "not found" errors
-		}
-		gt, err := groupStore.Get(ctx, "trainers")
-		if err != nil {
-			return false, nil //nolint:nilerr // Intentional to allow polling to retry on transient "not found" errors
-		}
-		return len(gs.Status().Nodes()) == 1 && len(gt.Status().Nodes()) == 1, nil
-	})
-	if err != nil {
-		t.Fatalf("Timed out waiting for store initialization: %v", err)
+	// Groups are no longer seeded from node labels: they are created on first
+	// Acquire and their nodes discovered from scheduled member pods, so the
+	// stores start empty. Just wait for the informer caches to sync so the
+	// infra orchestrator observes the pod events the scenario generates.
+	if !cache.WaitForCacheSync(ctx.Done(), nodeInformer.Informer().HasSynced, podInformer.Informer().HasSynced) {
+		t.Fatal("Timed out waiting for informer caches to sync")
 	}
 
-	t.Log("Store initialized with samplers and trainers groups")
+	t.Log("Informer caches synced; groups will be created on first Acquire")
 
 	// Run Scenario
 	if err := scenarios.RunSingleRLJobScenario(ctx, clientset, client, t, "", ""); err != nil {
@@ -263,25 +253,15 @@ func TestE2E_QueuedRLJobs(t *testing.T) {
 	defer conn.Close()
 	client := pb.NewTimeSliceOrchestratorServiceClient(conn)
 
-	// Nodes already populated at startup
-
-	// Wait for K8s caches to sync and infra orchestrator to populate stores
-	err = wait.PollUntilContextTimeout(ctx, 100*time.Millisecond, 5*time.Second, true, func(ctx context.Context) (bool, error) {
-		gs, err := groupStore.Get(ctx, "samplers")
-		if err != nil {
-			return false, nil //nolint:nilerr // Intentional to allow polling to retry on transient "not found" errors
-		}
-		gt, err := groupStore.Get(ctx, "trainers")
-		if err != nil {
-			return false, nil //nolint:nilerr // Intentional to allow polling to retry on transient "not found" errors
-		}
-		return len(gs.Status().Nodes()) == 1 && len(gt.Status().Nodes()) == 1, nil
-	})
-	if err != nil {
-		t.Fatalf("Timed out waiting for store initialization: %v", err)
+	// Groups are no longer seeded from node labels: they are created on first
+	// Acquire and their nodes discovered from scheduled member pods, so the
+	// stores start empty. Just wait for the informer caches to sync so the
+	// infra orchestrator observes the pod events the scenario generates.
+	if !cache.WaitForCacheSync(ctx.Done(), nodeInformer.Informer().HasSynced, podInformer.Informer().HasSynced) {
+		t.Fatal("Timed out waiting for informer caches to sync")
 	}
 
-	t.Log("Store initialized with samplers and trainers groups")
+	t.Log("Informer caches synced; groups will be created on first Acquire")
 
 	// Run Scenario
 	if err := scenarios.RunQueuedRLJobsScenario(ctx, clientset, client, t, "", ""); err != nil {

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -259,6 +259,7 @@ $K exec test-runner -- env "MODEL=${MODEL}" "TEST_NODE=${TEST_NODE:-}" \
   "SA_CHART_DEPLOYED=${SA_CHART_DEPLOYED}" \
   "ORCH_CHART_DEPLOYED=${ORCH_CHART_DEPLOYED}" \
   "CHART_AGENT_PORT=${CHART_AGENT_PORT}" \
+  "INTEG_EMERGENT=${INTEG_EMERGENT:-}" \
   sh -c "cd /workspace && go test -tags=integration -count=1 -v -timeout 40m -run '${RUN_PATTERN}' ./tests/integration/..." \
   || EXIT=$?
 


### PR DESCRIPTION
## What does this PR do?

Time-slice groups no longer require operators to label nodes with group.timeslice.io/<group>=true. The orchestrator now derives each group's node membership from where the group's member pods (labeled timeslice.io/group=<group>) are actually scheduled, and groups come into existence when a job first calls acquire(). Physical placement is owned entirely by the Kubernetes scheduler through the shared DRA ResourceClaims the workloads already use. Labeling a node has no effect; existing labels can be removed.

## Why is this change needed?

* Eliminates Manual Toil: Removes operator-applied group.timeslice.io/<group> node labels and fragile nodeSelector boilerplate.
* Pod-Driven Grouping: Workloads declare group membership directly on their pods via timeslice.io/group=<group>. Group node membership is dynamically derived from where live pods land.
* DRA-Driven Placement: DRA claims handle hardware allocation and pod co-location naturally via the Kubernetes scheduler.
* Resilient to Autoscaling & Auto-Repair: GKE node auto-repairs and pool scaling no longer break group discovery due to missing hand-applied node labels.


Followups: 
* Migrate rlts inspect/test-e2e from label scanning to the orchestrator API.
* Automate DRA claim creation.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

  Official manual integration test results (tests/integration/run.sh --phase orchestrator):

  === RUN   TestOrchestrator
  --- PASS: TestOrchestrator (504.04s)
      --- PASS: TestOrchestrator/SingleRLJob (100.23s)
      --- PASS: TestOrchestrator/QueuedRLJobs (403.39s)
  PASS
  ok  github.com/llm-d-incubation/llm-d-rl-time-slicing/tests/integration/orchestrator  504.063s

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Groups are created automatically on first acquisition.
  * Accelerator placement uses resource claims, with membership discovered from scheduled pods.
  * Workloads no longer require trainer- or sampler-specific node labels and selectors.

* **Bug Fixes**
  * Improved handling of zero-node and temporarily empty groups during startup and recovery.
  * Prevented active groups with lock activity from being removed prematurely.
  * Excluded completed workloads from placement and job tracking.

* **Documentation**
  * Simplified Slime and time-slicing setup, deployment, monitoring, and cleanup instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->