### PR TITLE
[GPU-CR Selective Checkpoint 2/N]: Wire protocol and dump format

### DIFF
--- a/third_party/gpu-cr/CMakeLists.txt
+++ b/third_party/gpu-cr/CMakeLists.txt
@@ -135,9 +135,10 @@ target_compile_options(multi_cr_client PRIVATE -O3 -g)
 
 # ---------------------------------------------------------------------------
 # Tests (GPU-free; run in Dockerfile.build)
-#   gpu_cr_unit_tests        — GoogleTest unit suite for the upstream-baseline
-#                              control channel, buffer mapping, fd exchange
-#                              and wire structs
+#   gpu_cr_unit_tests        — GoogleTest unit suite for the dump-format
+#                              code, plus the upstream-baseline control
+#                              channel, buffer mapping, fd exchange and
+#                              wire structs
 # ---------------------------------------------------------------------------
 option(GPU_CR_BUILD_TESTS "Build the GPU-free unit tests" OFF)
 
@@ -154,6 +155,8 @@ if(GPU_CR_BUILD_TESTS)
 
     add_executable(gpu_cr_unit_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/common_baseline_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/common_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/dump_format_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/ipc_fd_exchange_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/mmap_backend_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/share_mem_comm_test.cpp

--- a/third_party/gpu-cr/Dockerfile.build
+++ b/third_party/gpu-cr/Dockerfile.build
@@ -23,7 +23,7 @@ RUN cd /tmp/GPU-CR && \
     # control file only through a dedicated volume — the volume mount is the
     # access boundary. A stricter mode would need a UID/GID contract across
     # pods that the deployment cannot assume.
-    sed -i 's/int fd_control = open(control_name, O_CREAT | O_RDWR, 0755);/int fd_control = open(control_name, O_CREAT | O_RDWR, 0777); fchmod(fd_control, 0777);/' src/comm/share_mem.cpp && \
+    sed -i 's/fd_control = open(control_name, O_CREAT | O_RDWR, 0755);/fd_control = open(control_name, O_CREAT | O_RDWR, 0777); fchmod(fd_control, 0777);/' src/comm/share_mem.cpp && \
     grep -q "SIGRTMAX - 8" src/common.h && \
     grep -q "0777" src/comm/share_mem.cpp && \
     mkdir build && cd build && \

--- a/third_party/gpu-cr/src/backend/backend.h
+++ b/third_party/gpu-cr/src/backend/backend.h
@@ -27,6 +27,9 @@ public:
     void setup() override;
     void* get_tmp_buf() override;
     void* get_host_buffer();
+
+private:
+    void* map_dump_buffer(bool fatal);
 };
 
 #endif

--- a/third_party/gpu-cr/src/comm/comm.h
+++ b/third_party/gpu-cr/src/comm/comm.h
@@ -34,10 +34,15 @@ public:
 #define NCCL_SUSPEND_MSG 13
 #define NCCL_RESUME_MSG  14
 
+// Selective checkpoint/restore: operate on a caller-supplied subset of memory regions
+#define SELECTIVE_CKPT_MSG    20
+#define SELECTIVE_RESTORE_MSG 21
+
 class ShareMemComm : public Comm {
 public:
     signal_controls* control;
     pid_t pid;
+    int fd_control = -1; // kept open so callers can flock the op duration
 
     ShareMemComm(pid_t pid);
     ~ShareMemComm();

--- a/third_party/gpu-cr/src/comm/share_mem.cpp
+++ b/third_party/gpu-cr/src/comm/share_mem.cpp
@@ -24,6 +24,8 @@ ShareMemComm::ShareMemComm(pid_t pid) : Comm(pid), pid(pid) {
 }
 
 ShareMemComm::~ShareMemComm() {
+    // Also releases any flock a caller took for the op duration.
+    if (fd_control >= 0) close(fd_control);
 }
 
 void ShareMemComm::setup() {
@@ -31,7 +33,7 @@ void ShareMemComm::setup() {
     const char* ctl_dir = std::getenv("EXPORT_FILE_PATH");
     if (!ctl_dir) ctl_dir = "/mnt/huge-ckpt";
     snprintf(control_name, sizeof(control_name), "%s/control-%d", ctl_dir, pid);
-    int fd_control = open(control_name, O_CREAT | O_RDWR, 0755);
+    fd_control = open(control_name, O_CREAT | O_RDWR, 0755);
     if (fd_control < 0) {
         perror("open()");
         exit(EXIT_FAILURE);

--- a/third_party/gpu-cr/src/common.h
+++ b/third_party/gpu-cr/src/common.h
@@ -14,6 +14,7 @@
 #include <sys/mman.h>  // for mmap
 #include <pthread.h>  // for mutex lock
 #include <signal.h>   // for signal handling
+#include <cstring>    // for memset
 #include <map>
 #include <utility>
 #include <atomic>
@@ -77,8 +78,77 @@ struct shared_mem_fs {
     struct shared_mem_file files[MAX_FILE_NUM];
 };
 
+namespace gpu_cr {
+inline constexpr uint32_t kMaxSelectiveRegions = 4096;
+}  // namespace gpu_cr
+
+struct SelectiveCrRegion {
+    void* ptr;
+    uint64_t size;
+};
+
+// Destination-path selective checkpoints.
+// The v2 fields are APPENDED so the v1 prefix (num_regions + regions[])
+// keeps its exact offsets: a v1 .so never reads past regions[], and the
+// zero-initialized control mapping makes proto_version==0 (v1) the default.
+namespace gpu_cr {
+inline constexpr uint32_t kSelectiveCrProtoV2 = 2;
+inline constexpr size_t kSelectiveCrMaxPath = 256;
+}  // namespace gpu_cr
+
+struct SelectiveCrRequest {
+    uint32_t num_regions;
+    SelectiveCrRegion regions[gpu_cr::kMaxSelectiveRegions];
+    /* --- v2 extension --- */
+    uint32_t proto_version;                           /* 0 = v1, 2 = v2 */
+    /* dest_path: empty = per-PID buffer. Must be NUL-terminated; the
+     * client rejects paths >= kSelectiveCrMaxPath-1 chars before writing,
+     * and readers should treat dest_path[kSelectiveCrMaxPath-1] != '\0'
+     * as an invalid request. */
+    char     dest_path[gpu_cr::kSelectiveCrMaxPath];
+};
+
+namespace gpu_cr {
+// Capability bits published by the .so in signal_controls.capability at
+// init_CR and re-asserted at every FINISH (consume-once zeroing of the
+// request extension deliberately excludes this word).
+inline constexpr uint32_t kCrCapDestPath = 1u << 0;
+
+// Trailing commit marker for destination-file dumps: written at
+// fs->current_offset only after the last extent has landed, so a torn
+// dump is detectable. Restores from a destination file refuse dumps
+// whose marker is absent or has the wrong magic; generation is recorded
+// per dump and reserved for future staleness checks (not yet compared).
+inline constexpr uint64_t kDumpCommitMagic = 0x31524347u; /* "GCR1" */
+}  // namespace gpu_cr
+
+struct DumpCommit {
+    uint64_t magic;
+    uint64_t generation;
+};
+
 struct signal_controls {
     uint32_t signal;
+    SelectiveCrRequest selective_req;
+    /* --- v2 extension: appended, invisible to v1 readers --- */
+    uint32_t capability; /* gpu_cr::kCrCap* bits, persistent across ops */
+    uint32_t proto_ack;  /* proto level the .so served the last op at */
+    int32_t  op_status;  /* 0 = OK, else positive errno-style code */
 };
+
+namespace gpu_cr {
+// Post-op bookkeeping: report
+// status + proto ack, then consume the v2 request extension so a stale
+// dest_path can never redirect a later op (a v1 cr_client only rewrites
+// the v1 prefix). v2 clients gate cuda-checkpoint --toggle on op_status —
+// never freeze a process whose state was not saved.
+inline void FinishOpControls(signal_controls* c, int32_t op_status) {
+  c->op_status = op_status;
+  c->proto_ack = kSelectiveCrProtoV2;
+  c->selective_req.proto_version = 0;
+  std::memset(c->selective_req.dest_path, 0, kSelectiveCrMaxPath);
+  c->capability |= kCrCapDestPath;
+}
+}  // namespace gpu_cr
 
 #endif

--- a/third_party/gpu-cr/src/common.h
+++ b/third_party/gpu-cr/src/common.h
@@ -109,10 +109,15 @@ struct SelectiveCrRequest {
 };
 
 namespace gpu_cr {
-// Capability bits published by the .so in signal_controls.capability at
-// init_CR and re-asserted at every FINISH (consume-once zeroing of the
-// request extension deliberately excludes this word).
-inline constexpr uint32_t kCrCapDestPath = 1u << 0;
+// The .so publishes the selective protocol level it speaks in
+// signal_controls.proto_supported at init_CR and re-asserts it at every
+// FINISH (consume-once zeroing of the request extension deliberately
+// excludes this word). Zero means no .so has published yet — the mapping
+// zero-initializes — so a client that races init_CR fails fast instead of
+// signaling a library whose handlers are not armed. The word also lets a
+// future client detect an older resident .so: the library is LD_PRELOADed
+// for the life of the workload process, so rev N must publish the level
+// for a rev N+1 client to have anything to read.
 
 // Trailing commit marker for destination-file dumps: written at
 // fs->current_offset only after the last extent has landed, so a torn
@@ -131,7 +136,7 @@ struct signal_controls {
     uint32_t signal;
     SelectiveCrRequest selective_req;
     /* --- v2 extension: appended, invisible to v1 readers --- */
-    uint32_t capability; /* gpu_cr::kCrCap* bits, persistent across ops */
+    uint32_t proto_supported; /* selective proto level the .so speaks; 0 = not yet published */
     uint32_t proto_ack;  /* proto level the .so served the last op at */
     int32_t  op_status;  /* 0 = OK, else positive errno-style code */
 };
@@ -141,13 +146,14 @@ namespace gpu_cr {
 // status + proto ack, then consume the v2 request extension so a stale
 // dest_path can never redirect a later op (a v1 cr_client only rewrites
 // the v1 prefix). v2 clients gate cuda-checkpoint --toggle on op_status —
-// never freeze a process whose state was not saved.
+// never freeze a process whose state was not saved. proto_supported is
+// re-asserted so a client that attaches after init_CR still sees it.
 inline void FinishOpControls(signal_controls* c, int32_t op_status) {
   c->op_status = op_status;
   c->proto_ack = kSelectiveCrProtoV2;
   c->selective_req.proto_version = 0;
   std::memset(c->selective_req.dest_path, 0, kSelectiveCrMaxPath);
-  c->capability |= kCrCapDestPath;
+  c->proto_supported = kSelectiveCrProtoV2;
 }
 }  // namespace gpu_cr
 

--- a/third_party/gpu-cr/src/common.h
+++ b/third_party/gpu-cr/src/common.h
@@ -87,43 +87,46 @@ struct SelectiveCrRegion {
     uint64_t size;
 };
 
-// Destination-path selective checkpoints.
-// The v2 fields are APPENDED so the v1 prefix (num_regions + regions[])
-// keeps its exact offsets: a v1 .so never reads past regions[], and the
-// zero-initialized control mapping makes proto_version==0 (v1) the default.
+// Selective checkpoint/restore request: the region list names the
+// allocations to save/restore, and dest_path routes the dump to a
+// caller-named file instead of the per-PID buffer. Fields are only ever
+// APPENDED so the region-list prefix keeps its exact offsets across
+// separately-built cr_client and .so binaries sharing the mapping.
 namespace gpu_cr {
-inline constexpr uint32_t kSelectiveCrProtoV2 = 2;
 inline constexpr size_t kSelectiveCrMaxPath = 256;
 }  // namespace gpu_cr
 
 struct SelectiveCrRequest {
     uint32_t num_regions;
     SelectiveCrRegion regions[gpu_cr::kMaxSelectiveRegions];
-    /* --- v2 extension --- */
-    uint32_t proto_version;                           /* 0 = v1, 2 = v2 */
-    /* dest_path: empty = per-PID buffer. Must be NUL-terminated; the
-     * client rejects paths >= kSelectiveCrMaxPath-1 chars before writing,
-     * and readers should treat dest_path[kSelectiveCrMaxPath-1] != '\0'
-     * as an invalid request. */
+    /* dest_path: empty = per-PID buffer; non-empty = destination-file
+     * routing. Must be NUL-terminated: the client rejects paths
+     * >= kSelectiveCrMaxPath-1 chars before writing, and the .so refuses
+     * a request with dest_path[kSelectiveCrMaxPath-1] != '\0' (-EINVAL). */
     char     dest_path[gpu_cr::kSelectiveCrMaxPath];
 };
 
 namespace gpu_cr {
-// The .so publishes the selective protocol level it speaks in
-// signal_controls.proto_supported at init_CR and re-asserts it at every
-// FINISH (consume-once zeroing of the request extension deliberately
-// excludes this word). Zero means no .so has published yet — the mapping
-// zero-initializes — so a client that races init_CR fails fast instead of
-// signaling a library whose handlers are not armed. The word also lets a
-// future client detect an older resident .so: the library is LD_PRELOADed
-// for the life of the workload process, so rev N must publish the level
-// for a rev N+1 client to have anything to read.
+// The .so stores kSelectiveReady in signal_controls.selective_ready at
+// init_CR and re-asserts it at every FINISH (the consume-once zeroing of
+// the request deliberately leaves this word alone). Zero means no .so has
+// published yet — the mapping zero-initializes — so a client that races
+// init_CR, or one attached to a mismatched build, fails fast instead of
+// signaling a library whose handlers are not armed.
+inline constexpr uint32_t kSelectiveReady = 1;
+
+// op_status encoding: 0 = no result reported (fresh mapping, or the op
+// never reached FINISH), kOpStatusOk = success, negative = -errno.
+// FinishOpControls is the only writer: op sites record positive errno
+// values and FINISH negates, so 0 can never be mistaken for success.
+inline constexpr int32_t kOpStatusOk = 1;
 
 // Trailing commit marker for destination-file dumps: written at
 // fs->current_offset only after the last extent has landed, so a torn
-// dump is detectable. Restores from a destination file refuse dumps
-// whose marker is absent or has the wrong magic; generation is recorded
-// per dump and reserved for future staleness checks (not yet compared).
+// dump is detectable. Restores from a
+// destination file refuse dumps whose marker is absent or has the wrong
+// magic; generation is recorded per dump and reserved for future
+// staleness checks (not yet compared).
 inline constexpr uint64_t kDumpCommitMagic = 0x31524347u; /* "GCR1" */
 }  // namespace gpu_cr
 
@@ -135,25 +138,23 @@ struct DumpCommit {
 struct signal_controls {
     uint32_t signal;
     SelectiveCrRequest selective_req;
-    /* --- v2 extension: appended, invisible to v1 readers --- */
-    uint32_t proto_supported; /* selective proto level the .so speaks; 0 = not yet published */
-    uint32_t proto_ack;  /* proto level the .so served the last op at */
-    int32_t  op_status;  /* 0 = OK, else positive errno-style code */
+    uint32_t selective_ready; /* 0 until the .so publishes kSelectiveReady */
+    int32_t  op_status;       /* 0 = not reported, kOpStatusOk, or -errno */
 };
 
 namespace gpu_cr {
-// Post-op bookkeeping: report
-// status + proto ack, then consume the v2 request extension so a stale
-// dest_path can never redirect a later op (a v1 cr_client only rewrites
-// the v1 prefix). v2 clients gate cuda-checkpoint --toggle on op_status —
-// never freeze a process whose state was not saved. proto_supported is
-// re-asserted so a client that attaches after init_CR still sees it.
-inline void FinishOpControls(signal_controls* c, int32_t op_status) {
-  c->op_status = op_status;
-  c->proto_ack = kSelectiveCrProtoV2;
-  c->selective_req.proto_version = 0;
+// Post-op bookkeeping: publish the op result, then consume the request's
+// dest_path so a stale path can never redirect a later op — zeroing the
+// path IS the consumption, since a non-empty dest_path is what selects
+// destination-file routing. The region-list prefix is left alone: the
+// client rewrites it under flock for every op. Clients gate
+// cuda-checkpoint --toggle on a positive op_status — never freeze a
+// process whose state was not saved. selective_ready is re-asserted so a
+// client that attaches after init_CR still sees it.
+inline void FinishOpControls(signal_controls* c, int32_t rc) {
+  c->op_status = rc == 0 ? kOpStatusOk : -rc;
   std::memset(c->selective_req.dest_path, 0, kSelectiveCrMaxPath);
-  c->proto_supported = kSelectiveCrProtoV2;
+  c->selective_ready = kSelectiveReady;
 }
 }  // namespace gpu_cr
 

--- a/third_party/gpu-cr/src/common.h
+++ b/third_party/gpu-cr/src/common.h
@@ -80,8 +80,12 @@ struct shared_mem_fs {
 
 namespace gpu_cr {
 // Exclusive bound on regions per selective request: a request must carry
-// FEWER than this many regions. The dump writer refuses to fill the last
-// extent-table slot (file_num < MAX_FILE_NUM, matching
+// FEWER than this many regions. Each region becomes one shared_mem_fs
+// extent-table entry, so this equals MAX_FILE_NUM (the pristine GPU-CR
+// table size); at 16 bytes/region it also keeps the request at 64KiB in
+// the control mapping. Observed swaps use ~1000 regions, so the 4095
+// usable slots leave ~4x headroom. The dump writer refuses to fill the
+// last extent-table slot (file_num < MAX_FILE_NUM, matching
 // DumpHeaderPlausible), so a request gated at num_regions <
 // kMaxSelectiveRegions can never fail for capacity after the
 // device-to-host copy work has already been done.
@@ -99,6 +103,10 @@ struct SelectiveCrRegion {
 // APPENDED so the region-list prefix keeps its exact offsets across
 // separately-built cr_client and .so binaries sharing the mapping.
 namespace gpu_cr {
+// Destination paths are agent store files (<store>/<group>/ckpt-<id>.data,
+// well under 100 chars); 256 gives ample headroom while keeping the
+// request struct small. Not PATH_MAX: the client rejects longer paths
+// before signaling, so the cap fails crisply rather than by truncation.
 inline constexpr size_t kSelectiveCrMaxPath = 256;
 }  // namespace gpu_cr
 

--- a/third_party/gpu-cr/src/common.h
+++ b/third_party/gpu-cr/src/common.h
@@ -79,6 +79,12 @@ struct shared_mem_fs {
 };
 
 namespace gpu_cr {
+// Exclusive bound on regions per selective request: a request must carry
+// FEWER than this many regions. The dump writer refuses to fill the last
+// extent-table slot (file_num < MAX_FILE_NUM, matching
+// DumpHeaderPlausible), so a request gated at num_regions <
+// kMaxSelectiveRegions can never fail for capacity after the
+// device-to-host copy work has already been done.
 inline constexpr uint32_t kMaxSelectiveRegions = 4096;
 }  // namespace gpu_cr
 
@@ -122,8 +128,8 @@ inline constexpr uint32_t kSelectiveReady = 1;
 inline constexpr int32_t kOpStatusOk = 1;
 
 // Trailing commit marker for destination-file dumps: written at
-// fs->current_offset only after the last extent has landed, so a torn
-// dump is detectable. Restores from a
+// DumpCommitOffset(fs->current_offset) (see dump_format.h) only after
+// the last extent has landed, so a torn dump is detectable. Restores from a
 // destination file refuse dumps whose marker is absent or has the wrong
 // magic; generation is recorded per dump and reserved for future
 // staleness checks (not yet compared).

--- a/third_party/gpu-cr/src/dump_format.h
+++ b/third_party/gpu-cr/src/dump_format.h
@@ -4,11 +4,16 @@
 // Destination-file dump layout helpers.
 //
 // A dump is a shared_mem_fs header (2MiB-rounded), the extents, and a
-// trailing DumpCommit marker at current_offset. The marker is written
-// last, so its absence identifies a torn dump. These checks are shared
-// by cr_client (post-checkpoint validation, via read(2)) and the .so
-// (pre-restore validation, via mmap), and are pure so unit tests can
-// exercise them without a GPU.
+// trailing DumpCommit marker at DumpCommitOffset(current_offset). The
+// marker is written last, so its absence identifies a torn dump. These
+// checks are shared by cr_client (post-checkpoint validation, via
+// read(2)) and the .so (pre-restore validation, via mmap), and are pure
+// so unit tests can exercise them without a GPU.
+//
+// The format is host-endian (little-endian on every supported target;
+// dumps never cross machines of a different byte order). The 64-bit
+// magic carries 32 significant bits — "GCR1" as the first four bytes on
+// disk — with the upper half zero for extra discrimination.
 
 #include <stdint.h>
 #include <sys/stat.h>
@@ -18,17 +23,30 @@
 
 namespace gpu_cr {
 
+// Extents are packed unpadded, so current_offset itself can be
+// misaligned; the commit marker lives at the next alignof(DumpCommit)
+// boundary so the writer's atomic magic store and the mmap reader's load
+// are naturally aligned. May wrap to a smaller value for offsets near
+// UINT64_MAX — DumpHeaderPlausible rejects that case.
+inline constexpr uint64_t DumpCommitOffset(uint64_t current_offset) {
+  return (current_offset + alignof(DumpCommit) - 1) &
+         ~static_cast<uint64_t>(alignof(DumpCommit) - 1);
+}
+
 // Bounds-checks a dump header against the containing file/mapping size.
 // Does NOT check the commit marker (callers read it from its offset).
 inline bool DumpHeaderPlausible(uint64_t file_num, uint64_t current_offset,
                                 uint64_t total_size) {
   const uint64_t header_size = ROUND_UP_2MB(sizeof(shared_mem_fs));
-  // The subtraction form (not current_offset + sizeof(DumpCommit)) keeps a
-  // header-supplied offset near UINT64_MAX from wrapping past the bound.
+  const uint64_t marker = DumpCommitOffset(current_offset);
+  // The subtraction form (not marker + sizeof(DumpCommit)) keeps a
+  // header-supplied offset near UINT64_MAX from wrapping past the bound;
+  // marker >= current_offset rejects wrap in the rounding itself.
   return file_num > 0 && file_num < MAX_FILE_NUM &&
          total_size >= sizeof(DumpCommit) &&
          current_offset >= header_size &&
-         current_offset <= total_size - sizeof(DumpCommit);
+         marker >= current_offset &&
+         marker <= total_size - sizeof(DumpCommit);
 }
 
 // Validates a whole dump file through an open fd using pread(2) — no
@@ -42,7 +60,8 @@ inline bool ValidateDumpFd(int fd) {
              static_cast<ssize_t>(sizeof(hdr)) &&
          DumpHeaderPlausible(hdr[0], hdr[1],
                              static_cast<uint64_t>(st.st_size)) &&
-         pread(fd, &commit, sizeof(commit), static_cast<off_t>(hdr[1])) ==
+         pread(fd, &commit, sizeof(commit),
+               static_cast<off_t>(DumpCommitOffset(hdr[1]))) ==
              static_cast<ssize_t>(sizeof(commit)) &&
          commit.magic == kDumpCommitMagic;
 }

--- a/third_party/gpu-cr/src/dump_format.h
+++ b/third_party/gpu-cr/src/dump_format.h
@@ -15,6 +15,7 @@
 // magic carries 32 significant bits — "GCR1" as the first four bytes on
 // disk — with the upper half zero for extra discrimination.
 
+#include <stddef.h>
 #include <stdint.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -48,6 +49,14 @@ inline bool DumpHeaderPlausible(uint64_t file_num, uint64_t current_offset,
          marker >= current_offset &&
          marker <= total_size - sizeof(DumpCommit);
 }
+
+// ValidateDumpFd reads the header as two raw 64-bit words instead of a
+// shared_mem_fs (whose extent table would drag 64KiB through the pread);
+// pin the layout that shortcut hard-codes.
+static_assert(offsetof(shared_mem_fs, file_num) == 0,
+              "ValidateDumpFd reads file_num as raw word 0");
+static_assert(offsetof(shared_mem_fs, current_offset) == 8,
+              "ValidateDumpFd reads current_offset as raw word 1");
 
 // Validates a whole dump file through an open fd using pread(2) — no
 // mmap, so no hugetlb reservation or fault lands in the caller's cgroup.

--- a/third_party/gpu-cr/src/dump_format.h
+++ b/third_party/gpu-cr/src/dump_format.h
@@ -1,0 +1,52 @@
+#ifndef GPU_CR_SRC_DUMP_FORMAT_H_
+#define GPU_CR_SRC_DUMP_FORMAT_H_
+
+// Destination-file dump layout helpers.
+//
+// A dump is a shared_mem_fs header (2MiB-rounded), the extents, and a
+// trailing DumpCommit marker at current_offset. The marker is written
+// last, so its absence identifies a torn dump. These checks are shared
+// by cr_client (post-checkpoint validation, via read(2)) and the .so
+// (pre-restore validation, via mmap), and are pure so unit tests can
+// exercise them without a GPU.
+
+#include <stdint.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "common.h"
+
+namespace gpu_cr {
+
+// Bounds-checks a dump header against the containing file/mapping size.
+// Does NOT check the commit marker (callers read it from its offset).
+inline bool DumpHeaderPlausible(uint64_t file_num, uint64_t current_offset,
+                                uint64_t total_size) {
+  const uint64_t header_size = ROUND_UP_2MB(sizeof(shared_mem_fs));
+  // The subtraction form (not current_offset + sizeof(DumpCommit)) keeps a
+  // header-supplied offset near UINT64_MAX from wrapping past the bound.
+  return file_num > 0 && file_num < MAX_FILE_NUM &&
+         total_size >= sizeof(DumpCommit) &&
+         current_offset >= header_size &&
+         current_offset <= total_size - sizeof(DumpCommit);
+}
+
+// Validates a whole dump file through an open fd using pread(2) — no
+// mmap, so no hugetlb reservation or fault lands in the caller's cgroup.
+inline bool ValidateDumpFd(int fd) {
+  struct stat st;
+  uint64_t hdr[2];  // file_num, current_offset
+  DumpCommit commit;
+  return fstat(fd, &st) == 0 &&
+         pread(fd, hdr, sizeof(hdr), 0) ==
+             static_cast<ssize_t>(sizeof(hdr)) &&
+         DumpHeaderPlausible(hdr[0], hdr[1],
+                             static_cast<uint64_t>(st.st_size)) &&
+         pread(fd, &commit, sizeof(commit), static_cast<off_t>(hdr[1])) ==
+             static_cast<ssize_t>(sizeof(commit)) &&
+         commit.magic == kDumpCommitMagic;
+}
+
+}  // namespace gpu_cr
+
+#endif  // GPU_CR_SRC_DUMP_FORMAT_H_

--- a/third_party/gpu-cr/tests/unit/common_baseline_test.cpp
+++ b/third_party/gpu-cr/tests/unit/common_baseline_test.cpp
@@ -1,6 +1,6 @@
 // Upstream-baseline pieces of common.h (inherited from upstream): the 2MB
-// rounding macro, hugepage geometry, the C/R signal numbers, and the v1
-// control-word prefix that every later extension must leave undisturbed.
+// rounding macro, hugepage geometry, the C/R signal numbers, and the
+// control-word prefix that every appended field must leave undisturbed.
 
 #include "common.h"
 
@@ -41,8 +41,8 @@ TEST(RoundUp2MBTest, LargeValuesKeepFullWidth) {
   EXPECT_EQ(ROUND_UP_2MB((25UL << 30) + 1), (25UL << 30) + (2UL << 20));
 }
 
-// The v1 control word must stay at offset 0: an upstream cr_client and a
-// current .so share the same zero-initialized mapping.
+// The upstream control word must stay at offset 0: an upstream cr_client
+// and a current .so share the same zero-initialized mapping.
 TEST(SignalControlsLayoutTest, SignalWordIsFirst) {
   EXPECT_EQ(offsetof(signal_controls, signal), 0u);
 }

--- a/third_party/gpu-cr/tests/unit/common_test.cpp
+++ b/third_party/gpu-cr/tests/unit/common_test.cpp
@@ -1,0 +1,86 @@
+// Shared-protocol helpers from common.h: the consume-once FINISH
+// bookkeeping and the wire-layout guards for the v2 extension.
+
+#include "common.h"
+
+#include <errno.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "gtest/gtest.h"
+
+namespace gpu_cr {
+namespace {
+
+TEST(FinishOpControlsTest, ReportsStatusAndAck) {
+  signal_controls c;
+  memset(&c, 0, sizeof(c));
+  FinishOpControls(&c, ENOSPC);
+  EXPECT_EQ(c.op_status, ENOSPC);
+  EXPECT_EQ(c.proto_ack, kSelectiveCrProtoV2);
+  EXPECT_EQ(c.capability & kCrCapDestPath, kCrCapDestPath);
+}
+
+// A stale dest_path must never redirect a later op: the v2 extension is
+// consumed at FINISH.
+TEST(FinishOpControlsTest, ConsumesRequestExtension) {
+  signal_controls c;
+  memset(&c, 0, sizeof(c));
+  c.selective_req.proto_version = kSelectiveCrProtoV2;
+  strncpy(c.selective_req.dest_path, "/store/dump.bin",
+          kSelectiveCrMaxPath - 1);
+  c.selective_req.num_regions = 2;  // v1 prefix is NOT consumed
+
+  FinishOpControls(&c, 0);
+  EXPECT_EQ(c.selective_req.proto_version, 0u);
+  for (size_t i = 0; i < kSelectiveCrMaxPath; i++)
+    ASSERT_EQ(c.selective_req.dest_path[i], '\0');
+  EXPECT_EQ(c.selective_req.num_regions, 2u);
+}
+
+// Bits FINISH does not own must survive it: pre-set a foreign bit with
+// kCrCapDestPath clear and check FINISH keeps the former while OR-ing in
+// the latter.
+TEST(FinishOpControlsTest, CapabilityPersistsAcrossOps) {
+  constexpr uint32_t kForeignCap = 1u << 1;
+  signal_controls c;
+  memset(&c, 0, sizeof(c));
+  c.capability = kForeignCap;
+  FinishOpControls(&c, EIO);
+  EXPECT_EQ(c.capability & kForeignCap, kForeignCap);
+  EXPECT_EQ(c.capability & kCrCapDestPath, kCrCapDestPath);
+}
+
+// Layout guards for the shared-memory wire structs: the v2 fields are
+// appended so the v1 prefix keeps its exact offsets.
+TEST(WireLayoutTest, V1PrefixOffsetsUnchanged) {
+  EXPECT_EQ(offsetof(SelectiveCrRequest, num_regions), 0u);
+  EXPECT_EQ(offsetof(SelectiveCrRequest, regions), 8u);
+  EXPECT_EQ(offsetof(signal_controls, selective_req), 8u);
+}
+
+// The appended v2 fields are what a separately-built cr_client and .so
+// agree on through the shared mapping: pin the exact x86-64 offsets and
+// sizes (style of common_baseline_test.cpp) so an added/reordered field —
+// or a changed kMaxSelectiveRegions/kSelectiveCrMaxPath, which would
+// silently shift every v2 offset — fails here instead of on the wire.
+TEST(WireLayoutTest, V2ExtensionOffsetsPinned) {
+  EXPECT_EQ(kMaxSelectiveRegions, 4096u);
+  EXPECT_EQ(kSelectiveCrMaxPath, 256u);
+
+  EXPECT_EQ(offsetof(SelectiveCrRegion, ptr), 0u);
+  EXPECT_EQ(offsetof(SelectiveCrRegion, size), 8u);
+  EXPECT_EQ(sizeof(SelectiveCrRegion), 16u);
+
+  EXPECT_EQ(offsetof(SelectiveCrRequest, proto_version), 65544u);
+  EXPECT_EQ(offsetof(SelectiveCrRequest, dest_path), 65548u);
+  EXPECT_EQ(sizeof(SelectiveCrRequest), 65808u);
+
+  EXPECT_EQ(offsetof(signal_controls, capability), 65816u);
+  EXPECT_EQ(offsetof(signal_controls, proto_ack), 65820u);
+  EXPECT_EQ(offsetof(signal_controls, op_status), 65824u);
+  EXPECT_EQ(sizeof(signal_controls), 65832u);
+}
+
+}  // namespace
+}  // namespace gpu_cr

--- a/third_party/gpu-cr/tests/unit/common_test.cpp
+++ b/third_party/gpu-cr/tests/unit/common_test.cpp
@@ -18,7 +18,7 @@ TEST(FinishOpControlsTest, ReportsStatusAndAck) {
   FinishOpControls(&c, ENOSPC);
   EXPECT_EQ(c.op_status, ENOSPC);
   EXPECT_EQ(c.proto_ack, kSelectiveCrProtoV2);
-  EXPECT_EQ(c.capability & kCrCapDestPath, kCrCapDestPath);
+  EXPECT_EQ(c.proto_supported, kSelectiveCrProtoV2);
 }
 
 // A stale dest_path must never redirect a later op: the v2 extension is
@@ -38,17 +38,14 @@ TEST(FinishOpControlsTest, ConsumesRequestExtension) {
   EXPECT_EQ(c.selective_req.num_regions, 2u);
 }
 
-// Bits FINISH does not own must survive it: pre-set a foreign bit with
-// kCrCapDestPath clear and check FINISH keeps the former while OR-ing in
-// the latter.
-TEST(FinishOpControlsTest, CapabilityPersistsAcrossOps) {
-  constexpr uint32_t kForeignCap = 1u << 1;
+// The published proto level must survive the consume-once zeroing and be
+// re-asserted at every FINISH, so a client that attaches after init_CR
+// (word still 0 from its point of view) sees it once any op completes.
+TEST(FinishOpControlsTest, ReassertsProtoSupported) {
   signal_controls c;
-  memset(&c, 0, sizeof(c));
-  c.capability = kForeignCap;
+  memset(&c, 0, sizeof(c));  // as if the client raced init_CR
   FinishOpControls(&c, EIO);
-  EXPECT_EQ(c.capability & kForeignCap, kForeignCap);
-  EXPECT_EQ(c.capability & kCrCapDestPath, kCrCapDestPath);
+  EXPECT_EQ(c.proto_supported, kSelectiveCrProtoV2);
 }
 
 // Layout guards for the shared-memory wire structs: the v2 fields are
@@ -76,7 +73,7 @@ TEST(WireLayoutTest, V2ExtensionOffsetsPinned) {
   EXPECT_EQ(offsetof(SelectiveCrRequest, dest_path), 65548u);
   EXPECT_EQ(sizeof(SelectiveCrRequest), 65808u);
 
-  EXPECT_EQ(offsetof(signal_controls, capability), 65816u);
+  EXPECT_EQ(offsetof(signal_controls, proto_supported), 65816u);
   EXPECT_EQ(offsetof(signal_controls, proto_ack), 65820u);
   EXPECT_EQ(offsetof(signal_controls, op_status), 65824u);
   EXPECT_EQ(sizeof(signal_controls), 65832u);

--- a/third_party/gpu-cr/tests/unit/common_test.cpp
+++ b/third_party/gpu-cr/tests/unit/common_test.cpp
@@ -1,5 +1,5 @@
 // Shared-protocol helpers from common.h: the consume-once FINISH
-// bookkeeping and the wire-layout guards for the v2 extension.
+// bookkeeping and the wire-layout guards for the selective request.
 
 #include "common.h"
 
@@ -12,56 +12,59 @@
 namespace gpu_cr {
 namespace {
 
-TEST(FinishOpControlsTest, ReportsStatusAndAck) {
+// FinishOpControls is the only writer of op_status: op sites hand it a
+// positive errno (or 0), and it stores kOpStatusOk or the negated errno,
+// so 0 always means "no result reported".
+TEST(FinishOpControlsTest, ReportsStatus) {
   signal_controls c;
   memset(&c, 0, sizeof(c));
   FinishOpControls(&c, ENOSPC);
-  EXPECT_EQ(c.op_status, ENOSPC);
-  EXPECT_EQ(c.proto_ack, kSelectiveCrProtoV2);
-  EXPECT_EQ(c.proto_supported, kSelectiveCrProtoV2);
-}
-
-// A stale dest_path must never redirect a later op: the v2 extension is
-// consumed at FINISH.
-TEST(FinishOpControlsTest, ConsumesRequestExtension) {
-  signal_controls c;
-  memset(&c, 0, sizeof(c));
-  c.selective_req.proto_version = kSelectiveCrProtoV2;
-  strncpy(c.selective_req.dest_path, "/store/dump.bin",
-          kSelectiveCrMaxPath - 1);
-  c.selective_req.num_regions = 2;  // v1 prefix is NOT consumed
+  EXPECT_EQ(c.op_status, -ENOSPC);
 
   FinishOpControls(&c, 0);
-  EXPECT_EQ(c.selective_req.proto_version, 0u);
+  EXPECT_EQ(c.op_status, kOpStatusOk);
+  EXPECT_GT(c.op_status, 0);
+}
+
+// A stale dest_path must never redirect a later op: a non-empty path is
+// what selects destination-file routing, so FINISH zeroes it.
+TEST(FinishOpControlsTest, ConsumesDestPath) {
+  signal_controls c;
+  memset(&c, 0, sizeof(c));
+  strncpy(c.selective_req.dest_path, "/store/dump.bin",
+          kSelectiveCrMaxPath - 1);
+  c.selective_req.num_regions = 2;  // region-list prefix is NOT consumed
+
+  FinishOpControls(&c, 0);
   for (size_t i = 0; i < kSelectiveCrMaxPath; i++)
     ASSERT_EQ(c.selective_req.dest_path[i], '\0');
   EXPECT_EQ(c.selective_req.num_regions, 2u);
 }
 
-// The published proto level must survive the consume-once zeroing and be
+// The published ready word must survive the consume-once zeroing and be
 // re-asserted at every FINISH, so a client that attaches after init_CR
 // (word still 0 from its point of view) sees it once any op completes.
-TEST(FinishOpControlsTest, ReassertsProtoSupported) {
+TEST(FinishOpControlsTest, ReassertsSelectiveReady) {
   signal_controls c;
   memset(&c, 0, sizeof(c));  // as if the client raced init_CR
   FinishOpControls(&c, EIO);
-  EXPECT_EQ(c.proto_supported, kSelectiveCrProtoV2);
+  EXPECT_EQ(c.selective_ready, kSelectiveReady);
 }
 
-// Layout guards for the shared-memory wire structs: the v2 fields are
-// appended so the v1 prefix keeps its exact offsets.
-TEST(WireLayoutTest, V1PrefixOffsetsUnchanged) {
+// Layout guards for the shared-memory wire structs: fields are only ever
+// appended, so the region-list prefix keeps its exact offsets.
+TEST(WireLayoutTest, RegionListPrefixOffsets) {
   EXPECT_EQ(offsetof(SelectiveCrRequest, num_regions), 0u);
   EXPECT_EQ(offsetof(SelectiveCrRequest, regions), 8u);
   EXPECT_EQ(offsetof(signal_controls, selective_req), 8u);
 }
 
-// The appended v2 fields are what a separately-built cr_client and .so
-// agree on through the shared mapping: pin the exact x86-64 offsets and
-// sizes (style of common_baseline_test.cpp) so an added/reordered field —
-// or a changed kMaxSelectiveRegions/kSelectiveCrMaxPath, which would
-// silently shift every v2 offset — fails here instead of on the wire.
-TEST(WireLayoutTest, V2ExtensionOffsetsPinned) {
+// The appended fields are what a separately-built cr_client and .so agree
+// on through the shared mapping: pin the exact x86-64 offsets and sizes
+// (style of common_baseline_test.cpp) so an added/reordered field — or a
+// changed kMaxSelectiveRegions/kSelectiveCrMaxPath, which would silently
+// shift every later offset — fails here instead of on the wire.
+TEST(WireLayoutTest, AppendedFieldsOffsetsPinned) {
   EXPECT_EQ(kMaxSelectiveRegions, 4096u);
   EXPECT_EQ(kSelectiveCrMaxPath, 256u);
 
@@ -69,14 +72,12 @@ TEST(WireLayoutTest, V2ExtensionOffsetsPinned) {
   EXPECT_EQ(offsetof(SelectiveCrRegion, size), 8u);
   EXPECT_EQ(sizeof(SelectiveCrRegion), 16u);
 
-  EXPECT_EQ(offsetof(SelectiveCrRequest, proto_version), 65544u);
-  EXPECT_EQ(offsetof(SelectiveCrRequest, dest_path), 65548u);
-  EXPECT_EQ(sizeof(SelectiveCrRequest), 65808u);
+  EXPECT_EQ(offsetof(SelectiveCrRequest, dest_path), 65544u);
+  EXPECT_EQ(sizeof(SelectiveCrRequest), 65800u);
 
-  EXPECT_EQ(offsetof(signal_controls, proto_supported), 65816u);
-  EXPECT_EQ(offsetof(signal_controls, proto_ack), 65820u);
-  EXPECT_EQ(offsetof(signal_controls, op_status), 65824u);
-  EXPECT_EQ(sizeof(signal_controls), 65832u);
+  EXPECT_EQ(offsetof(signal_controls, selective_ready), 65808u);
+  EXPECT_EQ(offsetof(signal_controls, op_status), 65812u);
+  EXPECT_EQ(sizeof(signal_controls), 65816u);
 }
 
 }  // namespace

--- a/third_party/gpu-cr/tests/unit/dump_format_test.cpp
+++ b/third_party/gpu-cr/tests/unit/dump_format_test.cpp
@@ -50,6 +50,28 @@ TEST(DumpHeaderPlausibleTest, RejectsWrappingOffset) {
                                    kHeaderSize + sizeof(DumpCommit)));
 }
 
+// An offset whose alignment ROUNDING wraps must be rejected too:
+// DumpCommitOffset(UINT64_MAX - 3) wraps to 0.
+TEST(DumpHeaderPlausibleTest, RejectsOffsetWhoseRoundingWraps) {
+  EXPECT_FALSE(DumpHeaderPlausible(1, UINT64_MAX - 3,
+                                   kHeaderSize + sizeof(DumpCommit)));
+}
+
+// Extents are unpadded, so current_offset is routinely misaligned; the
+// marker sits at the next alignof(DumpCommit) boundary.
+TEST(DumpHeaderPlausibleTest, AcceptsMisalignedCurrentOffset) {
+  const uint64_t misaligned = kHeaderSize + 4093;  // 4093 % 8 != 0
+  EXPECT_TRUE(DumpHeaderPlausible(
+      1, misaligned, DumpCommitOffset(misaligned) + sizeof(DumpCommit)));
+}
+
+TEST(DumpCommitOffsetTest, RoundsUpToMarkerAlignment) {
+  EXPECT_EQ(DumpCommitOffset(0), 0u);
+  EXPECT_EQ(DumpCommitOffset(8), 8u);
+  EXPECT_EQ(DumpCommitOffset(9), 16u);
+  EXPECT_EQ(DumpCommitOffset(15), 16u);
+}
+
 // Writes a synthetic dump: header (file_num, current_offset), one extent of
 // `extent` bytes, and (optionally) the trailing commit marker.
 class ValidateDumpFdTest : public ::testing::Test {
@@ -67,14 +89,15 @@ class ValidateDumpFdTest : public ::testing::Test {
   void WriteDump(uint64_t file_num, uint64_t extent, bool with_commit,
                  uint64_t magic = kDumpCommitMagic) {
     uint64_t current_offset = kHeaderSize + extent;
+    uint64_t marker = DumpCommitOffset(current_offset);
     uint64_t hdr[2] = {file_num, current_offset};
     ASSERT_EQ(pwrite(fd_, hdr, sizeof(hdr), 0),
               static_cast<ssize_t>(sizeof(hdr)));
-    ASSERT_EQ(ftruncate(fd_, current_offset + sizeof(DumpCommit)), 0);
+    ASSERT_EQ(ftruncate(fd_, marker + sizeof(DumpCommit)), 0);
     if (with_commit) {
       DumpCommit commit = {magic, /*generation=*/1};
       ASSERT_EQ(pwrite(fd_, &commit, sizeof(commit),
-                       static_cast<off_t>(current_offset)),
+                       static_cast<off_t>(marker)),
                 static_cast<ssize_t>(sizeof(commit)));
     }
   }
@@ -85,6 +108,11 @@ class ValidateDumpFdTest : public ::testing::Test {
 
 TEST_F(ValidateDumpFdTest, AcceptsCommittedDump) {
   WriteDump(/*file_num=*/1, /*extent=*/4096, /*with_commit=*/true);
+  EXPECT_TRUE(ValidateDumpFd(fd_));
+}
+
+TEST_F(ValidateDumpFdTest, AcceptsCommittedDumpWithMisalignedExtent) {
+  WriteDump(/*file_num=*/1, /*extent=*/4093, /*with_commit=*/true);
   EXPECT_TRUE(ValidateDumpFd(fd_));
 }
 

--- a/third_party/gpu-cr/tests/unit/dump_format_test.cpp
+++ b/third_party/gpu-cr/tests/unit/dump_format_test.cpp
@@ -1,0 +1,117 @@
+// Destination-dump layout validation (header plausibility and
+// commit marker) against crafted files — no GPU required.
+
+#include "dump_format.h"
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <string>
+#include <vector>
+
+#include "gtest/gtest.h"
+
+namespace gpu_cr {
+namespace {
+
+constexpr uint64_t kHeaderSize = ROUND_UP_2MB(sizeof(shared_mem_fs));
+
+TEST(DumpHeaderPlausibleTest, AcceptsMinimalValidHeader) {
+  EXPECT_TRUE(DumpHeaderPlausible(/*file_num=*/1, kHeaderSize,
+                                  kHeaderSize + sizeof(DumpCommit)));
+}
+
+TEST(DumpHeaderPlausibleTest, RejectsZeroFiles) {
+  EXPECT_FALSE(DumpHeaderPlausible(0, kHeaderSize,
+                                   kHeaderSize + sizeof(DumpCommit)));
+}
+
+TEST(DumpHeaderPlausibleTest, RejectsFileNumAtLimit) {
+  EXPECT_FALSE(DumpHeaderPlausible(MAX_FILE_NUM, kHeaderSize,
+                                   kHeaderSize + sizeof(DumpCommit)));
+}
+
+TEST(DumpHeaderPlausibleTest, RejectsOffsetInsideHeader) {
+  EXPECT_FALSE(DumpHeaderPlausible(1, kHeaderSize - 1,
+                                   kHeaderSize + sizeof(DumpCommit)));
+}
+
+TEST(DumpHeaderPlausibleTest, RejectsCommitMarkerPastEof) {
+  EXPECT_FALSE(DumpHeaderPlausible(1, kHeaderSize,
+                                   kHeaderSize + sizeof(DumpCommit) - 1));
+}
+
+// A header-supplied offset near UINT64_MAX must not wrap
+// current_offset + sizeof(DumpCommit) back under total_size.
+TEST(DumpHeaderPlausibleTest, RejectsWrappingOffset) {
+  EXPECT_FALSE(DumpHeaderPlausible(1, UINT64_MAX - 8,
+                                   kHeaderSize + sizeof(DumpCommit)));
+}
+
+// Writes a synthetic dump: header (file_num, current_offset), one extent of
+// `extent` bytes, and (optionally) the trailing commit marker.
+class ValidateDumpFdTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    snprintf(path_, sizeof(path_), "/tmp/gpu-cr-dump-test-XXXXXX");
+    fd_ = mkstemp(path_);
+    ASSERT_GE(fd_, 0);
+  }
+  void TearDown() override {
+    close(fd_);
+    unlink(path_);
+  }
+
+  void WriteDump(uint64_t file_num, uint64_t extent, bool with_commit,
+                 uint64_t magic = kDumpCommitMagic) {
+    uint64_t current_offset = kHeaderSize + extent;
+    uint64_t hdr[2] = {file_num, current_offset};
+    ASSERT_EQ(pwrite(fd_, hdr, sizeof(hdr), 0),
+              static_cast<ssize_t>(sizeof(hdr)));
+    ASSERT_EQ(ftruncate(fd_, current_offset + sizeof(DumpCommit)), 0);
+    if (with_commit) {
+      DumpCommit commit = {magic, /*generation=*/1};
+      ASSERT_EQ(pwrite(fd_, &commit, sizeof(commit),
+                       static_cast<off_t>(current_offset)),
+                static_cast<ssize_t>(sizeof(commit)));
+    }
+  }
+
+  char path_[64];
+  int fd_ = -1;
+};
+
+TEST_F(ValidateDumpFdTest, AcceptsCommittedDump) {
+  WriteDump(/*file_num=*/1, /*extent=*/4096, /*with_commit=*/true);
+  EXPECT_TRUE(ValidateDumpFd(fd_));
+}
+
+TEST_F(ValidateDumpFdTest, RejectsTornDump) {
+  WriteDump(1, 4096, /*with_commit=*/false);
+  EXPECT_FALSE(ValidateDumpFd(fd_));
+}
+
+TEST_F(ValidateDumpFdTest, RejectsWrongMagic) {
+  WriteDump(1, 4096, true, /*magic=*/0xdeadbeef);
+  EXPECT_FALSE(ValidateDumpFd(fd_));
+}
+
+TEST_F(ValidateDumpFdTest, RejectsEmptyFile) {
+  EXPECT_FALSE(ValidateDumpFd(fd_));
+}
+
+TEST_F(ValidateDumpFdTest, RejectsZeroFileNum) {
+  WriteDump(0, 4096, true);
+  EXPECT_FALSE(ValidateDumpFd(fd_));
+}
+
+TEST_F(ValidateDumpFdTest, RejectsTruncatedBelowCurrentOffset) {
+  WriteDump(1, 4096, true);
+  ASSERT_EQ(ftruncate(fd_, kHeaderSize), 0);
+  EXPECT_FALSE(ValidateDumpFd(fd_));
+}
+
+}  // namespace
+}  // namespace gpu_cr


### PR DESCRIPTION
## What does this PR do?

Defines the contract for selective checkpointing — checkpointing/restoring a
  caller-specified list of GPU memory regions instead of the whole process. It has two halves:

  **Wire protocol** between `cr_client` and the preloaded `vGPU.so`, over the existing
  shared-memory control mapping:

  - A request struct: `num_regions` + `regions[]`, plus an optional `dest_path` that routes
    the dump to a caller-named file instead of the per-PID buffer.
  - Two new message IDs: `SELECTIVE_CKPT_MSG` / `SELECTIVE_RESTORE_MSG`.
  - A `selective_ready` word the `.so` publishes at init.
  - An `op_status` result word: `0` = op never reported, `kOpStatusOk` = saved,
    negative = `-errno`.
  - `FinishOpControls()` centralizes end-of-op bookkeeping: it is the only writer of
    `op_status`, and it zeroes `dest_path` so a request can never be consumed twice.

  **Dump format commit marker**: a 16-byte `DumpCommit` trailer written last (8-aligned,
  release-ordered), so an interrupted dump is detectable by its absence. `dump_format.h`
  holds the shared validation helpers (`DumpHeaderPlausible`, `ValidateDumpFd`) used by both
  the writer side and the restore side; validation is pread-based so callers don't take
  hugetlb mappings just to check a file.

  This PR is headers and CPU-only unit tests; nothing calls the new code yet.
<!-- Describe the changes and their purpose -->

## Why is this change needed?

Instead of dumping an entire
  process, the coordinator names exactly the regions that matter and where the dump should
  land in the snapshot store. Every later piece of the feature depends on both sides agreeing
  on what these bytes mean, so that agreement is established first, in one reviewable place.

  The specific mechanisms exist for failure modes we can't avoid:

  - The `.so` is LD_PRELOADed into a long-lived application process while `cr_client` ships
    separately. The control mapping starts zeroed, so `selective_ready == 0` means "no .so,
    wrong build, or not yet initialized" — the client refuses before signaling instead of
    writing a request nobody has armed handlers for.
  - The `op_status` encoding distinguishes "op never reported" from "saved", so the client
    only proceeds (e.g. to `cuda-checkpoint --toggle`) when state was actually written — a
    zeroed word can never read as success.
  - Consuming `dest_path` at FINISH guarantees a stale path can't silently redirect a
    later dump.
  - The dump writer is the process being checkpointed, so dying mid-dump (OOM-kill, eviction,
    node crash) is routine and runs no error path. The commit marker makes the file
    self-certifying: whoever reads it later can tell "finished" from "torn" with two preads,
    instead of restoring garbage into GPU memory.

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for selective checkpoint and restore requests.
  * Added readiness and operation-status reporting for checkpoint workflows.
  * Added validation for dump files, including headers, alignment, commit markers, truncation, and incomplete dumps.
  * Improved control-file handling during shared-memory operations.

* **Tests**
  * Added coverage for selective checkpoint protocol behavior and dump-format validation.
  * Expanded GPU-independent unit-test coverage for valid, invalid, and incomplete dump files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->