### PR TITLE
docs: fix stale orchestrator service name in generic integration guide

### DIFF
--- a/guides/rl-frameworks/README.md
+++ b/guides/rl-frameworks/README.md
@@ -100,7 +100,7 @@ Add time-slicing configuration options to the framework's argument parser:
 ```python
 parser.add_argument("--enable-timeslice", action="store_true", default=False)
 parser.add_argument("--timeslice-orchestrator-addr", type=str,
-    default="timeslice-acceleratororchestrator.timeslice-system.svc.cluster.local:50051")
+    default="timeslice-timesliceorchestrator.timeslice-system.svc.cluster.local:50051")
 parser.add_argument("--timeslice-job-id", type=str, default=None)
 parser.add_argument("--timeslice-sampler-group", type=str, default="samplers")
 parser.add_argument("--timeslice-trainer-group", type=str, default="trainers")


### PR DESCRIPTION
One-line doc fix: the code example in guides/rl-frameworks/README.md still referenced the pre-rename service name timeslice-acceleratororchestrator. The deployed service is timeslice-timesliceorchestrator since #136.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the manual Slime integration guide with the correct default timeslice orchestrator address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->