### PR TITLE
orchestrator: hold promotion while the active job's grant is unconsumed

### DIFF
--- a/pkg/timeslice-orchestrator/controller/controller.go
+++ b/pkg/timeslice-orchestrator/controller/controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
+	"sync"
 	"time"
 
 	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/logging"
@@ -95,6 +96,21 @@ type Controller struct {
 	infraOrchestrator InfrastructureOrchestrator
 	agentStore        store.SnapshotAgentStore
 	ResyncPeriod      time.Duration
+
+	// SettleTimeout bounds how long promotion of the next waiter is held
+	// while the current active job's grant is unconsumed (granted but never
+	// observed RUNNING). See waitForGrantSettlement.
+	SettleTimeout time.Duration
+
+	settleMu    sync.Mutex
+	settleSince map[string]settleEntry
+}
+
+// settleEntry remembers when a group's active job was first seen holding an
+// unconsumed grant, so the promotion hold is bounded per (group, job).
+type settleEntry struct {
+	jobID string
+	since time.Time
 }
 
 // NewController creates a new Controller with the provided stores, queue, and infrastructure orchestrator.
@@ -112,6 +128,8 @@ func NewController(
 		infraOrchestrator: infraOrchestrator,
 		agentStore:        agentStore,
 		ResyncPeriod:      30 * time.Second,
+		SettleTimeout:     30 * time.Second,
+		settleSince:       make(map[string]settleEntry),
 	}
 }
 
@@ -229,6 +247,10 @@ func (c *Controller) reconcileGroup(ctx context.Context, groupID string) error {
 
 	if err := c.tryDeduceActiveJob(ctx, group); err != nil {
 		return fmt.Errorf("failed to try deducing active job: %w", err)
+	}
+
+	if err := c.waitForGrantSettlement(ctx, group); err != nil {
+		return err
 	}
 
 	if _, err := group.Spec().TryPromote(ctx); err != nil {
@@ -351,6 +373,76 @@ func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activ
 	}
 
 	return nil
+}
+
+// waitForGrantSettlement holds promotion of the next waiter while the current
+// active job's grant is unconsumed: it was granted the group lock but has
+// never been observed RUNNING (its context state is still IDLE on a group
+// node). Such a job's engine may be seconds from touching the accelerator —
+// it registers IDLE when its pods appear and the watcher only reports PIDs on
+// its next poll — so promoting now would let the handoff restore another
+// job's context onto a device that is about to be occupied.
+//
+// This cannot reintroduce the cold-start deadlock (#137): parked
+// pre-provisioned jobs are never the ACTIVE job, so only the one job whose
+// grant is genuinely in flight is ever waited on, and the wait is bounded by
+// SettleTimeout for grants that never produce device activity (crashed
+// engine, a job that exited right after its grant).
+func (c *Controller) waitForGrantSettlement(ctx context.Context, group *store.Group) error {
+	groupID := group.ID()
+	active := group.Spec().ActiveJob()
+	// No hold unless a promotion is actually pending behind an active job.
+	if active == "" || group.Spec().LockingJob() != "" || group.Spec().GetWaitingJobQueue().Len() == 0 {
+		c.clearSettle(groupID)
+		return nil
+	}
+
+	job, err := c.jobStore.Get(ctx, groupID, active)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			// No pods -> nothing observable to wait on.
+			c.clearSettle(groupID)
+			return nil
+		}
+		return fmt.Errorf("failed to get active job %s: %w", active, err)
+	}
+
+	idleNode := ""
+	contextState := job.ContextState()
+	for _, node := range group.Status().Nodes() {
+		if contextState[node] == pb.SnapshotAgentJobState_STATE_IDLE {
+			idleNode = node
+			break
+		}
+	}
+	if idleNode == "" {
+		c.clearSettle(groupID)
+		return nil
+	}
+
+	c.settleMu.Lock()
+	entry, ok := c.settleSince[groupID]
+	if !ok || entry.jobID != active {
+		entry = settleEntry{jobID: active, since: time.Now()}
+		c.settleSince[groupID] = entry
+	}
+	c.settleMu.Unlock()
+
+	if waited := time.Since(entry.since); waited > c.SettleTimeout {
+		slog.WarnContext(ctx, "Active job's grant never produced device activity; proceeding with promotion",
+			"activeJob", active, "node", idleNode, "waited", waited)
+		c.clearSettle(groupID)
+		return nil
+	}
+
+	return fmt.Errorf("promotion pending: active job %s holds an unconsumed grant (IDLE on node %s); "+
+		"waiting for it to start or settle", active, idleNode)
+}
+
+func (c *Controller) clearSettle(groupID string) {
+	c.settleMu.Lock()
+	delete(c.settleSince, groupID)
+	c.settleMu.Unlock()
 }
 
 // tryDeduceActiveJob is a best-effort helper that deduces and sets the active job after a controller

--- a/pkg/timeslice-orchestrator/controller/settlement_test.go
+++ b/pkg/timeslice-orchestrator/controller/settlement_test.go
@@ -1,0 +1,166 @@
+package controller_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	agentpb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/timeslice-orchestrator/api/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/timeslice-orchestrator/controller"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/timeslice-orchestrator/store"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// settlementFixture builds the scenario behind the grant-settlement gate:
+// job-b was granted the samplers lock, deployed its pods (context IDLE) and
+// yielded before its engine was observed on the accelerator; job-a is SAVED
+// and queued for promotion. Promoting now would restore job-a onto a device
+// job-b's engine is about to occupy.
+func settlementFixture(t *testing.T, ctx context.Context, agentStore *controller.MockSnapshotAgentStore) (
+	*controller.Controller, *store.Group, *store.Job, *trackQueue,
+) {
+	t.Helper()
+
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
+
+	groupID := "group-1"
+	group, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	group.Status().SetNodes([]string{"node-1"})
+
+	// job-b: granted earlier (active), lock since yielded, engine never observed.
+	group.Spec().SetActiveJob("job-b")
+	jobB := store.NewJob(groupID, "job-b")
+	jobB.UpdateContextState("node-1", pb.SnapshotAgentJobState_STATE_IDLE)
+	if err := jobStore.Put(ctx, jobB); err != nil {
+		t.Fatalf("failed to put job-b: %v", err)
+	}
+
+	// job-a: checkpointed off-device, waiting for promotion.
+	jobA := store.NewJob(groupID, "job-a")
+	jobA.UpdateContextState("node-1", pb.SnapshotAgentJobState_STATE_SAVED)
+	if err := jobStore.Put(ctx, jobA); err != nil {
+		t.Fatalf("failed to put job-a: %v", err)
+	}
+	group.Spec().RequestLock("job-a")
+
+	mockOrch := &mockInfrastructureOrchestrator{
+		observeFunc: func(ctx context.Context, gID string) error { return nil },
+	}
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, agentStore)
+	return c, group, jobB, testQueue
+}
+
+// TestController_Reconcile_SettlementHoldsPromotion: while job-b's grant is
+// unconsumed, job-a must not be promoted and no snapshot/restore may be
+// issued — the reconcile requeues instead.
+func TestController_Reconcile_SettlementHoldsPromotion(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	agentStore := &controller.MockSnapshotAgentStore{
+		SnapshotFunc: func(ctx context.Context, nodeName, jobID, groupID string) (*agentpb.SnapshotResponse, error) {
+			t.Errorf("unexpected Snapshot(%s) while promotion is held", jobID)
+			return &agentpb.SnapshotResponse{}, nil
+		},
+		RestoreFunc: func(ctx context.Context, nodeName, jobID, groupID string) (*agentpb.RestoreResponse, error) {
+			t.Errorf("unexpected Restore(%s) while promotion is held", jobID)
+			return &agentpb.RestoreResponse{}, nil
+		},
+	}
+	c, group, _, testQueue := settlementFixture(t, ctx, agentStore)
+
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+	testQueue.Add("group-1")
+
+	// Let several reconcile cycles (initial + rate-limited requeues) pass.
+	if err := waitWithTimeout(func() bool { return testQueue.getDoneCount() >= 3 }, 3*time.Second); err != nil {
+		t.Fatalf("Timed out waiting for reconciles: %v", err)
+	}
+
+	if got := group.Spec().LockingJob(); got != "" {
+		t.Errorf("Expected promotion to be held (no locking job), got %q", got)
+	}
+	if depth := group.Spec().GetWaitingJobQueue().Len(); depth != 1 {
+		t.Errorf("Expected job-a to remain queued (depth 1), got %d", depth)
+	}
+}
+
+// TestController_Reconcile_SettlementReleasesOnRunning: the moment job-b is
+// observed RUNNING, the hold releases and job-a is promoted; job-b is then
+// evictable through the normal preemption path.
+func TestController_Reconcile_SettlementReleasesOnRunning(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	agentStore := &controller.MockSnapshotAgentStore{
+		OperationResponses: []*agentpb.GetOperationResponse{
+			{Status: agentpb.OperationStatus_OPERATION_STATUS_COMPLETE},
+		},
+	}
+	c, group, jobB, testQueue := settlementFixture(t, ctx, agentStore)
+
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+	testQueue.Add("group-1")
+
+	// First observe the hold...
+	if err := waitWithTimeout(func() bool { return testQueue.getDoneCount() >= 1 }, 2*time.Second); err != nil {
+		t.Fatalf("Timed out waiting for first reconcile: %v", err)
+	}
+	if got := group.Spec().LockingJob(); got != "" {
+		t.Fatalf("Expected promotion to be held before job-b runs, got %q", got)
+	}
+
+	// ...then job-b's engine lands (the watcher reports RUNNING).
+	jobB.UpdateContextState("node-1", pb.SnapshotAgentJobState_STATE_RUNNING)
+
+	if err := waitWithTimeout(func() bool { return group.Spec().LockingJob() == "job-a" }, 3*time.Second); err != nil {
+		t.Fatalf("Expected job-a to be promoted once job-b was observed RUNNING: %v", err)
+	}
+}
+
+// TestController_Reconcile_SettlementTimeoutUnblocks: a grant that never
+// produces device activity (crashed engine, job exited right after grant)
+// stops holding promotion once SettleTimeout expires.
+func TestController_Reconcile_SettlementTimeoutUnblocks(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	agentStore := &controller.MockSnapshotAgentStore{
+		OperationResponses: []*agentpb.GetOperationResponse{
+			{Status: agentpb.OperationStatus_OPERATION_STATUS_COMPLETE},
+		},
+	}
+	c, group, _, testQueue := settlementFixture(t, ctx, agentStore)
+	c.SettleTimeout = 100 * time.Millisecond
+
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+	testQueue.Add("group-1")
+
+	if err := waitWithTimeout(func() bool { return group.Spec().LockingJob() == "job-a" }, 5*time.Second); err != nil {
+		t.Fatalf("Expected promotion to proceed after SettleTimeout: %v", err)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

PR #152 fixed the cold-start deadlock by letting reconciliation skip non-active IDLE jobs. But IDLE is ambiguous: a just-granted job also reports IDLE for the few seconds between its grant and the watcher observing its GPU processes. In that window the controller believes the node is free, promotes the next waiter, and restores its checkpoint onto a device the previous job's engine is about to occupy. The results are fatal and timing-dependent: restore fails with OOM → job FAULTED → whole group bricked, or both workloads land on one GPU → reconciliation wedges on "impossible state: multiple jobs running". TestOrchestrator/QueuedRLJobs fails on main because of this (bisected to #152; passes at its parent commit).

This change closes the window at its source: before promoting the next waiter, hold reconciliation while the current active job's grant is unconsumed (granted but never observed RUNNING), bounded by a 30s settle timeout. It cannot reintroduce #137 — only the active job is ever waited on, never parked pre-provisioned waiters — and #152's grant-side fix is untouched.

## Why is this change needed?
Fix the integration test (TestOrchestrator/QueuedRLJobs) failure:

  ──────────── setup ────────────
  16:47:55  watcher: job-a's sampler engine (PID 68892) touches the GPU → job-a = RUNNING
            job-a holds the samplers lock, is mid-"sampling"; test blocks it, then
            job-b starts init and queues for the samplers lock behind job-a.

  ──────────── the handoff A → B (works fine) ────────────
  16:47:59  job-a yields samplers → controller promotes job-b, must evict job-a first:
            Snapshot(job-a) — cuda-checkpoint suspend starts
  16:48:59  suspend completes (60s) → job-a = SAVED, GPU free
            job-b's Acquire completes (nothing resident); job-b deploys its sampler pod
            on zwe4. Its engine container starts booting — GPU touch is seconds away,
            on its own schedule, decoupled from any lock.
            job-b's pod goes Ready → job-b yields samplers (init done) and moves on.
            job-a is meanwhile already queued again (loop iteration 2).

  ──────────── the fatal 2-second window (the #152 race) ────────────
  16:49:03  controller reconciles for the handoff B → A:
              agent states: job-a = SAVED, job-b = IDLE   ← watcher hasn't seen B's PIDs yet
              #152's IDLE-skip: "job-b is IDLE → nothing resident → skip preemption"
              (pre-#152 code would have returned "preemption pending: waiting for
               job-b IDLE→RUNNING" and requeued — slow, but safe)
            controller concludes the node is free → Restore(job-a), toggle starts
  16:49:05  watcher: job-b's engine (PID 70762) lands on the GPU → job-b = RUNNING
            — 2 seconds too late; the restore toggle is already copying job-a back
            onto a device job-b now occupies
  16:49:06  cuda-checkpoint restore fails mid-toggle:
              "Error toggling CUDA in process ID 68892: out of memory"
            state machine: restore worker error → job-a = FAULTED

  ──────────── the death spiral ────────────
  16:50:06+ every reconcile of samplers aborts:
              "active job job-a is in FAULTED state ... requires human intervention"
            isGroupFaulted(samplers) = true → every Acquire poll returns
              Unavailable: "group samplers is faulted"
            both jobs' clients treat it as transient and retry 20× @ 500ms:
              job-a: attempts 1..20 → "failed to acquire lock for samplers after retries" → exits
              job-b: mid-acquire → context canceled → exits
            --- FAIL: TestOrchestrator/QueuedRLJobs (~3 min)


## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

Integration test:
  === RUN   TestOrchestrator
  --- PASS: TestOrchestrator (436.81s)
      --- PASS: TestOrchestrator/SingleRLJob (10.19s)
      --- PASS: TestOrchestrator/QueuedRLJobs (425.93s)
  PASS
  ok    github.com/llm-d-incubation/llm-d-rl-time-slicing/tests/integration/orchestrator        436.830s

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

PR #152

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job scheduling to prevent premature promotion while an active job’s granted resources are still settling.
  * Promotion now proceeds when the job becomes active, the settlement period expires, or the grant is otherwise cleared.
  * Added safeguards for missing jobs, empty queues, and observed activity during reconciliation.

* **Tests**
  * Added coverage for deferred promotion, activity-based release, and timeout-based release scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->