### PR TITLE
[GPU-CR Selective Checkpoint 3/N]: Dump-file reservation and boundary-safe copies

### DIFF
--- a/third_party/gpu-cr/CMakeLists.txt
+++ b/third_party/gpu-cr/CMakeLists.txt
@@ -63,6 +63,11 @@ file(GLOB_RECURSE VGPU_SOURCE_FILES CONFIGURE_DEPENDS
 # Drop scratch sources.
 list(FILTER VGPU_SOURCE_FILES EXCLUDE REGEX "-pre\\.cpp$")
 
+# vGPU.cpp still carries its own memcpy_multi definition; the standalone
+# TU exists so the GPU-free unit suite can exercise it, and joins this
+# library when the preloader refactor drops the in-file copy.
+list(FILTER VGPU_SOURCE_FILES EXCLUDE REGEX "/memcpy_multi\\.cpp$")
+
 # Per-vendor backend exclusions.
 if(GPU_VENDOR STREQUAL "NVIDIA")
     list(FILTER VGPU_SOURCE_FILES EXCLUDE REGEX "/AMD/")
@@ -136,9 +141,9 @@ target_compile_options(multi_cr_client PRIVATE -O3 -g)
 # ---------------------------------------------------------------------------
 # Tests (GPU-free; run in Dockerfile.build)
 #   gpu_cr_unit_tests        — GoogleTest unit suite for the dump-format
-#                              code, plus the upstream-baseline control
-#                              channel, buffer mapping, fd exchange and
-#                              wire structs
+#                              and granule-clamp code, plus the
+#                              upstream-baseline control channel, buffer
+#                              mapping, fd exchange and memcpy_multi
 # ---------------------------------------------------------------------------
 option(GPU_CR_BUILD_TESTS "Build the GPU-free unit tests" OFF)
 
@@ -158,16 +163,25 @@ if(GPU_CR_BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/common_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/dump_format_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/ipc_fd_exchange_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/memcpy_multi_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/mmap_backend_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/share_mem_comm_test.cpp
         # GPU-free production sources under test (upstream-baseline functions)
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backend/mmap_backend.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/comm/share_mem.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/ipc_fd_exchange.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/memcpy_multi.cpp
     )
     target_include_directories(gpu_cr_unit_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
+    # The file backend reserves the full dump-buffer size up front
+    # (posix_fallocate); pin the suite to the 1GiB minimum so the
+    # mmap-backend tests don't reserve the 25GiB production default per
+    # checkpoint id. Expressed as compile *options* (-U then -D) so the
+    # override lands after any directory-level -DSHM_SIZE_GB from the
+    # build harness in the generated compile command.
+    target_compile_options(gpu_cr_unit_tests PRIVATE -USHM_SIZE_GB -DSHM_SIZE_GB=1)
     target_link_libraries(gpu_cr_unit_tests PRIVATE GTest::gtest_main pthread)
     add_test(NAME unit COMMAND gpu_cr_unit_tests)
 endif()

--- a/third_party/gpu-cr/src/backend/mmap_backend.cpp
+++ b/third_party/gpu-cr/src/backend/mmap_backend.cpp
@@ -3,8 +3,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <cerrno>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <string>
 
 #include "../common.h"
@@ -25,63 +27,78 @@ ShareMem::ShareMem(int id) : Backend(id), id(id) {
 ShareMem::~ShareMem() {
 }
 
+// Map the dump buffer. fatal=true keeps the historical exit() behavior
+// for eager setup; fatal=false returns nullptr so a caller can fail the
+// op cleanly instead of killing the workload.
+void* ShareMem::map_dump_buffer(bool fatal) {
+    char shm_name[512];
+    const char* export_file_path = std::getenv("EXPORT_FILE_PATH");
+    bool use_file_backend = (export_file_path != nullptr);
+    size_t size = SHM_SIZE;
+
+    if (use_file_backend) {
+        snprintf(shm_name, sizeof(shm_name), "%s/ckpt-%d.data", export_file_path, id);
+        fprintf(stderr, "[ShareMem] Using File Backend: %s (%zu MiB)\n", shm_name, size >> 20);
+    } else {
+        snprintf(shm_name, sizeof(shm_name), "/mnt/huge-ckpt/%d", id);
+    }
+
+    int fd = open(shm_name, O_CREAT | O_RDWR, use_file_backend ? 0644 : 0755);
+    if (fd < 0) {
+        perror("open() dump buffer");
+        if (fatal) exit(EXIT_FAILURE);
+        return nullptr;
+    }
+    if (ftruncate(fd, size) < 0) {
+        perror("ftruncate() dump buffer");
+        close(fd);
+        if (fatal) exit(EXIT_FAILURE);
+        return nullptr;
+    }
+    if (use_file_backend) {
+        // Reserve the full configured size up front: tmpfs/disk reserve
+        // nothing at ftruncate or mmap, so an over-committed store would
+        // SIGBUS mid-dump; full fallocate turns that into a synchronous
+        // ENOSPC here. Partial reservation would only move the fault,
+        // since the dump extent grows toward the configured size.
+        int rc = posix_fallocate(fd, 0, static_cast<off_t>(size));
+        if (rc != 0) {
+            fprintf(stderr, "[ShareMem] posix_fallocate(%s, %zu MiB): %s\n", shm_name, size >> 20, strerror(rc));
+            close(fd);
+            if (fatal) exit(EXIT_FAILURE);
+            return nullptr;
+        }
+    }
+
+    void* buf = mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    close(fd);
+    if (buf == MAP_FAILED) {
+        fprintf(stderr, "%s failed: %s\n",
+                use_file_backend ? "mmap (file backend)" : "mmap with hugepages", strerror(errno));
+        fprintf(stderr, "[ShareMem] configured dump-buffer size is %zu MiB (build-time SHM_SIZE_GB); "
+                        "check it against the pod's hugepages-2Mi request and the node pool size\n",
+                        size >> 20);
+        if (fatal) exit(EXIT_FAILURE);
+        return nullptr;
+    }
+    if (!use_file_backend)
+        fprintf(stderr, "Hugepage shared memory mapped at %p (%zu MiB)\n", buf, size >> 20);
+
+    shared_mem_fs* fs = static_cast<shared_mem_fs*>(buf);
+    fs->file_num = 0;
+    fs->current_offset = ROUND_UP_2MB(sizeof(shared_mem_fs));
+    return buf;
+}
+
 void ShareMem::setup() {
-    // tmp_buf
     char shm_name[512];
     const char* export_file_path = std::getenv("EXPORT_FILE_PATH");
     bool use_file_backend = (export_file_path != nullptr);
 
-    if(use_file_backend){
-        sprintf(shm_name, "%s/ckpt-%d.data", export_file_path, id);
-        fprintf(stderr, "[ShareMem] Using File Backend: %s\n", shm_name);
-        
-        int fd = open(shm_name, O_CREAT | O_RDWR, 0644);
-        if (fd < 0) {
-            perror("open() file backend");
-            exit(EXIT_FAILURE);
-        }
-
-        if (ftruncate(fd, SHM_SIZE) < 0) {
-            perror("ftruncate() file backend");
-            exit(EXIT_FAILURE);
-        }
-
-        tmp_buf = mmap(NULL, SHM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-        if (tmp_buf == MAP_FAILED) {
-            perror("mmap file backend failed");
-            exit(EXIT_FAILURE);
-        }
-    }
-    else{
-        sprintf(shm_name, "/mnt/huge-ckpt/%d", id);
-        int fd = open(shm_name, O_CREAT | O_RDWR, 0755);
-        if (fd < 0) {
-            perror("open()");
-            exit(EXIT_FAILURE);
-        }
-
-        int ret = ftruncate(fd, SHM_SIZE);
-        if (ret < 0) {
-            perror("ftruncate()");
-            exit(EXIT_FAILURE);
-        }
-
-        tmp_buf = mmap(NULL, SHM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
-        if (tmp_buf == MAP_FAILED) {
-            perror("mmap with hugepages failed");
-            fprintf(stderr, "Check if hugepages are configured properly\n");
-            exit(EXIT_FAILURE);
-        }
-
-        fprintf(stderr, "Hugepage shared memory mapped at %p\n", tmp_buf);
-    }
-
-    shared_mem_fs* fs = (shared_mem_fs*)tmp_buf;
+    // tmp_buf
     fs_mutex.lock();
-    fs->file_num = 0;
-    fs->current_offset = ROUND_UP_2MB(sizeof(shared_mem_fs));
+    tmp_buf = map_dump_buffer(/*fatal=*/true);
     fs_mutex.unlock();
-
 
     // host_buf — follow same backend selection as the main staging buffer.
     if (use_file_backend) {

--- a/third_party/gpu-cr/src/common.h
+++ b/third_party/gpu-cr/src/common.h
@@ -18,9 +18,28 @@
 #include <map>
 #include <utility>
 #include <atomic>
+#include <mutex>
 
 #define HUGE_PAGE_SIZE (2 * 1024 * 1024)
 #define ROUND_UP_2MB(x) (((x) + (2 * 1024 * 1024 - 1)) & ~(2 * 1024 * 1024 - 1))
+
+namespace gpu_cr {
+// CUDA VMM mapping granularity: every hooked allocation is reserved/mapped in
+// units of this size (see ROUND_UP_2MB uses in the cudaMalloc hook).
+inline constexpr size_t kVmmGranuleSize = 2UL * 1024 * 1024;
+
+// The driver rejects a cudaMemcpyAsync on a hooked VMM mapping
+// when the copy crosses a 2MB granule boundary with an unrounded length.
+// Clamps a device copy so it ends at the next granule boundary or at the
+// region end: every issued copy is <=2MB and granule-aligned at its start
+// or its end — the copy shapes validated at scale. Applies to the selective
+// (unrounded) paths only; the full-checkpoint paths copy rounded extents
+// and never hit this boundary.
+constexpr size_t GranuleClampLen(uintptr_t dev_addr, size_t len) {
+  size_t to_boundary = kVmmGranuleSize - (dev_addr & (kVmmGranuleSize - 1));
+  return len < to_boundary ? len : to_boundary;
+}
+}  // namespace gpu_cr
 
 // SHM_SIZE: Per-GPU checkpoint buffer on hugepages.
 // Each GPU process allocates SHM_SIZE + STAGING_BUF_SIZE*STAGING_BUF_NUM.
@@ -62,6 +81,8 @@ extern std::map<void*, size_t> allocated_memory;
 
 // Global memory type tracking: ptr -> type (0=runtime Malloc, 1=VMM)
 extern std::map<void*, int> allocated_memory_type;
+
+extern std::mutex gpu_mem_mutex;
 
 // Helper function declarations
 void memcpy_multi(void* dest, void* src, size_t size);

--- a/third_party/gpu-cr/src/memcpy_multi.cpp
+++ b/third_party/gpu-cr/src/memcpy_multi.cpp
@@ -1,0 +1,27 @@
+// Multi-threaded memcpy shared by the checkpoint/restore staging pipelines.
+// Own translation unit (not vGPU.cpp, which needs the CUDA/HIP link) so the
+// GPU-free unit suite can exercise it.
+
+#include <algorithm>
+#include <cstring>
+#include <thread>
+#include <vector>
+
+#include "common.h"
+
+// Helper function: multi-threaded memcpy
+void memcpy_multi(void* dest, void* src, size_t size) {
+    std::vector<std::thread> threads;
+    size_t chunk_size = (size + NUM_COPY_THREADS - 1) / NUM_COPY_THREADS;
+    for (int i = 0; i < NUM_COPY_THREADS; i++) {
+        size_t offset = i * chunk_size;
+        if (offset >= size) break;
+        size_t this_chunk_size = std::min(chunk_size, size - offset);
+        threads.emplace_back([=]() {
+            memcpy((char*)dest + offset, (char*)src + offset, this_chunk_size);
+        });
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+}

--- a/third_party/gpu-cr/tests/unit/common_baseline_test.cpp
+++ b/third_party/gpu-cr/tests/unit/common_baseline_test.cpp
@@ -41,6 +41,13 @@ TEST(RoundUp2MBTest, LargeValuesKeepFullWidth) {
   EXPECT_EQ(ROUND_UP_2MB((25UL << 30) + 1), (25UL << 30) + (2UL << 20));
 }
 
+// The VMM mapping granule and the hugepage size are the same 2MB constant;
+// ROUND_UP_2MB and GranuleClampLen must agree on where boundaries are.
+TEST(HugePageGeometryTest, GranuleMatchesHugePageSize) {
+  EXPECT_EQ(static_cast<size_t>(HUGE_PAGE_SIZE), kVmmGranuleSize);
+  EXPECT_EQ(ROUND_UP_2MB(1UL), kVmmGranuleSize);
+}
+
 // The upstream control word must stay at offset 0: an upstream cr_client
 // and a current .so share the same zero-initialized mapping.
 TEST(SignalControlsLayoutTest, SignalWordIsFirst) {

--- a/third_party/gpu-cr/tests/unit/common_test.cpp
+++ b/third_party/gpu-cr/tests/unit/common_test.cpp
@@ -1,5 +1,6 @@
-// Shared-protocol helpers from common.h: the consume-once FINISH
-// bookkeeping and the wire-layout guards for the selective request.
+// Shared-protocol helpers from common.h: granule clamping, the
+// consume-once FINISH bookkeeping and the wire-layout guards for the
+// selective request.
 
 #include "common.h"
 
@@ -11,6 +12,53 @@
 
 namespace gpu_cr {
 namespace {
+
+TEST(GranuleClampLenTest, ZeroLengthStaysZero) {
+  // A clamp must never turn an empty copy into a 2MB one.
+  EXPECT_EQ(GranuleClampLen(0, 0), 0u);
+  EXPECT_EQ(GranuleClampLen(kVmmGranuleSize - 4, 0), 0u);
+}
+
+TEST(GranuleClampLenTest, ShortCopyFromAlignedStartUnclamped) {
+  EXPECT_EQ(GranuleClampLen(0, 4096), 4096u);
+}
+
+TEST(GranuleClampLenTest, FullGranuleFromAlignedStartUnclamped) {
+  EXPECT_EQ(GranuleClampLen(0, kVmmGranuleSize), kVmmGranuleSize);
+}
+
+TEST(GranuleClampLenTest, LongCopyClampedToGranule) {
+  EXPECT_EQ(GranuleClampLen(0, kVmmGranuleSize + 1), kVmmGranuleSize);
+}
+
+TEST(GranuleClampLenTest, UnalignedStartClampsToBoundary) {
+  // 4 bytes shy of a boundary: at most 4 bytes may be issued.
+  uintptr_t addr = kVmmGranuleSize - 4;
+  EXPECT_EQ(GranuleClampLen(addr, 4096), 4u);
+  EXPECT_EQ(GranuleClampLen(addr, 2), 2u);
+}
+
+TEST(GranuleClampLenTest, EveryClampEndsAlignedOrAtRegionEnd) {
+  // Walk a simulated 5MiB+3 region from an unaligned base the way the
+  // selective copy loops do, asserting the clamp invariant for each
+  // issued copy: <=2MB, and granule-aligned at its start or its end
+  // (or it is the final copy of the region).
+  uintptr_t addr = 12345;
+  size_t remaining = 5 * (1UL << 20) + 3;
+  int copies = 0;
+  while (remaining > 0) {
+    size_t len = GranuleClampLen(addr, remaining);
+    ASSERT_GT(len, 0u);
+    ASSERT_LE(len, kVmmGranuleSize);
+    bool start_aligned = (addr % kVmmGranuleSize) == 0;
+    bool end_aligned = ((addr + len) % kVmmGranuleSize) == 0;
+    bool is_final = (len == remaining);
+    ASSERT_TRUE(start_aligned || end_aligned || is_final);
+    addr += len;
+    remaining -= len;
+    ASSERT_LT(++copies, 100);
+  }
+}
 
 // FinishOpControls is the only writer of op_status: op sites hand it a
 // positive errno (or 0), and it stores kOpStatusOk or the negated errno,

--- a/third_party/gpu-cr/tests/unit/memcpy_multi_test.cpp
+++ b/third_party/gpu-cr/tests/unit/memcpy_multi_test.cpp
@@ -1,0 +1,55 @@
+// Upstream-baseline memcpy_multi: the multi-threaded copy behind the
+// staging pipelines must be byte-exact for every size/thread split.
+
+#include <string.h>
+
+#include <vector>
+
+#include "common.h"
+#include "gtest/gtest.h"
+
+namespace {
+
+// Fills src with a position-dependent pattern, copies, and checks dest
+// byte-for-byte (plus a canary past the end to catch overruns).
+void CheckCopy(size_t size) {
+  std::vector<unsigned char> src(size + 1, 0);
+  std::vector<unsigned char> dest(size + 1, 0xEE);
+  for (size_t i = 0; i < size; i++) src[i] = static_cast<unsigned char>(i * 31 + 7);
+
+  memcpy_multi(dest.data(), src.data(), size);
+
+  ASSERT_EQ(memcmp(dest.data(), src.data(), size), 0) << "size=" << size;
+  EXPECT_EQ(dest[size], 0xEE) << "overrun at size=" << size;
+}
+
+TEST(MemcpyMultiTest, ZeroSizeIsANoOp) {
+  unsigned char dest[4] = {0xAA, 0xBB, 0xCC, 0xDD};
+  unsigned char src[4] = {1, 2, 3, 4};
+  memcpy_multi(dest, src, 0);
+  EXPECT_EQ(dest[0], 0xAA);
+  EXPECT_EQ(dest[3], 0xDD);
+}
+
+TEST(MemcpyMultiTest, SizesSmallerThanThreadCount) {
+  // Fewer bytes than NUM_COPY_THREADS: trailing threads must not spawn on
+  // out-of-range offsets.
+  for (size_t size = 1; size < NUM_COPY_THREADS; size++) CheckCopy(size);
+}
+
+TEST(MemcpyMultiTest, ExactChunkMultiples) {
+  CheckCopy(NUM_COPY_THREADS);
+  CheckCopy(NUM_COPY_THREADS * 4096);
+}
+
+TEST(MemcpyMultiTest, OddSizesSplitUnevenly) {
+  CheckCopy(NUM_COPY_THREADS + 1);
+  CheckCopy(4096 - 1);
+  CheckCopy((1UL << 20) + 7);
+}
+
+TEST(MemcpyMultiTest, MultiMegabyteCopyIsByteExact) {
+  CheckCopy(8UL << 20);
+}
+
+}  // namespace

--- a/third_party/gpu-cr/tests/unit/mmap_backend_test.cpp
+++ b/third_party/gpu-cr/tests/unit/mmap_backend_test.cpp
@@ -1,9 +1,7 @@
 // Upstream-baseline ShareMem backend (mmap_backend.cpp): setup() maps the
 // dump buffer and the two-slot host staging buffer, get_tmp_buf() /
 // get_host_buffer() hand them out. Exercised through the file backend
-// (EXPORT_FILE_PATH) so no hugepages are needed; the backing files are
-// sparse, so the compile-time SHM_SIZE costs address space, not disk.
-// Linux-only.
+// (EXPORT_FILE_PATH) so no hugepages are needed. Linux-only.
 
 #include "backend/backend.h"
 
@@ -147,14 +145,14 @@ TEST_F(MmapBackendTest, SetupResetsStaleHeaderOnExistingFile) {
   EXPECT_EQ(fs->current_offset, ROUND_UP_2MB(sizeof(shared_mem_fs)));
 }
 
-// setup() keeps the historical fatal-exit contract when the data dir is
-// unusable.
+// Eager setup keeps the historical fatal-exit contract when the data dir
+// is unusable.
 TEST_F(MmapBackendTest, MissingDataDirExitsFatally) {
   GTEST_FLAG_SET(death_test_style, "threadsafe");
   setenv("EXPORT_FILE_PATH", "/nonexistent-gpu-cr-unit-dir", 1);
   ShareMem backend(9);
   EXPECT_EXIT(backend.setup(), ::testing::ExitedWithCode(EXIT_FAILURE),
-              "open");
+              "dump buffer");
 }
 
 }  // namespace


### PR DESCRIPTION
## What does this PR do?

  All changes are in the dump data plane (the buffer checkpoint bytes are staged in, and the code that copies them); the control plane is untouched. Four changes:

  1. Unify dump-buffer setup. The two nearly identical open/ftruncate/mmap blocks in `setup()` — agent-managed named file via `EXPORT_FILE_PATH` vs. legacy fixed hugetlbfs path — become one routine, `map_dump_buffer()`, with the split reduced to path, file mode, and space reservation. File names, sizes, header init, and the fatal-exit contract are unchanged. Its non-fatal mode has no caller yet; the lazy-buffer follow-up PR uses it.
  2. Reserve file-backed buffer space up front. `posix_fallocate` at creation turns an over-committed store into a synchronous `ENOSPC` at pod startup instead of a `SIGBUS` mid-checkpoint. Hugetlbfs needs no equivalent — the mapping itself reserves.
  3. Add `GranuleClampLen()`. A pure, fully unit-tested helper encoding the driver's rule that no device copy may cross a 2 MB VMM granule seam with an unrounded length. Defined here; the follow-up preloader PR wires it into the selective copy loops.
  4. Move `memcpy_multi()` into its own translation unit and add its first direct tests (byte-exactness across thread splits, overrun canary, zero-containing patterns). Production keeps the identical in-file copy for now via a commented CMake filter; the follow-up PR makes this file the single definition.

<!-- Describe the changes and their purpose -->

## Why is this change needed?

  **A real failure mode in agent deployments.** The Snapshot-Agent points every workload's dump buffer at a shared store. Those buffers were sparse promises (`ftruncate` allocates nothing), so an over-committed store failed at an unpredictable moment: some Nth checkpoint of a healthy workload died with SIGBUS mid-dump. With up-front reservation, a store that can't hold a buffer rejects that workload at startup with ENOSPC and a sizing hint — and a buffer that was created can never run out of space later.

  **Selective checkpoints can't work without the copy rule.** Selective extents are exact byte ranges; they can't be rounded (adjacent byte belong to live state), and the driver rejects any copy crossing a 2 MB granule seam with an unrounded length. `GranuleClampLen` splits copies at the seams instead. Landing it fully tested here keeps the follow-up preloader PR down to wiring it into the copy loops.

  **The copy engine needed tests before it becomes load-bearing.** `memcpy_multi()` moves every dump/restore byte but lived only inside `vGPU.cpp`, which needs the CUDA link — zero direct test coverage. Its own translation unit makes GPU-free testing possible now, and becomes the single production definition when the follow-up PR deletes the in-file copy. The tests also pin a deliberate contract: zeros are copied like any other byte — zeros in a dump are real data that must overwrite the destination on restore (a zero-skipping "optimization" once silently restored another checkpoint's leftover bytes), so a future sparse-skip patch here is a correctness regression, not a perf win.

  **No behavior change for default deployments.** Without `EXPORT_FILE_PATH`: same path, mode, size, header, and fatal-exit contract; only unified error text and `snprintf` hardening. With it, the one intentional change is that insufficient store space fails at buffer creation instead of mid-checkpoint.

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
