### PR TITLE
fix(snapshot-agent): timeout cuda-checkpoint sudo commands

### DIFF
--- a/pkg/snapshot-agent/backends/cuda-checkpoint.go
+++ b/pkg/snapshot-agent/backends/cuda-checkpoint.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"strconv"
 	"sync"
@@ -138,10 +139,25 @@ func (c *CudaCheckpoint) getCudaCheckpointPath() string {
 }
 
 func (c *CudaCheckpoint) runSudoCommand(ctx context.Context, name string, args ...string) error {
+	// A hung cuda-checkpoint (e.g. a workload that dies mid-lock) would
+	// otherwise hold c.mu forever and wedge every later snapshot/restore.
+	ctx, cancel := context.WithTimeout(ctx, cudaCheckpointOpTimeout())
+	defer cancel()
 	if out, err := c.execCommand(ctx, name, args...); err != nil {
 		return fmt.Errorf("command failed: %w, output: %s", err, string(out))
 	}
 	return nil
+}
+
+// cudaCheckpointOpTimeout is the per-cuda-checkpoint-invocation deadline,
+// configurable via CUDA_CHECKPOINT_OP_TIMEOUT_SEC (default 120).
+func cudaCheckpointOpTimeout() time.Duration {
+	if v := os.Getenv("CUDA_CHECKPOINT_OP_TIMEOUT_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return 120 * time.Second
 }
 
 func (c *CudaCheckpoint) checkpointPIDs(ctx context.Context, pids []string) error {

--- a/pkg/snapshot-agent/backends/cuda_checkpoint_test.go
+++ b/pkg/snapshot-agent/backends/cuda_checkpoint_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/NVIDIA/go-nvml/pkg/nvml"
 	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
@@ -174,5 +175,31 @@ func TestHealthCheck(t *testing.T) {
 				t.Errorf("HealthCheck() error = %v, expectedErr %v", err, tt.expectedErr)
 			}
 		})
+	}
+}
+
+func TestCudaCheckpointOpTimeout(t *testing.T) {
+	t.Setenv("CUDA_CHECKPOINT_OP_TIMEOUT_SEC", "1")
+
+	c := backends.NewCudaCheckpoint()
+	c.SetExecCommand(func(ctx context.Context, _ string, _ ...string) ([]byte, error) {
+		// Simulate cuda-checkpoint hanging on a dead workload:
+		// block until the per-operation deadline cancels the context.
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+
+	start := time.Now()
+	err := c.Snapshot(context.Background(), backends.Request{JobID: "test-job", Config: cudaConfig(123)})
+	if err == nil {
+		t.Fatal("Snapshot() expected timeout error, got nil")
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("Snapshot() took %v; the 1s CUDA_CHECKPOINT_OP_TIMEOUT_SEC deadline was not applied", elapsed)
+	}
+
+	err = c.Restore(context.Background(), backends.Request{JobID: "test-job", Config: cudaConfig(123)})
+	if err == nil {
+		t.Fatal("Restore() expected timeout error, got nil")
 	}
 }


### PR DESCRIPTION
## What does this PR do?

Bound `CudaCheckpoint.runSudoCommand` with a per-invocation deadline so a hung `cuda-checkpoint` cannot hold `c.mu` forever and wedge later snapshot/restore calls.

This mirrors the DirectMemory pattern already landed in #141 (`directMemoryOpTimeout` / `DIRECT_MEMORY_OP_TIMEOUT_SEC`):

- `cudaCheckpointOpTimeout()` reads `CUDA_CHECKPOINT_OP_TIMEOUT_SEC` (default 120s)
- `runSudoCommand` wraps `execCommand` in `context.WithTimeout`

## Why is this change needed?

Fixes #142. Snapshot Agent external command calls can hang indefinitely. DirectMemory already has a timeout from #141; this PR targets the remaining `cuda-checkpoint` path.

Audit of other Snapshot Agent command paths (same PR, no extra changes needed):

- `DirectMemory.runCommand` — already timed out in #141
- `AppChannelBackend` — already uses `b.commandTimeout`
- `AppEndpointBackend` — HTTP client `Timeout` is 30s
- Integration harness — already uses `CommandContext` with a deadline

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

`go test ./pkg/snapshot-agent/...` — all packages passed.

`TestCudaCheckpointOpTimeout` injects a hung `execCommand` that blocks on `ctx.Done()` and asserts Snapshot/Restore return when the 1s env timeout fires (same style as `TestDirectMemoryOpTimeout`).

## Checklist

- [x] Commits are signed off (`git commit -s`) per DCO
- [x] Code follows project contributing guidelines
- [x] Tests pass locally (`go test ./pkg/snapshot-agent/...`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Fixes #142
Related to #141

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CUDA checkpoint and restore operations now enforce configurable timeouts.
  * Timeout duration can be set with `CUDA_CHECKPOINT_OP_TIMEOUT_SEC`; it defaults to 120 seconds when unset or invalid.
* **Bug Fixes**
  * Prevented checkpoint operations from hanging indefinitely by returning a timeout error when commands exceed the configured limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->