### PR TITLE
[Snapshot-Agent]: Add config builders for AppEndpointConfig and AppChannelConfig

### DIFF
--- a/pkg/client/python/tests/test_configs.py
+++ b/pkg/client/python/tests/test_configs.py
@@ -127,6 +127,14 @@ class TestBackendConfigBuilders(unittest.TestCase):
             with self.assertRaises(ValueError):
                 app_channel_config(mode=mode)
 
+    def test_rejects_bare_string_endpoints_and_tags(self):
+        with self.assertRaises(ValueError):
+            app_endpoint_config("vllm", "http://localhost:8000")
+        with self.assertRaises(ValueError):
+            app_endpoint_config("vllm", ["http://localhost:8000"], tags="weights")
+        with self.assertRaises(ValueError):
+            app_channel_config(tags="weights")
+
     def test_rejects_bad_tags(self):
         for tags in ([""], [123], [None]):
             with self.assertRaises(ValueError):

--- a/pkg/client/python/tests/test_configs.py
+++ b/pkg/client/python/tests/test_configs.py
@@ -2,7 +2,15 @@
 
 import unittest
 
-from timeslice.snapshot_agent import cuda_config, direct_memory_config
+from timeslice.snapshot_agent import (
+    app_channel_config,
+    app_endpoint_config,
+    cuda_config,
+    direct_memory_config,
+    sglang_config,
+    vllm_config,
+)
+from timeslice.snapshot_agent import snapshot_agent_pb2
 
 
 class TestBackendConfigBuilders(unittest.TestCase):
@@ -35,6 +43,96 @@ class TestBackendConfigBuilders(unittest.TestCase):
                 cuda_config(pids)
             with self.assertRaises((ValueError, TypeError)):
                 direct_memory_config(pids)
+
+    def test_app_endpoint_config_builds_full_config(self):
+        cfg = app_endpoint_config(
+            snapshot_agent_pb2.APP_VLLM,
+            ["http://localhost:8000", "http://localhost:8001"],
+            mode=snapshot_agent_pb2.SUSPEND_MODE_DISCARD,
+            tags=["weights", "kv_cache"],
+        )
+        self.assertEqual(cfg.WhichOneof("backend"), "app_endpoint")
+        self.assertEqual(cfg.app_endpoint.app, snapshot_agent_pb2.APP_VLLM)
+        self.assertEqual(
+            list(cfg.app_endpoint.endpoints),
+            ["http://localhost:8000", "http://localhost:8001"],
+        )
+        self.assertEqual(cfg.app_endpoint.mode, snapshot_agent_pb2.SUSPEND_MODE_DISCARD)
+        self.assertEqual(list(cfg.app_endpoint.tags), ["weights", "kv_cache"])
+
+    def test_app_endpoint_config_accepts_friendly_strings(self):
+        cfg = app_endpoint_config("vllm", ["http://localhost:8000"], mode="offload")
+        self.assertEqual(cfg.app_endpoint.app, snapshot_agent_pb2.APP_VLLM)
+        self.assertEqual(cfg.app_endpoint.mode, snapshot_agent_pb2.SUSPEND_MODE_OFFLOAD)
+        self.assertEqual(
+            cfg,
+            app_endpoint_config(
+                snapshot_agent_pb2.APP_VLLM,
+                ["http://localhost:8000"],
+                mode=snapshot_agent_pb2.SUSPEND_MODE_OFFLOAD,
+            ),
+        )
+
+    def test_app_endpoint_config_strings_are_case_insensitive(self):
+        cfg = app_endpoint_config("SGLang", ["http://localhost:8000"], mode="Discard")
+        self.assertEqual(cfg.app_endpoint.app, snapshot_agent_pb2.APP_SGLANG)
+        self.assertEqual(cfg.app_endpoint.mode, snapshot_agent_pb2.SUSPEND_MODE_DISCARD)
+
+    def test_app_endpoint_config_defaults(self):
+        cfg = app_endpoint_config("sglang", ["http://localhost:8000"])
+        self.assertEqual(
+            cfg.app_endpoint.mode, snapshot_agent_pb2.SUSPEND_MODE_UNSPECIFIED
+        )
+        self.assertEqual(list(cfg.app_endpoint.tags), [])
+
+    def test_vllm_and_sglang_presets(self):
+        cfg = vllm_config(["http://localhost:8000"], mode="discard", tags=["weights"])
+        self.assertEqual(
+            cfg,
+            app_endpoint_config(
+                "vllm", ["http://localhost:8000"], mode="discard", tags=["weights"]
+            ),
+        )
+        cfg = sglang_config(["http://localhost:8000"])
+        self.assertEqual(cfg.app_endpoint.app, snapshot_agent_pb2.APP_SGLANG)
+
+    def test_app_endpoint_config_rejects_bad_app(self):
+        for app in (snapshot_agent_pb2.APP_UNSPECIFIED, 999, "triton", ""):
+            with self.assertRaises(ValueError):
+                app_endpoint_config(app, ["http://localhost:8000"])
+
+    def test_app_endpoint_config_rejects_bad_endpoints(self):
+        for endpoints in ([], [""], [b"http://localhost:8000"], [123]):
+            with self.assertRaises(ValueError):
+                app_endpoint_config("vllm", endpoints)
+
+    def test_app_channel_config_builds_full_config(self):
+        cfg = app_channel_config(mode="offload", tags=["weights"])
+        self.assertEqual(cfg.WhichOneof("backend"), "app_channel")
+        self.assertEqual(cfg.app_channel.mode, snapshot_agent_pb2.SUSPEND_MODE_OFFLOAD)
+        self.assertEqual(list(cfg.app_channel.tags), ["weights"])
+
+    def test_app_channel_config_defaults(self):
+        cfg = app_channel_config()
+        self.assertEqual(cfg.WhichOneof("backend"), "app_channel")
+        self.assertEqual(
+            cfg.app_channel.mode, snapshot_agent_pb2.SUSPEND_MODE_UNSPECIFIED
+        )
+        self.assertEqual(list(cfg.app_channel.tags), [])
+
+    def test_rejects_bad_suspend_mode(self):
+        for mode in (999, "sleep", ""):
+            with self.assertRaises(ValueError):
+                app_endpoint_config("vllm", ["http://localhost:8000"], mode=mode)
+            with self.assertRaises(ValueError):
+                app_channel_config(mode=mode)
+
+    def test_rejects_bad_tags(self):
+        for tags in ([""], [123], [None]):
+            with self.assertRaises(ValueError):
+                app_endpoint_config("vllm", ["http://localhost:8000"], tags=tags)
+            with self.assertRaises(ValueError):
+                app_channel_config(tags=tags)
 
 
 if __name__ == "__main__":

--- a/pkg/client/python/timeslice/snapshot_agent/__init__.py
+++ b/pkg/client/python/timeslice/snapshot_agent/__init__.py
@@ -1,11 +1,22 @@
 from .client import SnapshotAgentClient
-from .configs import cuda_config, direct_memory_config
+from .configs import (
+    app_channel_config,
+    app_endpoint_config,
+    cuda_config,
+    direct_memory_config,
+    sglang_config,
+    vllm_config,
+)
 from .workload import WorkloadHandle, register_workload
 
 __all__ = [
     "SnapshotAgentClient",
     "WorkloadHandle",
+    "app_channel_config",
+    "app_endpoint_config",
     "cuda_config",
     "direct_memory_config",
     "register_workload",
+    "sglang_config",
+    "vllm_config",
 ]

--- a/pkg/client/python/timeslice/snapshot_agent/configs.py
+++ b/pkg/client/python/timeslice/snapshot_agent/configs.py
@@ -44,6 +44,8 @@ def _suspend_mode(mode: Union[str, int, None]) -> int:
 
 
 def _tags(tags: Optional[Sequence[str]]) -> list:
+    if isinstance(tags, str):
+        raise ValueError("tags must be a sequence of non-empty strings")
     tags = list(tags or [])
     if any(not isinstance(t, str) or not t for t in tags):
         raise ValueError(f"tags must be non-empty strings, got {tags!r}")
@@ -110,6 +112,8 @@ def app_endpoint_config(
         snapshot_agent_pb2.App.Name(app)  # raises ValueError if invalid
     if app == snapshot_agent_pb2.APP_UNSPECIFIED:
         raise ValueError(f"app must be specified; expected one of {sorted(_APPS)}")
+    if isinstance(endpoints, str):
+        raise ValueError("endpoints must be a sequence of non-empty endpoint URLs")
     endpoints = list(endpoints)
     if not endpoints or any(not isinstance(e, str) or not e for e in endpoints):
         raise ValueError("at least one non-empty endpoint URL is required")

--- a/pkg/client/python/timeslice/snapshot_agent/configs.py
+++ b/pkg/client/python/timeslice/snapshot_agent/configs.py
@@ -1,6 +1,6 @@
 """Helpers for building BackendConfig protos."""
 
-from typing import Sequence
+from typing import Optional, Sequence, Union
 
 from . import snapshot_agent_pb2
 
@@ -14,6 +14,40 @@ def _process_target(pids: Sequence[int]) -> snapshot_agent_pb2.ProcessTarget:
             raise ValueError(f"PID must be a positive integer, got {pid!r}")
         validated.append(pid)
     return snapshot_agent_pb2.ProcessTarget(pids=validated)
+
+
+_APPS = {
+    "vllm": snapshot_agent_pb2.APP_VLLM,
+    "sglang": snapshot_agent_pb2.APP_SGLANG,
+}
+
+_SUSPEND_MODES = {
+    "offload": snapshot_agent_pb2.SUSPEND_MODE_OFFLOAD,
+    "discard": snapshot_agent_pb2.SUSPEND_MODE_DISCARD,
+}
+
+
+def _suspend_mode(mode: Union[str, int, None]) -> int:
+    """None -> UNSPECIFIED (workload/application default); accepts friendly
+    strings ("offload"/"discard") or the raw enum value."""
+    if mode is None:
+        return snapshot_agent_pb2.SUSPEND_MODE_UNSPECIFIED
+    if isinstance(mode, str):
+        try:
+            return _SUSPEND_MODES[mode.lower()]
+        except KeyError:
+            raise ValueError(
+                f"unknown suspend mode {mode!r}; expected one of {sorted(_SUSPEND_MODES)}"
+            )
+    snapshot_agent_pb2.SuspendMode.Name(mode)  # raises ValueError if invalid
+    return mode
+
+
+def _tags(tags: Optional[Sequence[str]]) -> list:
+    tags = list(tags or [])
+    if any(not isinstance(t, str) or not t for t in tags):
+        raise ValueError(f"tags must be non-empty strings, got {tags!r}")
+    return tags
 
 
 def cuda_config(pids: Sequence[int]) -> snapshot_agent_pb2.BackendConfig:
@@ -45,5 +79,80 @@ def direct_memory_config(pids: Sequence[int]) -> snapshot_agent_pb2.BackendConfi
     return snapshot_agent_pb2.BackendConfig(
         direct_memory=snapshot_agent_pb2.DirectMemoryBackendConfig(
             explicit_target=_process_target(pids)
+        )
+    )
+
+
+def app_endpoint_config(
+    app: Union[str, int],
+    endpoints: Sequence[str],
+    mode: Union[str, int, None] = None,
+    tags: Optional[Sequence[str]] = None,
+) -> snapshot_agent_pb2.BackendConfig:
+    """Builds a BackendConfig selecting the app_endpoint backend, which
+    suspends/resumes an application-aware workload through its HTTP API.
+
+    ``app`` selects the HTTP dialect: "vllm", "sglang", or an App enum
+    value. ``endpoints`` targets the server(s), e.g.
+    ``["http://localhost:8000"]``. ``mode`` states what happens to durable
+    state while suspended: "offload", "discard", a SuspendMode value, or
+    None for the application's default (for SGLang it is advisory: the
+    effective mode is fixed by the server's launch flags). ``tags`` selects
+    regions, e.g. ``["weights", "kv_cache"]``; if None or empty, the
+    application's full default region set is used.
+    """
+    if isinstance(app, str):
+        try:
+            app = _APPS[app.lower()]
+        except KeyError:
+            raise ValueError(f"unknown app {app!r}; expected one of {sorted(_APPS)}")
+    else:
+        snapshot_agent_pb2.App.Name(app)  # raises ValueError if invalid
+    if app == snapshot_agent_pb2.APP_UNSPECIFIED:
+        raise ValueError(f"app must be specified; expected one of {sorted(_APPS)}")
+    endpoints = list(endpoints)
+    if not endpoints or any(not isinstance(e, str) or not e for e in endpoints):
+        raise ValueError("at least one non-empty endpoint URL is required")
+    return snapshot_agent_pb2.BackendConfig(
+        app_endpoint=snapshot_agent_pb2.AppEndpointConfig(
+            app=app, endpoints=endpoints, mode=_suspend_mode(mode), tags=_tags(tags)
+        )
+    )
+
+
+def vllm_config(
+    endpoints: Sequence[str],
+    mode: Union[str, int, None] = None,
+    tags: Optional[Sequence[str]] = None,
+) -> snapshot_agent_pb2.BackendConfig:
+    """app_endpoint_config preset for vLLM's sleep/wake API."""
+    return app_endpoint_config("vllm", endpoints, mode=mode, tags=tags)
+
+
+def sglang_config(
+    endpoints: Sequence[str],
+    mode: Union[str, int, None] = None,
+    tags: Optional[Sequence[str]] = None,
+) -> snapshot_agent_pb2.BackendConfig:
+    """app_endpoint_config preset for SGLang's memory-occupation API."""
+    return app_endpoint_config("sglang", endpoints, mode=mode, tags=tags)
+
+
+def app_channel_config(
+    mode: Union[str, int, None] = None,
+    tags: Optional[Sequence[str]] = None,
+) -> snapshot_agent_pb2.BackendConfig:
+    """Builds a BackendConfig selecting the app_channel backend, which
+    suspends/resumes an application-aware workload through its registered
+    workload channel (see ``register_workload``).
+
+    The workload is addressed by the request's job_id, so no endpoints are
+    needed. ``mode`` is "offload", "discard", a SuspendMode value, or None
+    for the workload's registered default (OFFLOAD if the workload did not
+    declare one). ``tags`` selects regions; see ``app_endpoint_config``.
+    """
+    return snapshot_agent_pb2.BackendConfig(
+        app_channel=snapshot_agent_pb2.AppChannelConfig(
+            mode=_suspend_mode(mode), tags=_tags(tags)
         )
     )


### PR DESCRIPTION
## What does this PR do?
Adds config builders for other backends, matching #171

<!-- Describe the changes and their purpose -->

## Why is this change needed?

See https://github.com/llm-d-incubation/llm-d-rl-time-slicing/pull/171#discussion_r3848725490

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration builders for application endpoints and channels.
  * Added ready-to-use configuration presets for vLLM and SGLang applications.
  * Added support for configuring suspend modes and region tags using friendly names or numeric values.
  * Added validation for applications, endpoints, suspend modes, tags, and configuration fields.
  * Expanded the public Python API to expose the new configuration helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->