### PR TITLE
[Snapshot-Agent]: Make pids optional in python library config builders for CudaBackend and DirectMemoryBackend

### DIFF
--- a/pkg/client/python/tests/test_configs.py
+++ b/pkg/client/python/tests/test_configs.py
@@ -7,32 +7,38 @@ from timeslice.snapshot_agent import cuda_config, direct_memory_config
 
 class TestBackendConfigBuilders(unittest.TestCase):
     def test_cuda_config_builds_explicit_target(self):
+        """Explicit PIDs land in cuda.explicit_target."""
         cfg = cuda_config([101, 102])
         self.assertEqual(cfg.WhichOneof("backend"), "cuda")
         self.assertEqual(list(cfg.cuda.explicit_target.pids), [101, 102])
 
     def test_direct_memory_config_builds_explicit_target(self):
+        """Explicit PIDs land in direct_memory.explicit_target."""
         cfg = direct_memory_config([101, 102])
         self.assertEqual(cfg.WhichOneof("backend"), "direct_memory")
         self.assertEqual(list(cfg.direct_memory.explicit_target.pids), [101, 102])
 
     def test_cuda_config_omits_target_when_pids_not_given(self):
+        """Omitting pids leaves cuda.explicit_target unset (k8s discovery)."""
         cfg = cuda_config()
         self.assertEqual(cfg.WhichOneof("backend"), "cuda")
         self.assertFalse(cfg.cuda.HasField("explicit_target"))
 
     def test_direct_memory_config_omits_target_when_pids_not_given(self):
+        """Omitting pids leaves direct_memory.explicit_target unset (k8s discovery)."""
         cfg = direct_memory_config()
         self.assertEqual(cfg.WhichOneof("backend"), "direct_memory")
         self.assertFalse(cfg.direct_memory.HasField("explicit_target"))
 
     def test_rejects_empty_pids(self):
+        """An explicitly empty PID list is an error, not discovery."""
         with self.assertRaises(ValueError):
             cuda_config([])
         with self.assertRaises(ValueError):
             direct_memory_config([])
 
     def test_rejects_non_positive_pids(self):
+        """Zero and negative PIDs are rejected."""
         for pids in ([0], [-5]):
             with self.assertRaises(ValueError):
                 cuda_config(pids)
@@ -40,6 +46,7 @@ class TestBackendConfigBuilders(unittest.TestCase):
                 direct_memory_config(pids)
 
     def test_rejects_non_integer_pids(self):
+        """Non-integer PID values are rejected."""
         for pids in ([1.5], ["123"], [True]):
             with self.assertRaises((ValueError, TypeError)):
                 cuda_config(pids)

--- a/pkg/client/python/tests/test_configs.py
+++ b/pkg/client/python/tests/test_configs.py
@@ -16,6 +16,16 @@ class TestBackendConfigBuilders(unittest.TestCase):
         self.assertEqual(cfg.WhichOneof("backend"), "direct_memory")
         self.assertEqual(list(cfg.direct_memory.explicit_target.pids), [101, 102])
 
+    def test_cuda_config_omits_target_when_pids_not_given(self):
+        cfg = cuda_config()
+        self.assertEqual(cfg.WhichOneof("backend"), "cuda")
+        self.assertFalse(cfg.cuda.HasField("explicit_target"))
+
+    def test_direct_memory_config_omits_target_when_pids_not_given(self):
+        cfg = direct_memory_config()
+        self.assertEqual(cfg.WhichOneof("backend"), "direct_memory")
+        self.assertFalse(cfg.direct_memory.HasField("explicit_target"))
+
     def test_rejects_empty_pids(self):
         with self.assertRaises(ValueError):
             cuda_config([])

--- a/pkg/client/python/timeslice/snapshot_agent/configs.py
+++ b/pkg/client/python/timeslice/snapshot_agent/configs.py
@@ -17,7 +17,9 @@ def _process_target(pids: Sequence[int]) -> snapshot_agent_pb2.ProcessTarget:
     return snapshot_agent_pb2.ProcessTarget(pids=validated)
 
 
-def cuda_config(pids: Optional[Sequence[int]] = None) -> snapshot_agent_pb2.BackendConfig:
+def cuda_config(
+    pids: Optional[Sequence[int]] = None,
+) -> snapshot_agent_pb2.BackendConfig:
     """Builds a BackendConfig selecting the cuda (cuda-checkpoint) backend.
 
     In k8s mode the agent discovers PIDs itself from the
@@ -30,7 +32,9 @@ def cuda_config(pids: Optional[Sequence[int]] = None) -> snapshot_agent_pb2.Back
     return snapshot_agent_pb2.BackendConfig(cuda=cuda)
 
 
-def direct_memory_config(pids: Optional[Sequence[int]] = None) -> snapshot_agent_pb2.BackendConfig:
+def direct_memory_config(
+    pids: Optional[Sequence[int]] = None,
+) -> snapshot_agent_pb2.BackendConfig:
     """Builds a BackendConfig selecting the direct_memory (GPU-CR
     full-process) backend.
 

--- a/pkg/client/python/timeslice/snapshot_agent/configs.py
+++ b/pkg/client/python/timeslice/snapshot_agent/configs.py
@@ -6,6 +6,7 @@ from . import snapshot_agent_pb2
 
 
 def _process_target(pids: Sequence[int]) -> snapshot_agent_pb2.ProcessTarget:
+    """Validates pids and builds a ProcessTarget proto."""
     if not pids:
         raise ValueError("at least one PID is required")
     validated = []

--- a/pkg/client/python/timeslice/snapshot_agent/configs.py
+++ b/pkg/client/python/timeslice/snapshot_agent/configs.py
@@ -1,6 +1,6 @@
 """Helpers for building BackendConfig protos."""
 
-from typing import Sequence
+from typing import Optional, Sequence
 
 from . import snapshot_agent_pb2
 
@@ -16,34 +16,33 @@ def _process_target(pids: Sequence[int]) -> snapshot_agent_pb2.ProcessTarget:
     return snapshot_agent_pb2.ProcessTarget(pids=validated)
 
 
-def cuda_config(pids: Sequence[int]) -> snapshot_agent_pb2.BackendConfig:
-    """Builds a BackendConfig selecting the cuda (cuda-checkpoint) backend
-    with an explicit process target.
+def cuda_config(pids: Optional[Sequence[int]] = None) -> snapshot_agent_pb2.BackendConfig:
+    """Builds a BackendConfig selecting the cuda (cuda-checkpoint) backend.
 
-    In k8s mode the agent can discover PIDs itself from the
-    ``timeslice.io/job-id`` pod label; pass explicit PIDs for standalone
-    mode or to override discovery.
+    In k8s mode the agent discovers PIDs itself from the
+    ``timeslice.io/job-id`` pod label, so ``pids`` may be omitted. Pass
+    explicit PIDs for standalone mode or to override discovery.
     """
-    return snapshot_agent_pb2.BackendConfig(
-        cuda=snapshot_agent_pb2.CudaBackendConfig(explicit_target=_process_target(pids))
-    )
+    cuda = snapshot_agent_pb2.CudaBackendConfig()
+    if pids is not None:
+        cuda.explicit_target.CopyFrom(_process_target(pids))
+    return snapshot_agent_pb2.BackendConfig(cuda=cuda)
 
 
-def direct_memory_config(pids: Sequence[int]) -> snapshot_agent_pb2.BackendConfig:
+def direct_memory_config(pids: Optional[Sequence[int]] = None) -> snapshot_agent_pb2.BackendConfig:
     """Builds a BackendConfig selecting the direct_memory (GPU-CR
-    full-process) backend with an explicit process target.
+    full-process) backend.
 
     Experimental: the agent rejects this config with FAILED_PRECONDITION
     unless it runs with --feature-gates=DirectMemoryBackend=true (or the
     FEATURE_GATES env var). The target workload must run under the GPU-CR
     vGPU preloader.
 
-    In k8s mode the agent can discover PIDs itself from the
-    ``timeslice.io/job-id`` pod label; pass explicit PIDs for standalone
-    mode or to override discovery.
+    In k8s mode the agent discovers PIDs itself from the
+    ``timeslice.io/job-id`` pod label, so ``pids`` may be omitted. Pass
+    explicit PIDs for standalone mode or to override discovery.
     """
-    return snapshot_agent_pb2.BackendConfig(
-        direct_memory=snapshot_agent_pb2.DirectMemoryBackendConfig(
-            explicit_target=_process_target(pids)
-        )
-    )
+    direct_memory = snapshot_agent_pb2.DirectMemoryBackendConfig()
+    if pids is not None:
+        direct_memory.explicit_target.CopyFrom(_process_target(pids))
+    return snapshot_agent_pb2.BackendConfig(direct_memory=direct_memory)


### PR DESCRIPTION

## What does this PR do?
Makes pids optional for cuda and direct memory backends

<!-- Describe the changes and their purpose -->

## Why is this change needed?
Addresses https://github.com/llm-d-incubation/llm-d-rl-time-slicing/pull/171#discussion_r3848695949

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - CUDA and direct-memory configurations can now be created without specifying process IDs.
  - When process IDs are provided, configurations target those processes explicitly.
  - When process IDs are omitted, target discovery is left to the agent.

- **Bug Fixes**
  - Configurations no longer include an unnecessary explicit target when process IDs are not supplied.

- **Tests**
  - Added coverage for backend selection and target handling in both configuration types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->