### PR TITLE
[GPU-CR Selective Checkpoint 4/N]: cr_client support for selective checkpoint/restore of GPU memory regions

### DIFF
--- a/third_party/gpu-cr/CMakeLists.txt
+++ b/third_party/gpu-cr/CMakeLists.txt
@@ -135,12 +135,17 @@ target_compile_options(multi_cr_client PRIVATE -O3 -g)
 
 # ---------------------------------------------------------------------------
 # Tests (GPU-free; run in Dockerfile.build)
-#   gpu_cr_unit_tests        — GoogleTest unit suite for the dump-format
-#                              code, plus the upstream-baseline control
-#                              channel, buffer mapping, fd exchange and
-#                              wire structs
+#   gpu_cr_unit_tests        — GoogleTest unit suite for the dump-format and
+#                              region-spec code, plus the upstream-baseline
+#                              control channel, buffer mapping, fd exchange
+#                              and wire structs
+#   fake_workload            — GPU-free stand-in for the vGPU.so side of the
+#                              control channel
+#   cr_client_integration    — drives the real cr_client binary against
+#                              fake_workload, asserting protocol behavior and
+#                              the documented exit codes
 # ---------------------------------------------------------------------------
-option(GPU_CR_BUILD_TESTS "Build the GPU-free unit tests" OFF)
+option(GPU_CR_BUILD_TESTS "Build the GPU-free unit and integration tests" OFF)
 
 if(GPU_CR_BUILD_TESTS)
     include(FetchContent)
@@ -159,6 +164,7 @@ if(GPU_CR_BUILD_TESTS)
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/dump_format_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/ipc_fd_exchange_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/mmap_backend_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/selective_spec_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/share_mem_comm_test.cpp
         # GPU-free production sources under test (upstream-baseline functions)
         ${CMAKE_CURRENT_SOURCE_DIR}/src/backend/mmap_backend.cpp
@@ -167,9 +173,25 @@ if(GPU_CR_BUILD_TESTS)
     )
     target_include_directories(gpu_cr_unit_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src
+        # selective_spec_test includes coordinator/selective_spec.h
+        ${CMAKE_CURRENT_SOURCE_DIR}/coordinator
     )
     target_link_libraries(gpu_cr_unit_tests PRIVATE GTest::gtest_main pthread)
     add_test(NAME unit COMMAND gpu_cr_unit_tests)
+
+    add_executable(fake_workload
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/integration/fake_workload.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/comm/share_mem.cpp
+    )
+    target_include_directories(fake_workload PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+
+    add_test(NAME cr_client_integration
+        COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/integration/cr_client_integration_test.sh
+                $<TARGET_FILE:cr_client> $<TARGET_FILE:fake_workload>
+    )
+    set_tests_properties(cr_client_integration PROPERTIES TIMEOUT 300)
 endif()
 
 # ---------------------------------------------------------------------------

--- a/third_party/gpu-cr/coordinator/cr_client.cpp
+++ b/third_party/gpu-cr/coordinator/cr_client.cpp
@@ -1,7 +1,9 @@
 #include <iostream>
 #include <stdint.h>
 #include <unistd.h>
+#include <errno.h>
 #include <fcntl.h>
+#include <sys/file.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <assert.h>
@@ -12,15 +14,34 @@
 #include <string>
 
 #ifdef __HIP_PLATFORM_AMD__
-// AMD platform 
+// AMD platform
 #else
 #include <cuda.h>
 #endif
 
 #include "common.h"
+#include "dump_format.h"
+#include "selective_spec.h"
 #include "comm/comm.h"
 
+namespace {
+
+// Exit codes (consumed by the snapshot agent):
+//   0 OK, 1 usage/parse, 2 op failed (op_status or invalid dump),
+//   3 gate refused (capability), 4 timeout.
+constexpr int kExitOpFailed = 2;
+constexpr int kExitRefused = 3;
+constexpr int kExitTimeout = 4;
+
+}  // namespace
+
 std::string get_cuda_checkpoint_path() {
+    // Deployment override (also used by the GPU-free integration tests):
+    // point at the cuda-checkpoint binary explicitly instead of relying on
+    // the layout-relative lookup below.
+    const char* env_path = getenv("GPU_CR_CUDA_CHECKPOINT");
+    if (env_path && env_path[0]) return env_path;
+
     char exe_path[1024];
     ssize_t count = readlink("/proc/self/exe", exe_path, 1024);
     if (count == -1) {
@@ -34,11 +55,154 @@ std::string get_cuda_checkpoint_path() {
 
     if (access(full_path.c_str(), X_OK) != 0) {
         fprintf(stderr, "WARNING: helper binary not found at: %s\n", full_path.c_str());
-        return "cuda-checkpoint"; 
+        return "cuda-checkpoint";
     }
 
     return full_path;
 }
+
+namespace {
+
+// Runs "<bin> --toggle --pid <pid>" without a shell: cr_client ships in
+// distroless agent images where system() has no /bin/sh and always fails
+// with 127. execlp keeps the PATH lookup for a bare "cuda-checkpoint".
+// Returns the command's exit status (127 if it could not be executed,
+// 128+signal if it died on one), or -1 if it could not be spawned/reaped —
+// mirroring system()'s <0 / status split the callers already handle.
+int RunCudaCheckpointToggle(const std::string& bin_path, pid_t target_pid) {
+    std::string pid_str = std::to_string(target_pid);
+    pid_t child = fork();
+    if (child < 0) return -1;
+    if (child == 0) {
+        execlp(bin_path.c_str(), bin_path.c_str(), "--toggle", "--pid",
+               pid_str.c_str(), static_cast<char*>(nullptr));
+        _exit(127);
+    }
+    int status = 0;
+    if (waitpid(child, &status, 0) < 0) return -1;
+    if (WIFEXITED(status)) return WEXITSTATUS(status);
+    if (WIFSIGNALED(status)) return 128 + WTERMSIG(status);
+    return -1;
+}
+
+// kill() with the result checked: a target that died between the pre-op
+// gates and the signal should fail crisply here, not burn the whole
+// FINISH timeout on a signal that never landed.
+void SignalOrDie(pid_t target_pid, int sig) {
+    if (kill(target_pid, sig) != 0) {
+        fprintf(stderr, "Error: kill(%d, %d): %s\n", target_pid, sig, strerror(errno));
+        exit(kExitRefused);
+    }
+}
+
+// Pre-creates the destination file: existence only (O_CREAT), never sizing —
+// the .so alone can compute the dump total (preloader-authoritative
+// sizing), and an inode costs no hugepages/blocks in this cgroup.
+bool SecurePrecreate(const char* path) {
+    if (path[0] != '/') {
+        fprintf(stderr, "Error: -o path must be absolute: %s\n", path);
+        return false;
+    }
+    char dir_buf[gpu_cr::kSelectiveCrMaxPath];
+    strncpy(dir_buf, path, sizeof(dir_buf) - 1);
+    dir_buf[sizeof(dir_buf) - 1] = '\0';
+    char* slash = strrchr(dir_buf, '/');
+    const char* base = slash + 1;
+    if (*base == '\0') {
+        fprintf(stderr, "Error: -o path is a directory: %s\n", path);
+        return false;
+    }
+    *slash = '\0';
+    const char* dir = dir_buf[0] ? dir_buf : "/";
+
+    int dfd = open(dir, O_PATH | O_DIRECTORY | O_CLOEXEC);
+    if (dfd < 0) {
+        fprintf(stderr, "Error: cannot open destination dir %s: %s\n", dir, strerror(errno));
+        return false;
+    }
+    // Symlink hardening: cr_client runs as root in the agent pod against a
+    // workload-writable store, so a symlink swap must not let it
+    // create/truncate arbitrary host files. `base` is a single slash-free
+    // component resolved relative to the already-opened parent, so
+    // O_NOFOLLOW closes the only traversal left — a trailing symlink fails
+    // with ELOOP (dangling included; O_CREAT does not create through one).
+    // For this shape, openat2(RESOLVE_BENEATH|RESOLVE_NO_SYMLINKS) would
+    // add nothing.
+    int fd = openat(dfd, base, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0644);
+    close(dfd);
+    if (fd < 0) {
+        fprintf(stderr, "Error: cannot create destination %s: %s\n", path, strerror(errno));
+        return false;
+    }
+    close(fd);
+    return true;
+}
+
+// Post-checkpoint validation of a destination dump: header
+// plausibility + trailing commit marker, via read(2) — no mmap, so no
+// hugetlb reservation or fault lands in this process's cgroup.
+bool ValidateDestDump(const char* path) {
+    int fd = open(path, O_RDONLY | O_CLOEXEC);
+    if (fd < 0) {
+        fprintf(stderr, "Error: cannot reopen destination %s: %s\n", path, strerror(errno));
+        return false;
+    }
+    bool ok = gpu_cr::ValidateDumpFd(fd);
+    close(fd);
+    if (!ok)
+        fprintf(stderr, "Error: destination %s failed dump validation (torn or unserved dump)\n", path);
+    return ok;
+}
+
+// Polls for FINISH with a deadline: a dead or wedged workload must fail this
+// invocation, not hang it (and the agent behind it) forever.
+bool WaitFinished(ShareMemComm* comm) {
+    long timeout_sec = 120;
+    const char* t = getenv("GPU_CR_OP_TIMEOUT_SEC");
+    if (t && atol(t) > 0) timeout_sec = atol(t);
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(timeout_sec);
+    while (!comm->is_finished()) {
+        if (std::chrono::steady_clock::now() >= deadline) {
+            fprintf(stderr, "Error: timed out after %lds waiting for FINISH\n", timeout_sec);
+            return false;
+        }
+        usleep(1000);
+    }
+    return true;
+}
+
+// After a FULL ckpt/restore: a v2 .so reports op_status (clean
+// failures: oversized checkpoint, deferred-buffer ENOMEM). On checkpoint
+// failure we must NOT proceed to cuda-checkpoint --toggle — freezing a
+// process whose state was never saved is unrecoverable; on restore
+// failure we must not unfreeze onto stale weights. A v1 .so leaves
+// proto_ack at 0 and keeps historical behavior.
+void CheckFullResult(ShareMemComm* comm, const char* what) {
+    if (comm->control->proto_ack >= gpu_cr::kSelectiveCrProtoV2 && comm->control->op_status != 0) {
+        int32_t st = comm->control->op_status;
+        fprintf(stderr, "Error: vGPU.so reported %s failure: %s (status=%d); NOT toggling cuda-checkpoint\n",
+                what, strerror(st), st);
+        exit(kExitOpFailed);
+    }
+}
+
+// After a selective op: surface the .so-reported status. A v2 ack with a
+// nonzero status is a clean op failure; a missing ack on a dest-path op
+// means the .so never saw the destination (v1 skew) — refuse loudly.
+void CheckSelectiveResult(ShareMemComm* comm, const char* dest_path) {
+    if (comm->control->proto_ack >= gpu_cr::kSelectiveCrProtoV2) {
+        int32_t st = comm->control->op_status;
+        if (st != 0) {
+            fprintf(stderr, "Error: vGPU.so reported op failure: %s (status=%d)\n", strerror(st), st);
+            exit(kExitOpFailed);
+        }
+    } else if (dest_path) {
+        fprintf(stderr, "Error: no v2 ack from vGPU.so — destination path was ignored (version skew)\n");
+        exit(kExitRefused);
+    }
+}
+
+}  // namespace
 
 
 int main(int argc, char* argv[]) {
@@ -50,7 +214,9 @@ int main(int argc, char* argv[]) {
     int pid = 0;
     int criu_pid = 0;
     int buffer_only = 0;
-    while ((opt = getopt(argc, argv, "icrdbp:m:")) != -1) {
+    const char* selective_spec = nullptr;
+    const char* dest_path = nullptr;
+    while ((opt = getopt(argc, argv, "icrdbp:m:s:o:")) != -1) {
         switch (opt) {
             case 'i':
                 init = 1;
@@ -70,8 +236,14 @@ int main(int argc, char* argv[]) {
             case 'b':
                 buffer_only = 1;
                 break;
+            case 's':
+                selective_spec = optarg;
+                break;
+            case 'o':
+                dest_path = optarg;
+                break;
             default:
-                fprintf(stderr, "Usage: %s [-i|-c|-r] -p pid [-m criu_pid] [-b]\n", argv[0]);
+                fprintf(stderr, "Usage: %s [-i|-c|-r] -p pid [-m criu_pid] [-b] [-s ptr:size,...] [-o /path/to/dump]\n", argv[0]);
                 exit(EXIT_FAILURE);
         }
     }
@@ -83,27 +255,102 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "Only one of -i, -c, or -r  can be specified\n");
         exit(EXIT_FAILURE);
     }
+    if (dest_path) {
+        if (!selective_spec || (!ckpt && !restore)) {
+            fprintf(stderr, "Error: -o requires -c or -r together with -s\n");
+            exit(EXIT_FAILURE);
+        }
+        if (strlen(dest_path) >= gpu_cr::kSelectiveCrMaxPath) {
+            fprintf(stderr, "Error: -o path exceeds %zu bytes\n", gpu_cr::kSelectiveCrMaxPath - 1);
+            exit(EXIT_FAILURE);
+        }
+    }
     assert(pid != 0);
     if (criu_pid == 0) criu_pid = pid;
 
-    Comm *comm = new ShareMemComm(pid);
+    ShareMemComm *comm = new ShareMemComm(pid);
     comm->setup();
 
-    int ret;
+    // Serialize concurrent cr_clients against the same PID for the whole
+    // op: nothing else orders two writers of selective_req. The control
+    // file was opened with open(O_CREAT) by setup(), and an inode lock
+    // faults no hugetlb pages, so it stays safe with a zero hugepages
+    // request; a failed flock warns and proceeds (historical behavior).
+    if (flock(comm->fd_control, LOCK_EX) != 0)
+        fprintf(stderr, "Warning: flock(control-%d) failed: %s\n", pid, strerror(errno));
+
+    // Dest-path gate, BEFORE any signal: a .so that never advertised the
+    // capability would silently serve the op from the per-PID buffer — for
+    // a restore that replays stale bytes into GPU memory, which no post-op
+    // check can undo.
+    if (dest_path && !(comm->control->capability & gpu_cr::kCrCapDestPath)) {
+        fprintf(stderr, "Error: vGPU.so has not advertised dest-path support "
+                        "(run -i first, or upgrade the preloaded library)\n");
+        exit(kExitRefused);
+    }
+
+    int ret = 0;
 
     if(init) {
         comm->send_msg(INIT_MSG);
-        kill(pid, CR_INIT_SIGNAL);
-        while(!comm->is_finished()) {
-            usleep(1000);
+        SignalOrDie(pid, CR_INIT_SIGNAL);
+        if (!WaitFinished(comm)) exit(kExitTimeout);
+    } else if (ckpt && selective_spec) {
+        SelectiveCrRequest req;
+        memset(&req, 0, sizeof(req));
+        if (!gpu_cr::ParseSelectiveRegions(selective_spec, &req)) {
+            fprintf(stderr, "Error: failed to parse selective regions\n");
+            exit(EXIT_FAILURE);
         }
-    }  else if(ckpt) {
+        printf("Selective checkpoint: %u regions\n", req.num_regions);
+        for (uint32_t i = 0; i < req.num_regions; i++) {
+            printf("  region %u: ptr=%p size=%lu\n", i, req.regions[i].ptr, req.regions[i].size);
+        }
+        // Always write the full v2 extension (zeroed dest when -o absent) so
+        // a stale dest_path from an earlier op can never survive this write.
+        req.proto_version = gpu_cr::kSelectiveCrProtoV2;
+        if (dest_path) {
+            if (!SecurePrecreate(dest_path)) exit(kExitOpFailed);
+            strncpy(req.dest_path, dest_path, gpu_cr::kSelectiveCrMaxPath - 1);
+        }
+        comm->control->selective_req = req;
+        comm->send_msg(SELECTIVE_CKPT_MSG);
+        SignalOrDie(pid, CR_CKPT_SIGNAL);
+        printf("Selective dump signal sent.\n");
+        if (!WaitFinished(comm)) exit(kExitTimeout);
+        CheckSelectiveResult(comm, dest_path);
+        if (dest_path && !ValidateDestDump(dest_path)) exit(kExitOpFailed);
+        printf("Selective checkpointing done\n");
+    } else if (restore && selective_spec) {
+        SelectiveCrRequest req;
+        memset(&req, 0, sizeof(req));
+        if (!gpu_cr::ParseSelectiveRegions(selective_spec, &req)) {
+            fprintf(stderr, "Error: failed to parse selective regions\n");
+            exit(EXIT_FAILURE);
+        }
+        printf("Selective restore: %u regions\n", req.num_regions);
+        req.proto_version = gpu_cr::kSelectiveCrProtoV2;
+        if (dest_path) {
+            struct stat st;
+            if (stat(dest_path, &st) != 0) {
+                fprintf(stderr, "Error: restore source %s: %s\n", dest_path, strerror(errno));
+                exit(kExitOpFailed);
+            }
+            strncpy(req.dest_path, dest_path, gpu_cr::kSelectiveCrMaxPath - 1);
+        }
+        comm->control->selective_req = req;
+        comm->send_msg(SELECTIVE_RESTORE_MSG);
+        SignalOrDie(pid, CR_RESTORE_SIGNAL);
+        printf("Selective restore signal sent.\n");
+        if (!WaitFinished(comm)) exit(kExitTimeout);
+        CheckSelectiveResult(comm, dest_path);
+        printf("Selective restore done\n");
+    } else if(ckpt) {
         comm->send_msg(CKPT_MSG);
-        kill(pid, CR_CKPT_SIGNAL);
+        SignalOrDie(pid, CR_CKPT_SIGNAL);
         printf("Dump signal sent.\n");
-        while(!comm->is_finished()) {
-            usleep(1000);
-        }
+        if (!WaitFinished(comm)) exit(kExitTimeout);
+        CheckFullResult(comm, "checkpoint");
         printf("Dumping done.\n");
 #ifdef __HIP_PLATFORM_AMD__
         // For AMD: call CRIU to dump the process
@@ -134,14 +381,22 @@ int main(int argc, char* argv[]) {
         printf("CRIU checkpoint time: %.3f s\n", std::chrono::duration<double>(t1 - t0).count());
 #else
         std::string bin_path = get_cuda_checkpoint_path();
-        std::string cmd = bin_path + " --toggle --pid " + std::to_string(pid);
-        // std::string cmd = "cuda-checkpoint --toggle --pid " + std::to_string(pid);
         auto t0 = std::chrono::high_resolution_clock::now();
-        if (!buffer_only)
-            ret = system(cmd.c_str());
-        if (ret < 0) {
-            perror("system()");
-            exit(EXIT_FAILURE);
+        if (!buffer_only) {
+            ret = RunCudaCheckpointToggle(bin_path, pid);
+            if (ret < 0) {
+                perror("toggle spawn");
+                exit(EXIT_FAILURE);
+            }
+            // A nonzero freeze exit means the process is still running on
+            // the GPU: report op failure (the dump itself is valid) rather
+            // than let the agent believe it parked.
+            if (ret != 0) {
+                fprintf(stderr, "Error: '%s --toggle --pid %d' exited with status %d — "
+                        "dump is valid but the process was NOT frozen\n",
+                        bin_path.c_str(), pid, ret);
+                exit(kExitOpFailed);
+            }
         }
         auto t1 = std::chrono::high_resolution_clock::now();
         printf("cuda-checkpoint checkpoint time: %.3f s\n", std::chrono::duration<double>(t1 - t0).count());
@@ -177,34 +432,41 @@ int main(int argc, char* argv[]) {
         printf("Calling GPU-CR\n");
 
         comm->send_msg(RESTORE_MSG);
-        kill(pid, CR_RESTORE_SIGNAL);
-        
-        while(!comm->is_finished()) {
-            usleep(1000);
-        }
+        SignalOrDie(pid, CR_RESTORE_SIGNAL);
+
+        if (!WaitFinished(comm)) exit(kExitTimeout);
         auto t2 = std::chrono::high_resolution_clock::now();
         printf("GPUos restore time: %.3f s\n", std::chrono::duration<double>(t2 - t1).count());
 
         printf("Process internal restoration finished.\n");
         printf("Restoring done\n");
 #else
+        // Upstream ordering: thaw first, then drive the in-process restore.
+        // The restore handler runs inside the target and needs a live CUDA
+        // context; signaling a still-checkpointed process would leave the
+        // handler blocked on its first driver call.
         std::string bin_path = get_cuda_checkpoint_path();
-        std::string cmd = bin_path + " --toggle --pid " + std::to_string(pid);
         auto t0 = std::chrono::high_resolution_clock::now();
-        if (!buffer_only)
-            ret = system(cmd.c_str());
-        if (ret < 0) {
-            perror("system()");
-            exit(EXIT_FAILURE);
+        if (!buffer_only) {
+            ret = RunCudaCheckpointToggle(bin_path, pid);
+            if (ret < 0) {
+                perror("toggle spawn");
+                exit(EXIT_FAILURE);
+            }
+            // A failed thaw leaves the process checkpointed — abort before
+            // kill() rather than wedge it mid-restore.
+            if (ret != 0) {
+                fprintf(stderr, "Error: '%s --toggle --pid %d' exited with status %d\n",
+                        bin_path.c_str(), pid, ret);
+                exit(kExitOpFailed);
+            }
         }
         auto t1 = std::chrono::high_resolution_clock::now();
         printf("cuda-checkpoint restore time: %.3f s\n", std::chrono::duration<double>(t1 - t0).count());
-        fflush(stdout);
         comm->send_msg(RESTORE_MSG);
-        kill(pid, CR_RESTORE_SIGNAL);
-        while(!comm->is_finished()) {
-            usleep(1000);
-        }
+        SignalOrDie(pid, CR_RESTORE_SIGNAL);
+        if (!WaitFinished(comm)) exit(kExitTimeout);
+        CheckFullResult(comm, "restore");
         printf("Restoring done\n");
 #endif
     }

--- a/third_party/gpu-cr/coordinator/cr_client.cpp
+++ b/third_party/gpu-cr/coordinator/cr_client.cpp
@@ -28,7 +28,7 @@ namespace {
 
 // Exit codes (consumed by the snapshot agent):
 //   0 OK, 1 usage/parse, 2 op failed (op_status or invalid dump),
-//   3 gate refused (capability), 4 timeout.
+//   3 gate refused (.so not ready), 4 timeout.
 constexpr int kExitOpFailed = 2;
 constexpr int kExitRefused = 3;
 constexpr int kExitTimeout = 4;
@@ -171,34 +171,35 @@ bool WaitFinished(ShareMemComm* comm) {
     return true;
 }
 
-// After a FULL ckpt/restore: a v2 .so reports op_status (clean
+// After a FULL ckpt/restore: the .so reports op_status at FINISH (clean
 // failures: oversized checkpoint, deferred-buffer ENOMEM). On checkpoint
 // failure we must NOT proceed to cuda-checkpoint --toggle — freezing a
 // process whose state was never saved is unrecoverable; on restore
-// failure we must not unfreeze onto stale weights. A v1 .so leaves
-// proto_ack at 0 and keeps historical behavior.
+// failure we must not unfreeze onto stale weights. op_status == 0 means
+// no result was reported (a .so that predates status reporting, or a
+// FINISH raced by a crash): full ops keep historical tolerance.
 void CheckFullResult(ShareMemComm* comm, const char* what) {
-    if (comm->control->proto_ack >= gpu_cr::kSelectiveCrProtoV2 && comm->control->op_status != 0) {
-        int32_t st = comm->control->op_status;
+    int32_t st = comm->control->op_status;
+    if (st < 0) {
         fprintf(stderr, "Error: vGPU.so reported %s failure: %s (status=%d); NOT toggling cuda-checkpoint\n",
-                what, strerror(st), st);
+                what, strerror(-st), st);
         exit(kExitOpFailed);
     }
 }
 
-// After a selective op: surface the .so-reported status. A v2 ack with a
-// nonzero status is a clean op failure; a missing ack on a dest-path op
-// means the .so never saw the destination (v1 skew) — refuse loudly.
-void CheckSelectiveResult(ShareMemComm* comm, const char* dest_path) {
-    if (comm->control->proto_ack >= gpu_cr::kSelectiveCrProtoV2) {
-        int32_t st = comm->control->op_status;
-        if (st != 0) {
-            fprintf(stderr, "Error: vGPU.so reported op failure: %s (status=%d)\n", strerror(st), st);
-            exit(kExitOpFailed);
-        }
-    } else if (dest_path) {
-        fprintf(stderr, "Error: no v2 ack from vGPU.so — destination path was ignored (version skew)\n");
-        exit(kExitRefused);
+// After a selective op: surface the .so-reported status. Negative is a
+// clean op failure. Zero means the op never reached FINISH bookkeeping
+// (the client zeroed the word before signaling) — for selective ops that
+// is out of contract, so fail rather than trust the dump.
+void CheckSelectiveResult(ShareMemComm* comm) {
+    int32_t st = comm->control->op_status;
+    if (st < 0) {
+        fprintf(stderr, "Error: vGPU.so reported op failure: %s (status=%d)\n", strerror(-st), st);
+        exit(kExitOpFailed);
+    }
+    if (st == 0) {
+        fprintf(stderr, "Error: vGPU.so reported no op result\n");
+        exit(kExitOpFailed);
     }
 }
 
@@ -279,15 +280,23 @@ int main(int argc, char* argv[]) {
     if (flock(comm->fd_control, LOCK_EX) != 0)
         fprintf(stderr, "Warning: flock(control-%d) failed: %s\n", pid, strerror(errno));
 
-    // Dest-path gate, BEFORE any signal: a .so that never advertised the
-    // capability would silently serve the op from the per-PID buffer — for
-    // a restore that replays stale bytes into GPU memory, which no post-op
-    // check can undo.
-    if (dest_path && !(comm->control->capability & gpu_cr::kCrCapDestPath)) {
-        fprintf(stderr, "Error: vGPU.so has not advertised dest-path support "
-                        "(run -i first, or upgrade the preloaded library)\n");
+    // Selective-op gate, BEFORE any signal: a .so that never published
+    // selective_ready (init_CR not yet run, or a mismatched build) has no
+    // armed handlers — a signaled op would just burn the FINISH timeout,
+    // and a dest-path restore served from the per-PID buffer would replay
+    // stale bytes into GPU memory, which no post-op check can undo.
+    // Full-process ops stay ungated (historical behavior).
+    if ((selective_spec || dest_path) &&
+        comm->control->selective_ready != gpu_cr::kSelectiveReady) {
+        fprintf(stderr, "Error: vGPU.so has not published selective support "
+                        "(run -i first, or fix the preloaded library)\n");
         exit(kExitRefused);
     }
+
+    // Consume any earlier op result before signaling: op_status semantics
+    // are "0 = this op never reported", which is only true if the word
+    // cannot carry a stale success from a previous op across a crash.
+    comm->control->op_status = 0;
 
     int ret = 0;
 
@@ -306,9 +315,8 @@ int main(int argc, char* argv[]) {
         for (uint32_t i = 0; i < req.num_regions; i++) {
             printf("  region %u: ptr=%p size=%lu\n", i, req.regions[i].ptr, req.regions[i].size);
         }
-        // Always write the full v2 extension (zeroed dest when -o absent) so
-        // a stale dest_path from an earlier op can never survive this write.
-        req.proto_version = gpu_cr::kSelectiveCrProtoV2;
+        // Always write the whole request (zeroed dest when -o absent) so a
+        // stale dest_path from an earlier op can never survive this write.
         if (dest_path) {
             if (!SecurePrecreate(dest_path)) exit(kExitOpFailed);
             strncpy(req.dest_path, dest_path, gpu_cr::kSelectiveCrMaxPath - 1);
@@ -318,7 +326,7 @@ int main(int argc, char* argv[]) {
         SignalOrDie(pid, CR_CKPT_SIGNAL);
         printf("Selective dump signal sent.\n");
         if (!WaitFinished(comm)) exit(kExitTimeout);
-        CheckSelectiveResult(comm, dest_path);
+        CheckSelectiveResult(comm);
         if (dest_path && !ValidateDestDump(dest_path)) exit(kExitOpFailed);
         printf("Selective checkpointing done\n");
     } else if (restore && selective_spec) {
@@ -329,7 +337,6 @@ int main(int argc, char* argv[]) {
             exit(EXIT_FAILURE);
         }
         printf("Selective restore: %u regions\n", req.num_regions);
-        req.proto_version = gpu_cr::kSelectiveCrProtoV2;
         if (dest_path) {
             struct stat st;
             if (stat(dest_path, &st) != 0) {
@@ -343,7 +350,7 @@ int main(int argc, char* argv[]) {
         SignalOrDie(pid, CR_RESTORE_SIGNAL);
         printf("Selective restore signal sent.\n");
         if (!WaitFinished(comm)) exit(kExitTimeout);
-        CheckSelectiveResult(comm, dest_path);
+        CheckSelectiveResult(comm);
         printf("Selective restore done\n");
     } else if(ckpt) {
         comm->send_msg(CKPT_MSG);

--- a/third_party/gpu-cr/coordinator/cr_client.cpp
+++ b/third_party/gpu-cr/coordinator/cr_client.cpp
@@ -104,7 +104,18 @@ void SignalOrDie(pid_t target_pid, int sig) {
 // truncate matters: a recycled path holding an older valid dump could
 // otherwise false-validate a torn write whenever the new commit-marker
 // offset landed on old payload bytes that happen to spell the magic.
-bool SecurePrecreate(const char* path) {
+//
+// Ownership: the dump is written by the TARGET, not by this client — the
+// .so opens dest_path O_RDWR, never O_CREAT. cr_client runs as root in
+// the agent pod while the workload is commonly non-root, so a root-owned
+// file would turn every checkpoint into EACCES inside the target. The
+// inode is chown'd to the target's uid/gid (stat of /proc/<pid>, which
+// needs no cross-pod UID contract) rather than opened 0666: the store
+// dir is shared, and dump validation proves a commit marker, not
+// authorship — world-writable would let any co-mounted uid plant a
+// marker-valid dump that a later restore trusts. (A non-dumpable target
+// stats as root:root and keeps today's root-owned behavior.)
+bool SecurePrecreate(const char* path, pid_t target_pid) {
     if (path[0] != '/') {
         fprintf(stderr, "Error: -o path must be absolute: %s\n", path);
         return false;
@@ -141,6 +152,24 @@ bool SecurePrecreate(const char* path) {
     close(dfd);
     if (fd < 0) {
         fprintf(stderr, "Error: cannot create destination %s: %s\n", path, strerror(errno));
+        return false;
+    }
+    char proc_path[64];
+    snprintf(proc_path, sizeof(proc_path), "/proc/%d", target_pid);
+    struct stat pst;
+    if (stat(proc_path, &pst) != 0) {
+        fprintf(stderr, "Error: cannot stat %s: %s\n", proc_path, strerror(errno));
+        close(fd);
+        return false;
+    }
+    // fchmod after the fact, not via the open mode: the mode must not be
+    // umask-filtered, and 0600 is enough — the writer owns the file, and
+    // the validating reopen runs as root (test rigs run both sides as
+    // one uid, which owner-rw also covers).
+    if (fchown(fd, pst.st_uid, pst.st_gid) != 0 || fchmod(fd, 0600) != 0) {
+        fprintf(stderr, "Error: cannot hand %s to uid %u: %s\n", path,
+                (unsigned)pst.st_uid, strerror(errno));
+        close(fd);
         return false;
     }
     close(fd);
@@ -338,7 +367,7 @@ int main(int argc, char* argv[]) {
         // Always write the whole request (zeroed dest when -o absent) so a
         // stale dest_path from an earlier op can never survive this write.
         if (dest_path) {
-            if (!SecurePrecreate(dest_path)) exit(kExitOpFailed);
+            if (!SecurePrecreate(dest_path, pid)) exit(kExitOpFailed);
             strncpy(req.dest_path, dest_path, gpu_cr::kSelectiveCrMaxPath - 1);
         }
         comm->control->selective_req = req;

--- a/third_party/gpu-cr/coordinator/cr_client.cpp
+++ b/third_party/gpu-cr/coordinator/cr_client.cpp
@@ -28,7 +28,10 @@ namespace {
 
 // Exit codes (consumed by the snapshot agent):
 //   0 OK, 1 usage/parse, 2 op failed (op_status or invalid dump),
-//   3 gate refused (.so not ready), 4 timeout.
+//   3 refused pre-signal (.so not ready, or target dead), 4 timeout.
+// Exit 4 poisons the channel: the flock releases at exit while the
+// wedged handler may still be mid-op, so the workload must be restarted
+// (or proven idle) before another op targets this PID.
 constexpr int kExitOpFailed = 2;
 constexpr int kExitRefused = 3;
 constexpr int kExitTimeout = 4;
@@ -95,9 +98,12 @@ void SignalOrDie(pid_t target_pid, int sig) {
     }
 }
 
-// Pre-creates the destination file: existence only (O_CREAT), never sizing —
+// Pre-creates the destination file empty (O_CREAT|O_TRUNC), never sized —
 // the .so alone can compute the dump total (preloader-authoritative
-// sizing), and an inode costs no hugepages/blocks in this cgroup.
+// sizing), and an inode costs no hugepages/blocks in this cgroup. The
+// truncate matters: a recycled path holding an older valid dump could
+// otherwise false-validate a torn write whenever the new commit-marker
+// offset landed on old payload bytes that happen to spell the magic.
 bool SecurePrecreate(const char* path) {
     if (path[0] != '/') {
         fprintf(stderr, "Error: -o path must be absolute: %s\n", path);
@@ -120,15 +126,18 @@ bool SecurePrecreate(const char* path) {
         fprintf(stderr, "Error: cannot open destination dir %s: %s\n", dir, strerror(errno));
         return false;
     }
-    // Symlink hardening: cr_client runs as root in the agent pod against a
-    // workload-writable store, so a symlink swap must not let it
-    // create/truncate arbitrary host files. `base` is a single slash-free
-    // component resolved relative to the already-opened parent, so
-    // O_NOFOLLOW closes the only traversal left — a trailing symlink fails
-    // with ELOOP (dangling included; O_CREAT does not create through one).
-    // For this shape, openat2(RESOLVE_BENEATH|RESOLVE_NO_SYMLINKS) would
-    // add nothing.
-    int fd = openat(dfd, base, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, 0644);
+    // Symlink hardening, trailing component only: cr_client runs as root
+    // in the agent pod against a workload-writable store, so a symlink
+    // swap of the final component must not let it create/truncate
+    // arbitrary host files. `base` is a single slash-free component
+    // resolved relative to the already-opened parent, so O_NOFOLLOW makes
+    // a trailing symlink fail with ELOOP (dangling included; O_CREAT does
+    // not create through one). Intermediate components of `dir` are NOT
+    // defended — the agent passes store paths whose parents it owns; a
+    // workload-writable intermediate would need
+    // openat2(RESOLVE_NO_SYMLINKS) to close.
+    int fd = openat(dfd, base,
+                    O_CREAT | O_RDWR | O_TRUNC | O_CLOEXEC | O_NOFOLLOW, 0644);
     close(dfd);
     if (fd < 0) {
         fprintf(stderr, "Error: cannot create destination %s: %s\n", path, strerror(errno));
@@ -159,7 +168,10 @@ bool ValidateDestDump(const char* path) {
 bool WaitFinished(ShareMemComm* comm) {
     long timeout_sec = 120;
     const char* t = getenv("GPU_CR_OP_TIMEOUT_SEC");
-    if (t && atol(t) > 0) timeout_sec = atol(t);
+    if (t) {
+        long v = atol(t);
+        if (v > 0) timeout_sec = v;
+    }
     auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(timeout_sec);
     while (!comm->is_finished()) {
         if (std::chrono::steady_clock::now() >= deadline) {
@@ -256,8 +268,12 @@ int main(int argc, char* argv[]) {
         fprintf(stderr, "Only one of -i, -c, or -r  can be specified\n");
         exit(EXIT_FAILURE);
     }
+    if (selective_spec && !ckpt && !restore) {
+        fprintf(stderr, "Error: -s requires -c or -r\n");
+        exit(EXIT_FAILURE);
+    }
     if (dest_path) {
-        if (!selective_spec || (!ckpt && !restore)) {
+        if (!selective_spec) {
             fprintf(stderr, "Error: -o requires -c or -r together with -s\n");
             exit(EXIT_FAILURE);
         }
@@ -286,7 +302,7 @@ int main(int argc, char* argv[]) {
     // and a dest-path restore served from the per-PID buffer would replay
     // stale bytes into GPU memory, which no post-op check can undo.
     // Full-process ops stay ungated (historical behavior).
-    if ((selective_spec || dest_path) &&
+    if (selective_spec &&
         comm->control->selective_ready != gpu_cr::kSelectiveReady) {
         fprintf(stderr, "Error: vGPU.so has not published selective support "
                         "(run -i first, or fix the preloaded library)\n");
@@ -296,6 +312,10 @@ int main(int argc, char* argv[]) {
     // Consume any earlier op result before signaling: op_status semantics
     // are "0 = this op never reported", which is only true if the word
     // cannot carry a stale success from a previous op across a crash.
+    // Control-word accesses here and in WaitFinished are plain loads and
+    // stores, matching the pre-existing channel style: safe on the pinned
+    // x86-64 target (TSO) with the opaque call boundaries as compiler
+    // barriers, not portable to weaker memory models.
     comm->control->op_status = 0;
 
     int ret = 0;

--- a/third_party/gpu-cr/coordinator/multi_cr_client.cpp
+++ b/third_party/gpu-cr/coordinator/multi_cr_client.cpp
@@ -180,7 +180,32 @@ static void* open_worker_shm(int cr_id) {
         return nullptr;
     }
 
-    void* ptr = mmap(nullptr, SHM_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+    // The worker ftruncate'd this file to its real (env-sized) buffer, so
+    // fstat's st_size is the authoritative extent — never OUR SHM_SIZE,
+    // which may disagree across pods or rolling restarts. Refuse a file
+    // smaller than the header window here rather than SIGBUS on first
+    // access to a torn or foreign file.
+    struct stat st;
+    if (fstat(fd, &st) != 0) {
+        fprintf(stderr, "[SHM] ERROR: fstat(%s) failed: %s\n", shm_path, strerror(errno));
+        close(fd);
+        return nullptr;
+    }
+    if (st.st_size < (off_t)ROUND_UP_2MB(sizeof(shared_mem_fs))) {
+        fprintf(stderr, "[SHM] ERROR: %s is %lld bytes, smaller than the %zu-byte header window\n",
+                shm_path, (long long)st.st_size,
+                (size_t)ROUND_UP_2MB(sizeof(shared_mem_fs)));
+        close(fd);
+        return nullptr;
+    }
+
+    // Map only the header window: the IPC scratch blocks (get_my_block /
+    // get_peer_block) live inside ROUND_UP_2MB(sizeof(shared_mem_fs)), and
+    // mapping the worker's full buffer at OUR compile-time SHM_SIZE was the
+    // one real cross-binary size coupling — an env-sized
+    // worker file plus a larger mapping here reserves the whole range on
+    // hugetlbfs (ENOMEM on right-sized pools) or SIGBUSes past EOF.
+    void* ptr = mmap(nullptr, ROUND_UP_2MB(sizeof(shared_mem_fs)), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
     close(fd);
     if (ptr == MAP_FAILED) {
         fprintf(stderr, "[SHM] ERROR: mmap failed for %s: %s\n", shm_path, strerror(errno));
@@ -265,7 +290,7 @@ static void exchange_ipc_export_info() {
     // Cleanup: unmap the shm files we opened
     for (size_t i = 0; i < n; i++) {
         if (shm_ptrs[i]) {
-            munmap(shm_ptrs[i], SHM_SIZE);
+            munmap(shm_ptrs[i], ROUND_UP_2MB(sizeof(shared_mem_fs)));
         }
     }
 

--- a/third_party/gpu-cr/coordinator/selective_spec.h
+++ b/third_party/gpu-cr/coordinator/selective_spec.h
@@ -31,7 +31,9 @@ inline bool ParseFullUint64(const char* s, uint64_t* out) {
 // semantics belong to the .so and the agent above it. Returns false —
 // with a message on stderr — for an empty spec, an empty or malformed
 // region (missing colon, sign, junk before or after either number), a
-// zero size, or more than kMaxSelectiveRegions regions. req->num_regions
+// zero size, or kMaxSelectiveRegions-or-more regions (the bound is
+// exclusive: the dump writer refuses to fill the last extent-table slot,
+// so a request must stay below it — see common.h). req->num_regions
 // is only meaningful on success.
 inline bool ParseSelectiveRegions(const char* spec, SelectiveCrRequest* req) {
   req->num_regions = 0;
@@ -41,9 +43,9 @@ inline bool ParseSelectiveRegions(const char* spec, SelectiveCrRequest* req) {
   // ("a:1,,b:2", trailing comma), not silently collapse.
   char* rest = buf;
   for (char* token = strsep(&rest, ","); token; token = strsep(&rest, ",")) {
-    if (req->num_regions >= kMaxSelectiveRegions) {
+    if (req->num_regions >= kMaxSelectiveRegions - 1) {
       fprintf(stderr, "Error: too many selective regions (max %u)\n",
-              kMaxSelectiveRegions);
+              kMaxSelectiveRegions - 1);
       free(buf);
       return false;
     }

--- a/third_party/gpu-cr/coordinator/selective_spec.h
+++ b/third_party/gpu-cr/coordinator/selective_spec.h
@@ -5,6 +5,7 @@
 // Header-only and GPU-free so unit tests can exercise it directly.
 
 #include <ctype.h>
+#include <errno.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -16,13 +17,16 @@ namespace gpu_cr {
 
 // Parses one unsigned number occupying the WHOLE string: any strtoull
 // base-0 form (0x..., decimal), no sign, no leading space, no trailing
-// junk. The digit-lead check rejects "", "-1" (which strtoull would
-// silently negate to ULLONG_MAX), "+1" and " 1".
+// junk, no overflow. The digit-lead check rejects "", "-1" (which
+// strtoull would silently negate to ULLONG_MAX), "+1" and " 1"; the
+// ERANGE check rejects values past UINT64_MAX, which strtoull would
+// silently saturate to ULLONG_MAX.
 inline bool ParseFullUint64(const char* s, uint64_t* out) {
   if (!isdigit(static_cast<unsigned char>(s[0]))) return false;
   char* end = nullptr;
+  errno = 0;
   *out = strtoull(s, &end, 0);
-  return end != s && *end == '\0';
+  return errno != ERANGE && end != s && *end == '\0';
 }
 
 // Fills req->regions/num_regions from a comma-separated "ptr:size" list.

--- a/third_party/gpu-cr/coordinator/selective_spec.h
+++ b/third_party/gpu-cr/coordinator/selective_spec.h
@@ -1,0 +1,82 @@
+#ifndef GPU_CR_COORDINATOR_SELECTIVE_SPEC_H_
+#define GPU_CR_COORDINATOR_SELECTIVE_SPEC_H_
+
+// Parser for the cr_client "-s ptr:size,ptr:size,..." region spec.
+// Header-only and GPU-free so unit tests can exercise it directly.
+
+#include <ctype.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "common.h"
+
+namespace gpu_cr {
+
+// Parses one unsigned number occupying the WHOLE string: any strtoull
+// base-0 form (0x..., decimal), no sign, no leading space, no trailing
+// junk. The digit-lead check rejects "", "-1" (which strtoull would
+// silently negate to ULLONG_MAX), "+1" and " 1".
+inline bool ParseFullUint64(const char* s, uint64_t* out) {
+  if (!isdigit(static_cast<unsigned char>(s[0]))) return false;
+  char* end = nullptr;
+  *out = strtoull(s, &end, 0);
+  return end != s && *end == '\0';
+}
+
+// Fills req->regions/num_regions from a comma-separated "ptr:size" list.
+// Pointers and sizes accept any strtoull base-0 form (0x..., decimal).
+// Syntax only: duplicate or overlapping regions pass through — their
+// semantics belong to the .so and the agent above it. Returns false —
+// with a message on stderr — for an empty spec, an empty or malformed
+// region (missing colon, sign, junk before or after either number), a
+// zero size, or more than kMaxSelectiveRegions regions. req->num_regions
+// is only meaningful on success.
+inline bool ParseSelectiveRegions(const char* spec, SelectiveCrRequest* req) {
+  req->num_regions = 0;
+  char* buf = strdup(spec);
+  if (!buf) return false;
+  // strsep, not strtok_r: empty tokens must surface as malformed regions
+  // ("a:1,,b:2", trailing comma), not silently collapse.
+  char* rest = buf;
+  for (char* token = strsep(&rest, ","); token; token = strsep(&rest, ",")) {
+    if (req->num_regions >= kMaxSelectiveRegions) {
+      fprintf(stderr, "Error: too many selective regions (max %u)\n",
+              kMaxSelectiveRegions);
+      free(buf);
+      return false;
+    }
+    char* colon = strchr(token, ':');
+    if (!colon) {
+      fprintf(stderr, "Error: invalid region format '%s' (expected ptr:size)\n",
+              token);
+      free(buf);
+      return false;
+    }
+    *colon = '\0';
+    uint64_t ptr = 0;
+    uint64_t size = 0;
+    if (!ParseFullUint64(token, &ptr) || !ParseFullUint64(colon + 1, &size)) {
+      fprintf(stderr,
+              "Error: invalid region '%s:%s' (expected unsigned ptr:size)\n",
+              token, colon + 1);
+      free(buf);
+      return false;
+    }
+    if (size == 0) {
+      fprintf(stderr, "Error: region size is 0 for ptr %s\n", token);
+      free(buf);
+      return false;
+    }
+    req->regions[req->num_regions].ptr = reinterpret_cast<void*>(ptr);
+    req->regions[req->num_regions].size = size;
+    req->num_regions++;
+  }
+  free(buf);
+  return req->num_regions > 0;
+}
+
+}  // namespace gpu_cr
+
+#endif  // GPU_CR_COORDINATOR_SELECTIVE_SPEC_H_

--- a/third_party/gpu-cr/tests/README.md
+++ b/third_party/gpu-cr/tests/README.md
@@ -9,14 +9,17 @@ fails the build.
 
 ## What you need
 
-- **GPU-free tiers (unit + integration) — no GPU, no cloud, no
-  cluster.** Any Linux machine with
-  CMake and a C++ compiler works; GoogleTest downloads at configure time,
-  so network access is the only external dependency. Build only the
-  `gpu_cr_unit_tests` target — the default targets (vGPU.so, cr_client)
-  additionally need the CUDA toolkit. `docker build -f Dockerfile.build .`
-  runs the same suite hermetically if you'd rather not install a
-  toolchain.
+- **Unit tier — no GPU, no cloud, no cluster, no CUDA.** Any Linux
+  machine with CMake and a C++ compiler works; GoogleTest downloads at
+  configure time, so network access is the only external dependency.
+  Build only the `gpu_cr_unit_tests` target — the default targets
+  (vGPU.so, cr_client) additionally need the CUDA toolkit.
+- **Integration tier — no GPU or driver, but the CUDA toolkit to
+  compile.** The `cr_client_integration` ctest entry drives the real
+  `cr_client` binary, which includes `<cuda.h>` and links the CUDA
+  stubs, so a plain C++ box cannot build it. Nothing at run time touches
+  a GPU. `docker build -f Dockerfile.build .` runs both GPU-free tiers
+  hermetically if you'd rather not install the toolchain.
 - **Google Cloud Build is not required.** Every image is a plain
   `docker build`; `gcloud builds submit` flows are an optional
   convenience for building off your machine. The one exception as
@@ -116,8 +119,21 @@ reuses the production control-channel code (ShareMemComm, FINISH
 bookkeeping, dump validator). Covers the control-file flow,
 destination-path checkpoint/restore, torn-dump refusal, op_status
 propagation (including the "never freeze after a failed checkpoint" gate),
-timeouts, version skew, and the documented exit codes
-(0 OK / 1 usage / 2 op failed / 3 refused / 4 timeout).
+timeouts, not-ready refusals, and the documented exit codes
+(0 OK / 1 usage / 2 op failed / 3 refused pre-signal — not-ready gate or
+dead target / 4 timeout).
+
+Two contract points the suite pins, worth knowing when driving
+`cr_client` from the agent:
+
+- **Every op now carries a deadline** (`GPU_CR_OP_TIMEOUT_SEC`, default
+  120s) — including full-process ops, which historically waited forever.
+- **Exit 4 poisons the control channel.** The client's flock releases at
+  exit while the wedged in-process handler may still be mid-op, and the
+  next invocation rewrites the shared request words. After a timeout,
+  restart the workload (or prove the handler finished) before issuing
+  another op against that PID; a dest-path dump interrupted by a timeout
+  carries no commit marker and is refused on restore.
 
 ```sh
 ctest -R cr_client_integration --output-on-failure

--- a/third_party/gpu-cr/tests/README.md
+++ b/third_party/gpu-cr/tests/README.md
@@ -1,15 +1,16 @@
 # GPU-CR test suites
 
-Three tiers, from GPU-free unit tests to on-node performance regression.
+Four tiers, from GPU-free unit tests to on-node performance regression.
 Throughout, "upstream" means the original GPU-CR project this tree builds
 on — <https://github.com/gpu-os/GPU-CR/tree/main> — pinned at commit
-`e9bbb52`. The unit tier runs automatically inside every
+`e9bbb52`. The first two tiers run automatically inside every
 `Dockerfile.build` image build (`RUN_TESTS=1`, the default) — a red suite
 fails the build.
 
 ## What you need
 
-- **Unit tier — no GPU, no cloud, no cluster.** Any Linux machine with
+- **GPU-free tiers (unit + integration) — no GPU, no cloud, no
+  cluster.** Any Linux machine with
   CMake and a C++ compiler works; GoogleTest downloads at configure time,
   so network access is the only external dependency. Build only the
   `gpu_cr_unit_tests` target — the default targets (vGPU.so, cr_client)
@@ -88,32 +89,52 @@ and rebuild — registration is automatic. A brand-new test file must also
 be added to the `gpu_cr_unit_tests` source list in the top-level
 `CMakeLists.txt`, or it will not be compiled in.
 
-The two GPU tiers below are plain bash scripts, not GoogleTest: each
-prints a `PASS`/`FAIL` line per gate and exits nonzero if any gate
-failed.
+The remaining tiers are bash scripts, not GoogleTest: each prints a
+`PASS`/`FAIL` line per scenario or gate and exits nonzero if anything
+failed. The integration script is registered with ctest too, so it
+reports through the same `ctest` front end as the unit tier.
 
 ## 1. Unit tests — `tests/unit/` (GoogleTest, no GPU, Linux)
 
-Function-level coverage of the upstream-baseline functions: the
-2MB rounding macro, signal numbers and wire structs
-(`common_baseline_test`), the ShareMemComm control channel
-(`share_mem_comm_test`), the ShareMem dump/staging buffer mapping via the
-file backend (`mmap_backend_test`), and the UDS SCM_RIGHTS fd exchange
-(`ipc_fd_exchange_test`). `createGPU()` and the CUDA/HIP hook layers need
-a driver link, so they stay covered by the e2e tier.
+Function-level coverage of two layers:
 
-## 2. End-to-end — `tests/e2e/run_e2e.sh` (GPU node)
+- **Code added on top of upstream**: dump-format validation, consume-once
+  FINISH bookkeeping, region-spec parsing, and wire-layout guards.
+- **The upstream-baseline functions themselves**: the 2MB rounding macro,
+  signal numbers and wire structs (`common_baseline_test`), the
+  ShareMemComm control channel (`share_mem_comm_test`), the ShareMem
+  dump/staging buffer mapping via the file backend (`mmap_backend_test`),
+  and the UDS SCM_RIGHTS fd exchange (`ipc_fd_exchange_test`).
+  `createGPU()` and the CUDA/HIP hook layers need a driver link, so they
+  stay covered by the integration and e2e tiers.
+
+## 2. Integration tests — `tests/integration/` (no GPU, Linux)
+
+`cr_client_integration_test.sh` drives the **real `cr_client` binary**
+against `fake_workload`, a GPU-free stand-in for the vGPU.so side that
+reuses the production control-channel code (ShareMemComm, FINISH
+bookkeeping, dump validator). Covers the control-file flow,
+destination-path checkpoint/restore, torn-dump refusal, op_status
+propagation (including the "never freeze after a failed checkpoint" gate),
+timeouts, version skew, and the documented exit codes
+(0 OK / 1 usage / 2 op failed / 3 refused / 4 timeout).
+
+```sh
+ctest -R cr_client_integration --output-on-failure
+```
+
+## 3. End-to-end — `tests/e2e/run_e2e.sh` (GPU node)
 
 A real CUDA workload (`pattern_workload`) under `LD_PRELOAD=vGPU-NVIDIA.so`
 goes through full checkpoint/restore, gating on **byte-identical GPU memory
 after every restore**.
 
-## 3. Performance regression — `tests/e2e/perf_regression.sh` (GPU node)
+## 4. Performance regression — `tests/e2e/perf_regression.sh` (GPU node)
 
-Verifies a build has not regressed the full checkpoint/restore data plane
-that upstream (`e9bbb52`) delivers: same workload, same node,
-baseline .so vs candidate .so, median-of-N compared against a threshold
-(default 15%).
+Verifies the consolidated build has not regressed the full checkpoint/
+restore data plane that upstream (`e9bbb52`) delivers: same workload,
+same node, baseline .so vs candidate .so, median-of-N compared against a
+threshold (default 15%).
 
 Build the baseline once with `tests/e2e/build_baseline_so.sh` (run from
 a checkout containing the pinned upstream commit — a vendored copy of

--- a/third_party/gpu-cr/tests/README.md
+++ b/third_party/gpu-cr/tests/README.md
@@ -139,6 +139,9 @@ Two contract points the suite pins, worth knowing when driving
 ctest -R cr_client_integration --output-on-failure
 ```
 
+The full per-case matrix (setup, invocation, expected exit) lives in
+[`tests/integration/README.md`](integration/README.md).
+
 ## 3. End-to-end — `tests/e2e/run_e2e.sh` (GPU node)
 
 A real CUDA workload (`pattern_workload`) under `LD_PRELOAD=vGPU-NVIDIA.so`

--- a/third_party/gpu-cr/tests/integration/README.md
+++ b/third_party/gpu-cr/tests/integration/README.md
@@ -1,0 +1,71 @@
+# Integration test matrix — `tests/integration/`
+
+GPU-free integration tier: each harness drives a **real production
+binary** against a fake for the side it talks to, on any Linux machine
+with the CUDA toolkit installed (no GPU or driver at run time — see
+"What you need" in [`../README.md`](../README.md)). Every harness is
+registered with ctest, so the whole tier runs as:
+
+```sh
+ctest -R integration --output-on-failure
+```
+
+Each harness gets its own subheader below; when a new integration test
+lands, add its case table here under a new subheader.
+
+## cr_client
+
+`cr_client_integration_test.sh` drives the real `cr_client` binary
+against `fake_workload`, which reuses the production control-channel
+code (ShareMemComm, FINISH bookkeeping, `ValidateDumpFd`) and fakes only
+the GPU work (pattern bytes for VRAM). The `cuda-checkpoint` binary is a
+stub that records having been invoked, so freeze/thaw behavior is
+observable without a driver. Exit-code contract asserted throughout:
+0 OK / 1 usage / 2 op failed / 3 refused pre-signal / 4 timeout.
+
+`fake_workload` knobs used by the cases below:
+
+| Env | Fake behavior |
+|---|---|
+| `FAKE_OP_STATUS=<errno>` | Handler reports the op failed with that status |
+| `FAKE_NO_FINISH=1` | Handler never signals FINISH (wedged workload) |
+| `FAKE_SKIP_COMMIT=1` | Dest dump written without the trailing commit marker (torn write) |
+| `FAKE_NOT_READY=1` | `.so` never publishes `selective_ready` |
+
+Test cases (in script order):
+
+| Group | Test case | Setup | `cr_client` invocation | Expected |
+|---|---|---|---|---|
+| Happy path | init | — | `-i` | 0 |
+| Happy path | dest-path selective ckpt | — | `-c -s <regions> -o <path>` | 0; dump file created |
+| Happy path | dest-path selective restore | — | `-r -s <regions> -o <path>` | 0 |
+| Happy path | buffer selective ckpt | — | `-c -s <regions>` | 0 |
+| Happy path | full ckpt | — | `-c` | 0 |
+| Happy path | full restore | — | `-r` | 0; toggle stub invoked |
+| Buffer-only | full ckpt `-b` never toggles | — | `-c -b` | 0; toggle NOT invoked |
+| Buffer-only | full restore `-b` never toggles | — | `-r -b` | 0; toggle NOT invoked |
+| Torn dump | ckpt fails post-op validation | `FAKE_SKIP_COMMIT=1` | `-c -s -o` | 2 |
+| Torn dump | restore refuses a marker-less file | 100-byte junk file at `-o` | `-r -s -o` | 2 |
+| op_status | selective ckpt surfaces handler failure | `FAKE_OP_STATUS=28` | `-c -s -o` | 2 |
+| op_status | full ckpt fails cleanly, never freezes | `FAKE_OP_STATUS=28` | `-c` | 2; toggle NOT invoked |
+| op_status | full restore fails after thaw | `FAKE_OP_STATUS=28` | `-r` | 2; toggle invoked (thaw precedes outcome — upstream ordering) |
+| Recycled dest | precreate truncates a reused path | 2-region dump, then 1-region dump to the same path | `-c -s -o` twice | both 0; file shrinks (`O_TRUNC` pins the torn-write false-validate fix) |
+| Timeout | wedged workload fails the op | `FAKE_NO_FINISH=1`, 2s deadline | `-c -s` | 4 |
+| Timeout | dest-path timeout leaves an uncommitted artifact | `FAKE_NO_FINISH=1 FAKE_SKIP_COMMIT=1`, 2s deadline | `-c -s -o` | 4; precreated dest survives, no marker |
+| Timeout | restore refuses the timeout artifact | fresh fake | `-r -s -o <artifact>` | 2 |
+| Not ready | dest-path ckpt refused pre-signal | `FAKE_NOT_READY=1` | `-c -s -o` | 3 |
+| Not ready | buffer ckpt refused pre-signal | `FAKE_NOT_READY=1` | `-c -s` | 3 |
+| Not ready | dest-path restore refused pre-signal (the gate's worst case: stale-buffer replay) | `FAKE_NOT_READY=1` | `-r -s -o` | 3 |
+| Not ready | buffer restore refused pre-signal | `FAKE_NOT_READY=1` | `-r -s` | 3 |
+| Not ready | full ckpt keeps historical tolerance | `FAKE_NOT_READY=1` | `-c` | 0 |
+| Usage | `-o` without `-s` | no fake needed | `-c -o -p 1` | 1 |
+| Usage | `-s` without `-c`/`-r` | no fake needed | `-i -s -p 1` | 1 |
+| Usage | `-o` path over the 256-byte max | no fake needed | 300-char `-o` | 1 |
+| Usage | malformed `-s` fails at parse | armed fake (parse sits after the ready-gate) | `-c -s bogus` | 1 |
+| Usage | restore from a missing file | — | `-r -s -o <nonexistent>` | 2 |
+| Dest hardening | relative `-o` refused | — | `-o rel/dump.bin` | 2 |
+| Dest hardening | symlink dest refused | `ln -s /etc/hostname <path>` | `-c -s -o <path>` | 2 (ELOOP via `O_NOFOLLOW`) |
+
+File-existence assertions (`dump created`, toggle-marker checks, the
+timeout artifact) count as separate pass/fail lines in the script's
+summary, so the printed total exceeds the row count above.

--- a/third_party/gpu-cr/tests/integration/README.md
+++ b/third_party/gpu-cr/tests/integration/README.md
@@ -38,6 +38,7 @@ Test cases (in script order):
 |---|---|---|---|---|
 | Happy path | init | — | `-i` | 0 |
 | Happy path | dest-path selective ckpt | — | `-c -s <regions> -o <path>` | 0; dump file created |
+| Happy path | precreated dest handed to the target | — | `-c -s -o` | dump owned by the target's uid, mode 0600 (the .so writes it; root-owned would EACCES a non-root workload) |
 | Happy path | dest-path selective restore | — | `-r -s <regions> -o <path>` | 0 |
 | Happy path | buffer selective ckpt | — | `-c -s <regions>` | 0 |
 | Happy path | full ckpt | — | `-c` | 0 |

--- a/third_party/gpu-cr/tests/integration/cr_client_integration_test.sh
+++ b/third_party/gpu-cr/tests/integration/cr_client_integration_test.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# Integration tests for cr_client against the GPU-free fake workload.
+#
+# Exercises the real control-channel protocol end to end on Linux without
+# a GPU: destination-path checkpoint/restore, dump validation, op_status
+# propagation (including the cuda-checkpoint toggle gate), timeouts, and
+# version-skew refusals. Asserts the documented exit codes: 0 OK,
+# 1 usage, 2 op failed, 3 refused, 4 timeout.
+#
+# Usage: cr_client_integration_test.sh <cr_client> <fake_workload>
+set -u
+
+CR_CLIENT=$(readlink -f "$1")
+FAKE=$(readlink -f "$2")
+
+WORK=$(mktemp -d /tmp/gpu-cr-it-data.XXXXXX)
+STUB_DIR=$(mktemp -d /tmp/gpu-cr-it-stub.XXXXXX)
+TOGGLE_MARKER="$STUB_DIR/toggled"
+cat > "$STUB_DIR/cuda-checkpoint" <<EOF
+#!/bin/sh
+touch "$TOGGLE_MARKER"
+exit 0
+EOF
+chmod +x "$STUB_DIR/cuda-checkpoint"
+export PATH="$STUB_DIR:$PATH"
+export GPU_CR_CUDA_CHECKPOINT="$STUB_DIR/cuda-checkpoint"
+export GPU_CR_OP_TIMEOUT_SEC=10
+
+FAKE_PID=""
+PASS=0
+FAIL=0
+
+cleanup() {
+    stop_fake
+    rm -rf "$WORK" "$STUB_DIR"
+}
+trap cleanup EXIT
+
+# start_fake [ENV=VAL ...] — starts fake_workload with the given extra env
+# and waits for its control channel to come up.
+start_fake() {
+    stop_fake
+    local ready="$WORK/ready.$$"
+    rm -f "$ready"
+    env "$@" FAKE_READY_FILE="$ready" FAKE_LOG="$WORK/fake.log" \
+        "$FAKE" 2>> "$WORK/fake.stderr" &
+    FAKE_PID=$!
+    for _ in $(seq 1 100); do
+        [ -f "$ready" ] && return 0
+        sleep 0.1
+    done
+    echo "FATAL: fake workload did not come up" >&2
+    exit 1
+}
+
+stop_fake() {
+    if [ -n "$FAKE_PID" ]; then
+        kill "$FAKE_PID" 2>/dev/null
+        wait "$FAKE_PID" 2>/dev/null
+        FAKE_PID=""
+    fi
+    rm -f "$WORK"/control* "$WORK"/dump* "$WORK"/fake.log \
+          "$TOGGLE_MARKER" 2>/dev/null
+    return 0
+}
+
+# check <name> <expected_exit> <cmd...>
+check() {
+    local name=$1 expected=$2
+    shift 2
+    "$@" > "$WORK/out.log" 2>&1
+    local got=$?
+    if [ "$got" -eq "$expected" ]; then
+        echo "ok:   $name"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $name (exit $got, expected $expected)"
+        sed 's/^/      | /' "$WORK/out.log" | tail -15
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+expect_file() {
+    if [ -e "$2" ]; then echo "ok:   $1"; PASS=$((PASS + 1));
+    else echo "FAIL: $1 (missing $2)"; FAIL=$((FAIL + 1)); fi
+}
+
+expect_no_file() {
+    if [ ! -e "$2" ]; then echo "ok:   $1"; PASS=$((PASS + 1));
+    else echo "FAIL: $1 (unexpected $2)"; FAIL=$((FAIL + 1)); fi
+}
+
+ENV="EXPORT_FILE_PATH=$WORK"
+REGIONS="0x7f0000000000:4096,0x7f0000100000:8192"
+
+# --- happy paths -------------------------------------------------------------
+start_fake $ENV
+check "init"                    0 env $ENV "$CR_CLIENT" -i -p "$FAKE_PID"
+check "dest-path selective ckpt" 0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+expect_file "dump created" "$WORK/dump.bin"
+check "dest-path selective restore" 0 env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+check "buffer selective ckpt"   0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+check "full ckpt"               0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID"
+check "full restore (stub toggle)" 0 env $ENV "$CR_CLIENT" -r -p "$FAKE_PID"
+expect_file "cuda-checkpoint toggled on success" "$TOGGLE_MARKER"
+
+# --- -b (buffer-only) never touches cuda-checkpoint --------------------------
+start_fake $ENV
+check "full ckpt -b"            0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -b
+expect_no_file "-b ckpt did not toggle" "$TOGGLE_MARKER"
+check "full restore -b"         0 env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -b
+expect_no_file "-b restore did not toggle" "$TOGGLE_MARKER"
+
+# --- torn dump is refused post-checkpoint ----------------------------------
+start_fake $ENV FAKE_SKIP_COMMIT=1
+check "torn dump: ckpt fails validation" 2 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+
+# --- restore refuses a torn dump (fake mirrors .so via ValidateDumpFd) -----
+start_fake $ENV
+head -c 100 /dev/zero > "$WORK/torn.bin"
+check "torn dump: restore refused"   2 env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/torn.bin"
+
+# --- op_status propagation --------------------------------------------------
+start_fake $ENV FAKE_OP_STATUS=28    # ENOSPC
+check "op_status: selective ckpt surfaces failure" 2 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+check "op_status: full ckpt fails cleanly" 2 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID"
+expect_no_file "op_status: NOT frozen after a failed ckpt" "$TOGGLE_MARKER"
+# Restore thaws before the op outcome is known (upstream ordering: the
+# in-process handler needs a live CUDA context), so a failed restore
+# still exits 2 but the toggle has already run.
+check "op_status: full restore fails cleanly" 2 env $ENV "$CR_CLIENT" -r -p "$FAKE_PID"
+expect_file "op_status: restore thawed before the failed op" "$TOGGLE_MARKER"
+
+# --- timeout ----------------------------------------------------------------
+start_fake $ENV FAKE_NO_FINISH=1
+check "timeout: wedged workload fails the op" 4 \
+    env $ENV GPU_CR_OP_TIMEOUT_SEC=2 "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+
+# --- version skew: v1 .so ----------------------------------------------------
+start_fake $ENV FAKE_V1=1
+check "skew: v1 .so + dest-path -> refused pre-signal" 3 \
+    env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+check "skew: v1 .so + buffer op keeps historical behavior" 0 \
+    env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+
+# --- usage errors ------------------------------------------------------------
+check "usage: -o without -s"          1 env $ENV "$CR_CLIENT" -c -o "$WORK/dump.bin" -p 1
+start_fake $ENV
+check "usage: restore from missing file" 2 \
+    env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/nonexistent.bin"
+
+echo
+echo "cr_client integration: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/third_party/gpu-cr/tests/integration/cr_client_integration_test.sh
+++ b/third_party/gpu-cr/tests/integration/cr_client_integration_test.sh
@@ -4,7 +4,7 @@
 # Exercises the real control-channel protocol end to end on Linux without
 # a GPU: destination-path checkpoint/restore, dump validation, op_status
 # propagation (including the cuda-checkpoint toggle gate), timeouts, and
-# version-skew refusals. Asserts the documented exit codes: 0 OK,
+# not-ready refusals. Asserts the documented exit codes: 0 OK,
 # 1 usage, 2 op failed, 3 refused, 4 timeout.
 #
 # Usage: cr_client_integration_test.sh <cr_client> <fake_workload>
@@ -136,12 +136,16 @@ start_fake $ENV FAKE_NO_FINISH=1
 check "timeout: wedged workload fails the op" 4 \
     env $ENV GPU_CR_OP_TIMEOUT_SEC=2 "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
 
-# --- version skew: v1 .so ----------------------------------------------------
-start_fake $ENV FAKE_V1=1
-check "skew: v1 .so + dest-path -> refused pre-signal" 3 \
+# --- not-ready .so: selective ops refused pre-signal -------------------------
+start_fake $ENV FAKE_NOT_READY=1
+check "not-ready .so: dest-path op refused pre-signal" 3 \
     env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
-check "skew: v1 .so + buffer op keeps historical behavior" 0 \
+check "not-ready .so: buffer selective op refused pre-signal" 3 \
     env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+# Full-process ops stay ungated: a silent .so (no op_status) keeps
+# historical tolerance.
+check "not-ready .so: full ckpt keeps historical behavior" 0 \
+    env $ENV "$CR_CLIENT" -c -p "$FAKE_PID"
 
 # --- usage errors ------------------------------------------------------------
 check "usage: -o without -s"          1 env $ENV "$CR_CLIENT" -c -o "$WORK/dump.bin" -p 1

--- a/third_party/gpu-cr/tests/integration/cr_client_integration_test.sh
+++ b/third_party/gpu-cr/tests/integration/cr_client_integration_test.sh
@@ -131,10 +131,37 @@ expect_no_file "op_status: NOT frozen after a failed ckpt" "$TOGGLE_MARKER"
 check "op_status: full restore fails cleanly" 2 env $ENV "$CR_CLIENT" -r -p "$FAKE_PID"
 expect_file "op_status: restore thawed before the failed op" "$TOGGLE_MARKER"
 
+# --- recycled destination is truncated at precreate --------------------------
+# A dest path holding an older, larger dump must not contribute stale bytes
+# to the new file: after a smaller dump to the same path, the file must
+# shrink (O_TRUNC), or a torn write could false-validate against leftover
+# marker bytes.
+start_fake $ENV
+check "recycle setup: 2-region dump"  0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/recycle.bin"
+big_size=$(stat -c %s "$WORK/recycle.bin")
+check "recycled dest: smaller dump"   0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "0x7f0000000000:4096" -o "$WORK/recycle.bin"
+small_size=$(stat -c %s "$WORK/recycle.bin")
+if [ "$small_size" -lt "$big_size" ]; then
+    echo "ok:   recycled dest truncated ($big_size -> $small_size bytes)"; PASS=$((PASS + 1))
+else
+    echo "FAIL: recycled dest not truncated ($big_size -> $small_size bytes)"; FAIL=$((FAIL + 1))
+fi
+
 # --- timeout ----------------------------------------------------------------
 start_fake $ENV FAKE_NO_FINISH=1
 check "timeout: wedged workload fails the op" 4 \
     env $ENV GPU_CR_OP_TIMEOUT_SEC=2 "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+
+# --- timeout leaves an uncommitted dest artifact ------------------------------
+# Pins the exit-4 on-disk contract: the precreated dest survives, carries no
+# commit marker, and a later restore must refuse it.
+start_fake $ENV FAKE_NO_FINISH=1 FAKE_SKIP_COMMIT=1
+check "timeout: dest-path ckpt fails" 4 \
+    env $ENV GPU_CR_OP_TIMEOUT_SEC=2 "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/t4.bin"
+expect_file "timeout leaves the precreated dest" "$WORK/t4.bin"
+start_fake $ENV
+check "timeout artifact: restore refuses the unmarked dump" 2 \
+    env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/t4.bin"
 
 # --- not-ready .so: selective ops refused pre-signal -------------------------
 start_fake $ENV FAKE_NOT_READY=1
@@ -142,6 +169,12 @@ check "not-ready .so: dest-path op refused pre-signal" 3 \
     env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
 check "not-ready .so: buffer selective op refused pre-signal" 3 \
     env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+# The gate's worst case: a dest-path restore served from the stale per-PID
+# buffer would replay old bytes into GPU memory — must refuse pre-signal.
+check "not-ready .so: dest-path restore refused pre-signal" 3 \
+    env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+check "not-ready .so: buffer selective restore refused pre-signal" 3 \
+    env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS"
 # Full-process ops stay ungated: a silent .so (no op_status) keeps
 # historical tolerance.
 check "not-ready .so: full ckpt keeps historical behavior" 0 \
@@ -149,9 +182,21 @@ check "not-ready .so: full ckpt keeps historical behavior" 0 \
 
 # --- usage errors ------------------------------------------------------------
 check "usage: -o without -s"          1 env $ENV "$CR_CLIENT" -c -o "$WORK/dump.bin" -p 1
+check "usage: -s without -c or -r"    1 env $ENV "$CR_CLIENT" -i -p 1 -s "$REGIONS"
+check "usage: -o path too long"       1 env $ENV "$CR_CLIENT" -c -p 1 -s "$REGIONS" \
+    -o "/$(printf 'a%.0s' $(seq 1 300))"
 start_fake $ENV
+check "usage: malformed -s fails at parse" 1 \
+    env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "bogus"
 check "usage: restore from missing file" 2 \
     env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/nonexistent.bin"
+
+# --- destination hardening ----------------------------------------------------
+check "dest: relative -o refused" 2 \
+    env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "rel/dump.bin"
+ln -s /etc/hostname "$WORK/link.bin"
+check "dest: symlink dest refused (ELOOP)" 2 \
+    env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/link.bin"
 
 echo
 echo "cr_client integration: $PASS passed, $FAIL failed"

--- a/third_party/gpu-cr/tests/integration/cr_client_integration_test.sh
+++ b/third_party/gpu-cr/tests/integration/cr_client_integration_test.sh
@@ -98,6 +98,19 @@ start_fake $ENV
 check "init"                    0 env $ENV "$CR_CLIENT" -i -p "$FAKE_PID"
 check "dest-path selective ckpt" 0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
 expect_file "dump created" "$WORK/dump.bin"
+# The target writes the dump (the .so opens dest_path O_RDWR, no O_CREAT),
+# and cr_client may run as root while the target does not: the precreate
+# must hand the inode to the target's owner and pin mode 0600. Without the
+# explicit fchmod a default umask would leave 644, so the mode assertion
+# alone pins the handoff.
+dump_owner=$(stat -c %u "$WORK/dump.bin")
+target_owner=$(stat -c %u "/proc/$FAKE_PID")
+dump_mode=$(stat -c %a "$WORK/dump.bin")
+if [ "$dump_owner" = "$target_owner" ] && [ "$dump_mode" = "600" ]; then
+    echo "ok:   precreated dest handed to the target (uid $dump_owner, mode $dump_mode)"; PASS=$((PASS + 1))
+else
+    echo "FAIL: precreated dest owner/mode (uid $dump_owner vs target $target_owner, mode $dump_mode)"; FAIL=$((FAIL + 1))
+fi
 check "dest-path selective restore" 0 env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
 check "buffer selective ckpt"   0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
 check "full ckpt"               0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID"

--- a/third_party/gpu-cr/tests/integration/fake_workload.cpp
+++ b/third_party/gpu-cr/tests/integration/fake_workload.cpp
@@ -7,8 +7,9 @@
 //   FAKE_OP_STATUS   errno-style status to report at FINISH (default 0)
 //   FAKE_SKIP_COMMIT write destination dumps WITHOUT the commit marker
 //   FAKE_NO_FINISH   never send FINISH (drives the cr_client timeout path)
-//   FAKE_V1          behave like a v1-only .so: no capability, no
-//                    proto_ack/op_status, no consume-once, no dest-path
+//   FAKE_NOT_READY   behave like a .so that never armed selective
+//                    support: no selective_ready, no op_status, no
+//                    consume-once, no dest-path
 //   FAKE_READY_FILE  file created once the control channel is up
 //   FAKE_LOG         per-op log: "op=<msg> dest=<path-or-empty>" lines
 
@@ -27,7 +28,7 @@
 namespace {
 
 ShareMemComm* g_comm = nullptr;
-bool g_v1 = false;
+bool g_not_ready = false;
 int g_fake_status = 0;
 
 void LogOp(uint32_t msg, const char* dest) {
@@ -79,17 +80,15 @@ bool WriteFakeDump(const SelectiveCrRequest* req, const char* dest_path) {
 }
 
 void Finish(int op_status) {
-  if (!g_v1) gpu_cr::FinishOpControls(g_comm->control, op_status);
+  if (!g_not_ready) gpu_cr::FinishOpControls(g_comm->control, op_status);
   if (!getenv("FAKE_NO_FINISH")) g_comm->send_msg(FINISH_MSG);
 }
 
 void SignalHandler(int signum) {
   uint32_t msg = g_comm->recv_msg();
   const SelectiveCrRequest* req = &g_comm->control->selective_req;
-  const char* dest = (!g_v1 && req->proto_version >= gpu_cr::kSelectiveCrProtoV2 &&
-                      req->dest_path[0] != '\0')
-                         ? req->dest_path
-                         : nullptr;
+  const char* dest =
+      (!g_not_ready && req->dest_path[0] != '\0') ? req->dest_path : nullptr;
   fprintf(stderr, "[fake-workload] signal %d msg %u dest %s\n", signum, msg,
           dest ? dest : "(buffer)");
   LogOp(msg, dest);
@@ -97,7 +96,7 @@ void SignalHandler(int signum) {
   int status = g_fake_status;
   switch (msg) {
     case INIT_MSG:
-      if (!g_v1) g_comm->control->capability |= gpu_cr::kCrCapDestPath;
+      if (!g_not_ready) g_comm->control->selective_ready = gpu_cr::kSelectiveReady;
       if (!getenv("FAKE_NO_FINISH")) g_comm->send_msg(FINISH_MSG);
       return;  // real init path predates op_status reporting
     case SELECTIVE_CKPT_MSG:
@@ -125,13 +124,13 @@ void SignalHandler(int signum) {
 }  // namespace
 
 int main() {
-  g_v1 = getenv("FAKE_V1") != nullptr;
+  g_not_ready = getenv("FAKE_NOT_READY") != nullptr;
   const char* st = getenv("FAKE_OP_STATUS");
   if (st) g_fake_status = atoi(st);
 
   g_comm = new ShareMemComm(getpid());
   g_comm->setup();
-  if (!g_v1) g_comm->control->capability |= gpu_cr::kCrCapDestPath;
+  if (!g_not_ready) g_comm->control->selective_ready = gpu_cr::kSelectiveReady;
 
   signal(CR_INIT_SIGNAL, SignalHandler);
   signal(CR_CKPT_SIGNAL, SignalHandler);
@@ -146,7 +145,7 @@ int main() {
     }
   }
 
-  fprintf(stderr, "[fake-workload] ready, pid=%d v1=%d\n",
-          getpid(), g_v1 ? 1 : 0);
+  fprintf(stderr, "[fake-workload] ready, pid=%d not_ready=%d\n",
+          getpid(), g_not_ready ? 1 : 0);
   for (;;) pause();
 }

--- a/third_party/gpu-cr/tests/integration/fake_workload.cpp
+++ b/third_party/gpu-cr/tests/integration/fake_workload.cpp
@@ -1,0 +1,152 @@
+// GPU-free stand-in for the vGPU.so side of the control channel, used by
+// the cr_client integration tests. It reuses the REAL product pieces —
+// ShareMemComm, FinishOpControls, ValidateDumpFd — and fakes only the
+// GPU work (dump extents are pattern bytes instead of VRAM).
+//
+// Behavior knobs (env):
+//   FAKE_OP_STATUS   errno-style status to report at FINISH (default 0)
+//   FAKE_SKIP_COMMIT write destination dumps WITHOUT the commit marker
+//   FAKE_NO_FINISH   never send FINISH (drives the cr_client timeout path)
+//   FAKE_V1          behave like a v1-only .so: no capability, no
+//                    proto_ack/op_status, no consume-once, no dest-path
+//   FAKE_READY_FILE  file created once the control channel is up
+//   FAKE_LOG         per-op log: "op=<msg> dest=<path-or-empty>" lines
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "dump_format.h"
+#include "comm/comm.h"
+
+namespace {
+
+ShareMemComm* g_comm = nullptr;
+bool g_v1 = false;
+int g_fake_status = 0;
+
+void LogOp(uint32_t msg, const char* dest) {
+  const char* log = getenv("FAKE_LOG");
+  if (!log) return;
+  FILE* f = fopen(log, "a");
+  if (!f) return;
+  fprintf(f, "op=%u dest=%s\n", msg, dest ? dest : "");
+  fclose(f);
+}
+
+// Writes a valid destination dump for the requested regions: header, one
+// extent per region (pattern bytes), and the commit marker unless
+// FAKE_SKIP_COMMIT is set.
+bool WriteFakeDump(const SelectiveCrRequest* req, const char* dest_path) {
+  FILE* f = fopen(dest_path, "r+");
+  if (!f) {
+    fprintf(stderr, "[fake-workload] cannot open %s: %s\n", dest_path,
+            strerror(errno));
+    return false;
+  }
+  uint64_t header_size = ROUND_UP_2MB(sizeof(shared_mem_fs));
+  uint64_t current_offset = header_size;
+  uint64_t hdr[2];
+  hdr[0] = req->num_regions;
+  for (uint32_t i = 0; i < req->num_regions; i++)
+    current_offset += req->regions[i].size;
+  hdr[1] = current_offset;
+
+  fseek(f, 0, SEEK_SET);
+  fwrite(hdr, sizeof(hdr), 1, f);
+  uint64_t offset = header_size;
+  for (uint32_t i = 0; i < req->num_regions; i++) {
+    fseek(f, offset, SEEK_SET);
+    for (uint64_t b = 0; b < req->regions[i].size; b++) fputc(0xAB, f);
+    offset += req->regions[i].size;
+  }
+  if (!getenv("FAKE_SKIP_COMMIT")) {
+    DumpCommit commit = {gpu_cr::kDumpCommitMagic, 1};
+    fseek(f, current_offset, SEEK_SET);
+    fwrite(&commit, sizeof(commit), 1, f);
+  } else {
+    // Still size the file past the marker so only the magic is missing.
+    fseek(f, current_offset + sizeof(DumpCommit) - 1, SEEK_SET);
+    fputc(0, f);
+  }
+  fclose(f);
+  return true;
+}
+
+void Finish(int op_status) {
+  if (!g_v1) gpu_cr::FinishOpControls(g_comm->control, op_status);
+  if (!getenv("FAKE_NO_FINISH")) g_comm->send_msg(FINISH_MSG);
+}
+
+void SignalHandler(int signum) {
+  uint32_t msg = g_comm->recv_msg();
+  const SelectiveCrRequest* req = &g_comm->control->selective_req;
+  const char* dest = (!g_v1 && req->proto_version >= gpu_cr::kSelectiveCrProtoV2 &&
+                      req->dest_path[0] != '\0')
+                         ? req->dest_path
+                         : nullptr;
+  fprintf(stderr, "[fake-workload] signal %d msg %u dest %s\n", signum, msg,
+          dest ? dest : "(buffer)");
+  LogOp(msg, dest);
+
+  int status = g_fake_status;
+  switch (msg) {
+    case INIT_MSG:
+      if (!g_v1) g_comm->control->capability |= gpu_cr::kCrCapDestPath;
+      if (!getenv("FAKE_NO_FINISH")) g_comm->send_msg(FINISH_MSG);
+      return;  // real init path predates op_status reporting
+    case SELECTIVE_CKPT_MSG:
+      if (dest && status == 0 && !WriteFakeDump(req, dest)) status = EIO;
+      break;
+    case SELECTIVE_RESTORE_MSG:
+      // Mimic the .so's pre-restore gate with the REAL validator.
+      if (dest && status == 0) {
+        int fd = open(dest, O_RDONLY);
+        if (fd < 0 || !gpu_cr::ValidateDumpFd(fd)) status = EINVAL;
+        if (fd >= 0) close(fd);
+      }
+      break;
+    case CKPT_MSG:
+    case RESTORE_MSG:
+      break;
+    default:
+      fprintf(stderr, "[fake-workload] unexpected msg %u\n", msg);
+      status = EPROTO;
+      break;
+  }
+  Finish(status);
+}
+
+}  // namespace
+
+int main() {
+  g_v1 = getenv("FAKE_V1") != nullptr;
+  const char* st = getenv("FAKE_OP_STATUS");
+  if (st) g_fake_status = atoi(st);
+
+  g_comm = new ShareMemComm(getpid());
+  g_comm->setup();
+  if (!g_v1) g_comm->control->capability |= gpu_cr::kCrCapDestPath;
+
+  signal(CR_INIT_SIGNAL, SignalHandler);
+  signal(CR_CKPT_SIGNAL, SignalHandler);
+  signal(CR_RESTORE_SIGNAL, SignalHandler);
+
+  const char* ready = getenv("FAKE_READY_FILE");
+  if (ready) {
+    FILE* f = fopen(ready, "w");
+    if (f) {
+      fprintf(f, "%d\n", getpid());
+      fclose(f);
+    }
+  }
+
+  fprintf(stderr, "[fake-workload] ready, pid=%d v1=%d\n",
+          getpid(), g_v1 ? 1 : 0);
+  for (;;) pause();
+}

--- a/third_party/gpu-cr/tests/integration/fake_workload.cpp
+++ b/third_party/gpu-cr/tests/integration/fake_workload.cpp
@@ -66,13 +66,14 @@ bool WriteFakeDump(const SelectiveCrRequest* req, const char* dest_path) {
     for (uint64_t b = 0; b < req->regions[i].size; b++) fputc(0xAB, f);
     offset += req->regions[i].size;
   }
+  uint64_t marker = gpu_cr::DumpCommitOffset(current_offset);
   if (!getenv("FAKE_SKIP_COMMIT")) {
     DumpCommit commit = {gpu_cr::kDumpCommitMagic, 1};
-    fseek(f, current_offset, SEEK_SET);
+    fseek(f, marker, SEEK_SET);
     fwrite(&commit, sizeof(commit), 1, f);
   } else {
     // Still size the file past the marker so only the magic is missing.
-    fseek(f, current_offset + sizeof(DumpCommit) - 1, SEEK_SET);
+    fseek(f, marker + sizeof(DumpCommit) - 1, SEEK_SET);
     fputc(0, f);
   }
   fclose(f);

--- a/third_party/gpu-cr/tests/unit/common_baseline_test.cpp
+++ b/third_party/gpu-cr/tests/unit/common_baseline_test.cpp
@@ -9,6 +9,7 @@
 #include <set>
 
 #include "gtest/gtest.h"
+#include "ipc_hooks.h"
 
 namespace gpu_cr {
 namespace {
@@ -54,6 +55,17 @@ TEST(SignalControlsLayoutTest, SignalWordIsFirst) {
 TEST(SharedMemFsTest, HeaderFitsWithinOneHugepageExtent) {
   EXPECT_EQ(ROUND_UP_2MB(sizeof(shared_mem_fs)),
             static_cast<size_t>(HUGE_PAGE_SIZE));
+}
+
+// multi_cr_client maps only ROUND_UP_2MB(sizeof(shared_mem_fs)) of each
+// worker buffer and places the two IPC scratch blocks at the tail of that
+// window (get_my_block/get_peer_block; the .so uses the same formula).
+// The blocks must fit in the round-up slack above the header, or an
+// IPC_MAX_EXPORTS_PER_PROC bump would silently overlap the header or
+// read past the coordinator's mapping.
+TEST(SharedMemFsTest, IpcScratchBlocksFitInHeaderWindowSlack) {
+  EXPECT_LE(sizeof(shared_mem_fs) + 2 * sizeof(IpcRebuildShmBlock),
+            ROUND_UP_2MB(sizeof(shared_mem_fs)));
 }
 
 // shared_mem_file / shared_mem_fs are the persisted dump-header layout,

--- a/third_party/gpu-cr/tests/unit/selective_spec_test.cpp
+++ b/third_party/gpu-cr/tests/unit/selective_spec_test.cpp
@@ -74,6 +74,23 @@ TEST(ParseSelectiveRegionsTest, RejectsNegativeSize) {
   EXPECT_FALSE(ParseSelectiveRegions("0x1000:-1", &req));
 }
 
+TEST(ParseSelectiveRegionsTest, RejectsOverflowingPtr) {
+  SelectiveCrRequest req;
+  // strtoull would saturate 2^65-ish to ULLONG_MAX (ERANGE) — the parser
+  // must reject, not hand the .so a region at 0xFFFFFFFFFFFFFFFF.
+  EXPECT_FALSE(ParseSelectiveRegions("0x1FFFFFFFFFFFFFFFF:4096", &req));
+}
+
+TEST(ParseSelectiveRegionsTest, RejectsOverflowingSize) {
+  SelectiveCrRequest req;
+  EXPECT_FALSE(ParseSelectiveRegions("0x1000:18446744073709551616", &req));
+}
+
+TEST(ParseSelectiveRegionsTest, RejectsEmptySize) {
+  SelectiveCrRequest req;
+  EXPECT_FALSE(ParseSelectiveRegions("0x1000:", &req));
+}
+
 // Syntax-only parser: duplicate regions pass through untouched —
 // dedup/overlap semantics belong to the .so and the agent above it.
 TEST(ParseSelectiveRegionsTest, AcceptsDuplicateRegions) {

--- a/third_party/gpu-cr/tests/unit/selective_spec_test.cpp
+++ b/third_party/gpu-cr/tests/unit/selective_spec_test.cpp
@@ -1,0 +1,109 @@
+// cr_client "-s ptr:size,..." region-spec parser.
+
+#include "selective_spec.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace gpu_cr {
+namespace {
+
+TEST(ParseSelectiveRegionsTest, SingleHexRegion) {
+  SelectiveCrRequest req;
+  ASSERT_TRUE(ParseSelectiveRegions("0x7f0000000000:4096", &req));
+  ASSERT_EQ(req.num_regions, 1u);
+  EXPECT_EQ(req.regions[0].ptr, reinterpret_cast<void*>(0x7f0000000000UL));
+  EXPECT_EQ(req.regions[0].size, 4096u);
+}
+
+TEST(ParseSelectiveRegionsTest, MultipleRegionsMixedBases) {
+  SelectiveCrRequest req;
+  ASSERT_TRUE(ParseSelectiveRegions("0x1000:0x2000,4096:65536", &req));
+  ASSERT_EQ(req.num_regions, 2u);
+  EXPECT_EQ(req.regions[0].ptr, reinterpret_cast<void*>(0x1000UL));
+  EXPECT_EQ(req.regions[0].size, 0x2000u);
+  EXPECT_EQ(req.regions[1].ptr, reinterpret_cast<void*>(4096UL));
+  EXPECT_EQ(req.regions[1].size, 65536u);
+}
+
+TEST(ParseSelectiveRegionsTest, RejectsEmptySpec) {
+  SelectiveCrRequest req;
+  EXPECT_FALSE(ParseSelectiveRegions("", &req));
+}
+
+TEST(ParseSelectiveRegionsTest, RejectsMissingColon) {
+  SelectiveCrRequest req;
+  EXPECT_FALSE(ParseSelectiveRegions("0x1000", &req));
+}
+
+TEST(ParseSelectiveRegionsTest, RejectsZeroSize) {
+  SelectiveCrRequest req;
+  EXPECT_FALSE(ParseSelectiveRegions("0x1000:0", &req));
+}
+
+TEST(ParseSelectiveRegionsTest, RejectsMalformedTrailingRegion) {
+  SelectiveCrRequest req;
+  EXPECT_FALSE(ParseSelectiveRegions("0x1000:4096,bogus", &req));
+}
+
+TEST(ParseSelectiveRegionsTest, RejectsGarbagePtr) {
+  SelectiveCrRequest req;
+  // strtoull would quietly parse "bogus" as 0 — the parser must not.
+  EXPECT_FALSE(ParseSelectiveRegions("bogus:4096", &req));
+}
+
+TEST(ParseSelectiveRegionsTest, RejectsTrailingJunkInSize) {
+  SelectiveCrRequest req;
+  EXPECT_FALSE(ParseSelectiveRegions("0x1000:12junk", &req));
+}
+
+TEST(ParseSelectiveRegionsTest, RejectsEmptyMiddleToken) {
+  SelectiveCrRequest req;
+  EXPECT_FALSE(ParseSelectiveRegions("0x1000:1,,0x2000:1", &req));
+}
+
+TEST(ParseSelectiveRegionsTest, RejectsTrailingComma) {
+  SelectiveCrRequest req;
+  EXPECT_FALSE(ParseSelectiveRegions("0x1000:1,", &req));
+}
+
+TEST(ParseSelectiveRegionsTest, RejectsNegativeSize) {
+  SelectiveCrRequest req;
+  // strtoull would negate "-1" to ULLONG_MAX — the parser must not.
+  EXPECT_FALSE(ParseSelectiveRegions("0x1000:-1", &req));
+}
+
+// Syntax-only parser: duplicate regions pass through untouched —
+// dedup/overlap semantics belong to the .so and the agent above it.
+TEST(ParseSelectiveRegionsTest, AcceptsDuplicateRegions) {
+  SelectiveCrRequest req;
+  ASSERT_TRUE(ParseSelectiveRegions("0x1000:4096,0x1000:4096", &req));
+  ASSERT_EQ(req.num_regions, 2u);
+  EXPECT_EQ(req.regions[0].ptr, req.regions[1].ptr);
+  EXPECT_EQ(req.regions[0].size, req.regions[1].size);
+}
+
+TEST(ParseSelectiveRegionsTest, AcceptsExactlyMaxRegions) {
+  std::string spec;
+  for (uint32_t i = 0; i < kMaxSelectiveRegions; i++) {
+    if (i) spec += ",";
+    spec += "0x1000:1";
+  }
+  SelectiveCrRequest req;
+  ASSERT_TRUE(ParseSelectiveRegions(spec.c_str(), &req));
+  EXPECT_EQ(req.num_regions, kMaxSelectiveRegions);
+}
+
+TEST(ParseSelectiveRegionsTest, RejectsOverMaxRegions) {
+  std::string spec;
+  for (uint32_t i = 0; i < kMaxSelectiveRegions + 1; i++) {
+    if (i) spec += ",";
+    spec += "0x1000:1";
+  }
+  SelectiveCrRequest req;
+  EXPECT_FALSE(ParseSelectiveRegions(spec.c_str(), &req));
+}
+
+}  // namespace
+}  // namespace gpu_cr

--- a/third_party/gpu-cr/tests/unit/selective_spec_test.cpp
+++ b/third_party/gpu-cr/tests/unit/selective_spec_test.cpp
@@ -84,20 +84,22 @@ TEST(ParseSelectiveRegionsTest, AcceptsDuplicateRegions) {
   EXPECT_EQ(req.regions[0].size, req.regions[1].size);
 }
 
-TEST(ParseSelectiveRegionsTest, AcceptsExactlyMaxRegions) {
+// The bound is exclusive: kMaxSelectiveRegions-1 is the largest request
+// the dump writer can serve without filling the last extent-table slot.
+TEST(ParseSelectiveRegionsTest, AcceptsLargestServableRequest) {
   std::string spec;
-  for (uint32_t i = 0; i < kMaxSelectiveRegions; i++) {
+  for (uint32_t i = 0; i < kMaxSelectiveRegions - 1; i++) {
     if (i) spec += ",";
     spec += "0x1000:1";
   }
   SelectiveCrRequest req;
   ASSERT_TRUE(ParseSelectiveRegions(spec.c_str(), &req));
-  EXPECT_EQ(req.num_regions, kMaxSelectiveRegions);
+  EXPECT_EQ(req.num_regions, kMaxSelectiveRegions - 1);
 }
 
-TEST(ParseSelectiveRegionsTest, RejectsOverMaxRegions) {
+TEST(ParseSelectiveRegionsTest, RejectsRequestAtExclusiveBound) {
   std::string spec;
-  for (uint32_t i = 0; i < kMaxSelectiveRegions + 1; i++) {
+  for (uint32_t i = 0; i < kMaxSelectiveRegions; i++) {
     if (i) spec += ",";
     spec += "0x1000:1";
   }


### PR DESCRIPTION
## How to call selective checkpoint

  The target process must be running with `vGPU.so` preloaded and initialized
  (`-i` arms the handlers and publishes selective support). The process **keeps
  running** during selective ops — there is no `cuda-checkpoint` freeze/thaw.

  ```sh
  # One-time per process: initialize the preloaded library
  cr_client -i -p <pid>

  # Checkpoint specific device regions into the per-PID staging buffer
  cr_client -c -p <pid> -s 0x7f0000000000:4096,0x7f0000100000:8192

  # Checkpoint the same regions to a file instead
  cr_client -c -p <pid> -s <ptr:size,...> -o /store/dump.bin

  # Restore, from the buffer or from a file
  cr_client -r -p <pid> -s <ptr:size,...> [-o /store/dump.bin]
  ```

  - `-s` takes comma-separated `ptr:size` pairs, hex or decimal, up to 4095
    regions per request. Malformed or overflowing values fail at parse time.
  - `-o` must be an absolute path. After a checkpoint the client validates the
    dump's commit marker; before a restore it refuses a torn or empty dump.
  - Every op has a deadline: `GPU_CR_OP_TIMEOUT_SEC` (default 120 s).

  ## Exit codes

  `cr_client` used to exit 0 or 1. Codes 2–4 are new, so callers (the snapshot
  agent) can tell outcomes apart:

  | Exit | Meaning | Typical cause |
  |------|---------|---------------|
  | 0 | Success | |
  | 1 | Usage error | bad flag combination, malformed `-s`, over-long `-o` |
  | 2 | Op failed | the library reported failure, dump failed validation, bad destination path |
  | 3 | Refused pre-signal | library has not published selective support, or the target died — nothing was perturbed |
  | 4 | Timeout | workload never finished the op; restart the workload before issuing another op on that PID |

## What does this PR do?

  Adds the coordinator-side client for the selective checkpoint protocol that
  landed in #177, plus hardening of the shared `cr_client` path:

  - **Selective ops**: `-s` (region list) and `-o` (file destination) drive
    `SELECTIVE_CKPT_MSG` / `SELECTIVE_RESTORE_MSG`. Region parsing is strict
    (`selective_spec.h`, header-only), fails at admission time, and enforces the
    region-count bound so a request can never fail for table capacity after the
    device-to-host copy already ran.
  - **Safety around the shared channel**: a `flock` on the control file
    serializes concurrent clients for the whole op; selective ops are refused
    before any signal if the library never published support; destination files
    are pre-created with symlink protection and truncation so a recycled path
    can never make a torn dump look valid, then chown'd to the target's uid
    with mode 0600 — the workload (often non-root) writes the dump, and
    owner-only write keeps a co-mounted uid from planting a marker-valid dump
    that a restore would trust.
  - **Hardening of existing full ops**: a dead target fails immediately instead
    of burning the timeout; the previously unbounded finish-wait now has a
    deadline; `cuda-checkpoint` runs via fork/exec instead of `system()` (works
    in images with no `/bin/sh`); a failed freeze or thaw is reported instead of
    silently ignored.
  - **`multi_cr_client`** sizes worker mappings by `fstat` instead of a
    compile-time constant, removing a cross-binary size coupling.

<!-- Describe the changes and their purpose -->

## Why is this change needed?

  The snapshot agent needs to move *chosen* memory regions (one model's weights,
  one group's KV) in and out of a live process. A full checkpoint freezes the
  process and copies all of VRAM; selective checkpoint copies only the named
  regions while the process keeps serving. #177 defined the wire format; this PR
  adds the client that actually drives it — without it the protocol is
  unreachable.

  The hardening exists because a machine, not a human, runs this binary: the
  agent must be able to distinguish "done", "failed", "refused, nothing
  happened", and "wedged" from the exit code alone, and must never be told a
  process parked when it is still running on the GPU. Before this change,
  `cr_client` could hang forever on a wedged workload and silently mis-report
  toggle failures.

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [X] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->

