### PR TITLE
Fix teardown race

### DIFF
--- a/pkg/snapshot-agent/server/server.go
+++ b/pkg/snapshot-agent/server/server.go
@@ -508,7 +508,7 @@ func resolvePIDs(ctx context.Context, jobID string, reqPIDs []int32) (allPIDs []
 	}
 
 	if len(pods) == 0 {
-		return nil, nil, fmt.Errorf("no pods found for job %s", jobID)
+		return nil, nil, fmt.Errorf("no pods found for job %s: %w", jobID, sm.ErrNoLiveProcesses)
 	}
 
 	allPIDs, allPIDStrings, errPIDs := getPIDsFromPods(ctx, pods)
@@ -517,7 +517,7 @@ func resolvePIDs(ctx context.Context, jobID string, reqPIDs []int32) (allPIDs []
 	}
 
 	if len(allPIDStrings) == 0 {
-		return nil, nil, fmt.Errorf("no GPU PIDs found for job %s", jobID)
+		return nil, nil, fmt.Errorf("no GPU PIDs found for job %s: %w", jobID, sm.ErrNoLiveProcesses)
 	}
 
 	return allPIDs, allPIDStrings, nil

--- a/pkg/snapshot-agent/server/server_internal_test.go
+++ b/pkg/snapshot-agent/server/server_internal_test.go
@@ -628,6 +628,89 @@ func TestServer_Snapshot_StandaloneMode(t *testing.T) {
 // inference engine configs are passed through to the backend without PID
 // discovery: no pods or PIDs are mocked for this job, so the snapshot only
 // succeeds if the server skipped the CUDA discovery path.
+// TestServer_Snapshot_K8sMode_WorkloadExited covers the end-of-run teardown
+// race (issue #164): a job yields with its snapshot deferred, exits, and only
+// then does lazy eviction snapshot it. Whether the job's pods are gone
+// entirely or linger with no GPU processes, the operation must COMPLETE and
+// the job must return to IDLE — a FAULTED ghost blocks the whole group.
+func TestServer_Snapshot_K8sMode_WorkloadExited(t *testing.T) {
+	initGRPCServer()
+	ctx := context.Background()
+	conn, err := grpc.NewClient("passthrough://bufnet",
+		grpc.WithContextDialer(bufDialer),
+		grpc.WithTransportCredentials(insecure.NewCredentials()))
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+	defer conn.Close()
+	client := pb.NewSnapshotAgentServiceClient(conn)
+
+	tests := []struct {
+		name    string
+		jobID   string
+		podName string // empty: no pods at all ("no pods found" path)
+	}{
+		{
+			name:  "PodsDeleted",
+			jobID: "test-job-exited-nopods",
+		},
+		{
+			name:    "PodsLingerWithoutGPUProcesses",
+			jobID:   "test-job-exited-nogpupids",
+			podName: "pod-exited-nogpupids",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.podName != "" {
+				// A live pod whose GPU processes have exited: GetPodPIDs
+				// returns nothing (no mockedPIDs entry).
+				createFakePod(ctx, t, tc.jobID, tc.podName)
+			}
+
+			// The agent believes the job is RUNNING with cached PIDs — the
+			// stale occupancy record left by the deferred final snapshot.
+			testServer.state.RegisterJob(tc.jobID, "test-group")
+			if err := testServer.state.TransitionToRunning(tc.jobID, []int{4242}); err != nil {
+				t.Fatalf("Failed to transition job to RUNNING: %v", err)
+			}
+
+			resp, err := client.Snapshot(ctx, &pb.SnapshotRequest{JobId: tc.jobID, Group: "test-group"})
+			if err != nil {
+				t.Fatalf("Snapshot RPC failed: %v", err)
+			}
+
+			var opResp *pb.GetOperationResponse
+			for range 100 {
+				opResp, err = client.GetOperation(ctx, &pb.GetOperationRequest{OperationId: resp.GetOperationId()})
+				if err != nil {
+					t.Fatalf("GetOperation failed: %v", err)
+				}
+				if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_PENDING {
+					break
+				}
+				time.Sleep(10 * time.Millisecond)
+			}
+			if opResp.GetStatus() != pb.OperationStatus_OPERATION_STATUS_COMPLETE {
+				t.Fatalf("Expected operation COMPLETE for exited workload, got %v (error: %q)",
+					opResp.GetStatus(), opResp.GetError())
+			}
+
+			statusResp, err := client.Status(ctx, &pb.StatusRequest{})
+			if err != nil {
+				t.Fatalf("Status RPC failed: %v", err)
+			}
+			for _, js := range statusResp.GetJobStatuses() {
+				if js.GetJobId() == tc.jobID && js.GetState() != pb.JobState_JOB_STATE_IDLE {
+					t.Fatalf("Expected job %s to be IDLE after exited-workload snapshot, got %v",
+						tc.jobID, js.GetState())
+				}
+			}
+		})
+	}
+}
+
 func TestServer_Snapshot_K8sMode_InferenceEngine(t *testing.T) {
 	initGRPCServer()
 	ctx := context.Background()

--- a/pkg/snapshot-agent/state-machine/state-manager.go
+++ b/pkg/snapshot-agent/state-machine/state-manager.go
@@ -1,6 +1,7 @@
 package statemachine
 
 import (
+	"errors"
 	"log/slog"
 	"sync"
 	"time"
@@ -10,6 +11,14 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
+
+// ErrNoLiveProcesses marks a snapshot worker failure that means the job's
+// workload processes no longer exist (e.g. the job completed and released its
+// lock with the snapshot deferred, then exited before lazy eviction ran).
+// There is nothing left to checkpoint and the accelerator is already free, so
+// the snapshot operation completes and the job returns to IDLE instead of
+// FAULTED — a FAULTED ghost would block every other job in the group.
+var ErrNoLiveProcesses = errors.New("no live workload processes for job")
 
 // OpType represents the type of operation (Snapshot or Restore).
 type OpType string
@@ -143,11 +152,22 @@ func (sm *StateManager) StartSnapshotSlot(jobID, group, slot string, worker func
 		defer job.mu.Unlock()
 
 		op.FinishedAt = time.Now()
-		if err != nil {
+		switch {
+		case errors.Is(err, ErrNoLiveProcesses):
+			// The workload exited before this (lazily deferred) snapshot ran.
+			// The eviction goal — a free accelerator — is already met, so the
+			// operation completes and the job returns to IDLE with no context.
+			slog.Warn("Snapshot found no live processes; treating job as exited",
+				"jobID", jobID, "error", err)
+			op.Status = pb.OperationStatus_OPERATION_STATUS_COMPLETE
+			job.State = pb.JobState_JOB_STATE_IDLE
+			job.PIDs = nil
+			job.Slot = ""
+		case err != nil:
 			op.Status = pb.OperationStatus_OPERATION_STATUS_FAILED
 			op.Error = err.Error()
 			job.State = pb.JobState_JOB_STATE_FAULTED
-		} else {
+		default:
 			op.Status = pb.OperationStatus_OPERATION_STATUS_COMPLETE
 			op.StorageBytes = 1024
 			job.State = pb.JobState_JOB_STATE_SAVED

--- a/pkg/snapshot-agent/state-machine/state-manager_test.go
+++ b/pkg/snapshot-agent/state-machine/state-manager_test.go
@@ -2,6 +2,7 @@ package statemachine_test
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -146,6 +147,45 @@ func TestStartSnapshot(t *testing.T) {
 				checkJobState(t, sm, jobID, tc.finalState)
 			}
 		})
+	}
+}
+
+// TestStartSnapshot_NoLiveProcesses covers the end-of-run teardown race
+// (issue #164): a job releases its lock with the snapshot deferred, exits,
+// and only then does lazy eviction trigger the snapshot. PID discovery finds
+// nothing, which must complete the operation and return the job to IDLE —
+// not FAULTED, which would block every other job in the group.
+func TestStartSnapshot_NoLiveProcesses(t *testing.T) {
+	sm := statemachine.NewStateManager()
+	jobID := "job-1"
+	group := "group-1"
+
+	sm.RegisterJob(jobID, group)
+	if err := sm.TransitionToRunning(jobID, []int{123, 456}); err != nil {
+		t.Fatalf("TransitionToRunning failed: %v", err)
+	}
+
+	worker := func() error {
+		return fmt.Errorf("no GPU PIDs found for job %s: %w", jobID, statemachine.ErrNoLiveProcesses)
+	}
+
+	opID, err := sm.StartSnapshot(jobID, group, worker)
+	if err != nil {
+		t.Fatalf("StartSnapshot failed: %v", err)
+	}
+
+	op := waitForOperation(t, sm, opID)
+	checkOperationStatus(t, op, pb.OperationStatus_OPERATION_STATUS_COMPLETE, "")
+	checkJobState(t, sm, jobID, pb.JobState_JOB_STATE_IDLE)
+
+	// The dead workload's PIDs must be dropped so a stale restore can't target them.
+	if _, err := sm.GetJobPIDs(jobID); err == nil {
+		t.Error("Expected GetJobPIDs to fail after PIDs were cleared, got nil error")
+	}
+
+	// The job ID must be reusable: a fresh workload can run again.
+	if err := sm.TransitionToRunning(jobID, []int{789}); err != nil {
+		t.Errorf("Expected job to be re-runnable after no-live-processes snapshot, got: %v", err)
 	}
 }
 

--- a/tests/integration/orchestrator/orchestrator_test.go
+++ b/tests/integration/orchestrator/orchestrator_test.go
@@ -31,6 +31,31 @@ func TestOrchestrator(t *testing.T) {
 
 	h := NewComposedHarness(t)
 
+	t.Run("TeardownRace", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+		defer cancel()
+
+		conn, err := grpc.NewClient(
+			h.OrchAddr,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err != nil {
+			t.Fatalf("dialing orchestrator at %s: %v", h.OrchAddr, err)
+		}
+		defer conn.Close()
+
+		client := pb.NewTimeSliceOrchestratorServiceClient(conn)
+
+		execFn := func(ctx context.Context, podName, container string, command ...string) (string, error) {
+			return h.ExecPod(podName, container, 2*time.Minute, command...)
+		}
+
+		err = scenarios.RunTeardownRaceScenario(ctx, h.Client, client, t, execFn)
+		if err != nil {
+			t.Fatalf("TeardownRace scenario failed: %v", err)
+		}
+	})
+
 	t.Run("SingleRLJob", func(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 		defer cancel()
@@ -51,8 +76,8 @@ func TestOrchestrator(t *testing.T) {
 			h.Client,
 			client,
 			t,
-			"",  // sampler template key (default: PyTorch GPU burner)
-			"",  // trainer template key (default: PyTorch GPU burner)
+			"", // sampler template key (default: PyTorch GPU burner)
+			"", // trainer template key (default: PyTorch GPU burner)
 		)
 		if err != nil {
 			t.Fatalf("SingleRLJob scenario failed: %v", err)
@@ -79,11 +104,12 @@ func TestOrchestrator(t *testing.T) {
 			h.Client,
 			client,
 			t,
-			"",  // sampler template key (default: PyTorch GPU burner)
-			"",  // trainer template key (default: PyTorch GPU burner)
+			"", // sampler template key (default: PyTorch GPU burner)
+			"", // trainer template key (default: PyTorch GPU burner)
 		)
 		if err != nil {
 			t.Fatalf("QueuedRLJobs scenario failed: %v", err)
 		}
 	})
+
 }

--- a/tests/integration/orchestrator/scenarios/scenarios.go
+++ b/tests/integration/orchestrator/scenarios/scenarios.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	pb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/timeslice-orchestrator/api/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -300,5 +301,201 @@ func deleteSharedClaim(ctx context.Context, clientset kubernetes.Interface, name
 	if err != nil && !k8serrors.IsNotFound(err) {
 		return fmt.Errorf("failed to delete shared claim %s: %w", name, err)
 	}
+	return nil
+}
+
+// ExecInPod runs a command inside a scenario pod's container; wired to the
+// harness's SPDY exec helper by the test that drives the scenario.
+type ExecInPod func(ctx context.Context, podName, container string, command ...string) (string, error)
+
+// killableBurnerPod is the default GPU burner restructured so the GPU
+// process can be killed WITHOUT the pod dying: a shell stays as PID 1,
+// records the python PID, and keeps the pod alive after it exits. This
+// reproduces a real workload teardown (Ray drivers exit, worker pods
+// linger) where the accelerator processes are gone but the pod - and with
+// it the platform's job bookkeeping - remains.
+func killableBurnerPod() *corev1.Pod {
+	gracePeriodSec := int64(2)
+	script := `cat > /tmp/burn.py <<'PYEOF'
+import torch, time
+total = torch.cuda.get_device_properties(0).total_memory
+alloc = int(total * 0.5)
+print(f"Allocating 50% VRAM: {alloc / 1e9:.2f} GB")
+t = torch.zeros(alloc // 4, dtype=torch.float32, device='cuda')
+torch.cuda.synchronize()
+print("holding VRAM")
+while True:
+    time.sleep(1)
+PYEOF
+python3 /tmp/burn.py &
+echo $! > /tmp/gpu.pid
+wait $(cat /tmp/gpu.pid)
+echo "GPU process exited; keeping pod alive"
+sleep infinity`
+	return &corev1.Pod{
+		Spec: corev1.PodSpec{
+			TerminationGracePeriodSeconds: &gracePeriodSec,
+			Containers: []corev1.Container{
+				{
+					Name:            "pytorch-container",
+					Image:           "pytorch/pytorch:2.1.0-cuda12.1-cudnn8-runtime",
+					Command:         []string{"sh", "-c"},
+					Args:            []string{script},
+					ImagePullPolicy: corev1.PullIfNotPresent,
+				},
+			},
+		},
+	}
+}
+
+// waitAgentJobState polls GetGroupStatus until the given job reports the
+// wanted state on at least one agent of the group.
+func waitAgentJobState(
+	ctx context.Context,
+	client pb.TimeSliceOrchestratorServiceClient,
+	groupID, jobID string,
+	want pb.SnapshotAgentJobState_State,
+	timeout time.Duration,
+) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		resp, err := client.GetGroupStatus(ctx, &pb.GetGroupStatusRequest{GroupId: groupID})
+		if err != nil {
+			//nolint:nilerr // the group may not exist yet (NotFound); keep polling until timeout
+			return false, nil
+		}
+		for _, s := range resp.AgentJobStates {
+			if s.JobId == jobID && s.JobState == want {
+				return true, nil
+			}
+		}
+		return false, nil
+	})
+}
+
+// RunTeardownRaceScenario reproduces the end-of-run teardown race
+// (issue #164): a job releases its group lock with no waiters (the snapshot
+// is deferred, so the agent keeps reporting it RUNNING), then its
+// accelerator processes exit while its pods linger. The next job's Acquire
+// triggers lazy eviction of this ghost - a checkpoint of processes that no
+// longer exist. Without the fix, PID discovery fails the snapshot, the dead
+// job is marked FAULTED, and the survivor's Acquire fails with
+// "group samplers is faulted"; with the fix, the eviction completes, the
+// ghost settles to IDLE, and the survivor is granted the lock.
+func RunTeardownRaceScenario(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	client pb.TimeSliceOrchestratorServiceClient,
+	logger Logger,
+	execInPod ExecInPod,
+) error {
+	logger.Log("Starting Teardown Race Scenario")
+
+	const ghostJob = "ghost-job"
+	const survivorJob = "survivor-job"
+	samplerClaim := "claim-shared-teardown-samplers"
+
+	if err := createSharedClaim(ctx, clientset, samplerClaim); err != nil {
+		return err
+	}
+	defer func() {
+		if err := deleteSharedClaim(ctx, clientset, samplerClaim); err != nil {
+			logger.Errorf("Failed to delete shared claim %s: %v", samplerClaim, err)
+		}
+	}()
+
+	jobA := NewFakeRLJob(
+		ghostJob, client, clientset, 0, logger,
+		"killable", "", samplerClaim, "",
+	)
+	jobA.RegisterPodTemplate("killable", killableBurnerPod())
+	defer func() {
+		if err := jobA.cleanupPods(context.WithoutCancel(ctx)); err != nil {
+			logger.Errorf("Failed to clean up ghost job pods: %v", err)
+		}
+	}()
+
+	// 1. The ghost job acquires samplers and deploys its GPU workload.
+	logger.Logf("[Test] %s acquiring samplers...", ghostJob)
+	resp, err := jobA.acquireWithRetry(ctx, "samplers")
+	if err != nil {
+		return fmt.Errorf("ghost job failed to acquire samplers: %w", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("ghost job samplers acquire was not successful")
+	}
+	if err := jobA.deployPods(ctx, "samplers"); err != nil {
+		return fmt.Errorf("ghost job failed to deploy sampler pod: %w", err)
+	}
+
+	// 2. Wait until the agent observes the workload on the accelerator.
+	logger.Logf("[Test] Waiting for %s to be observed RUNNING by the agent...", ghostJob)
+	if err := waitAgentJobState(ctx, client, "samplers", ghostJob,
+		pb.SnapshotAgentJobState_STATE_RUNNING, 6*time.Minute); err != nil {
+		return fmt.Errorf("ghost job never observed RUNNING: %w", err)
+	}
+
+	// 3. Final release with NO waiters: the snapshot is deferred, so the
+	// agent keeps reporting the job RUNNING.
+	logger.Logf("[Test] %s releasing samplers (no waiters - snapshot deferred)...", ghostJob)
+	if err := jobA.yieldWithRetry(ctx, "samplers"); err != nil {
+		return fmt.Errorf("ghost job failed to yield samplers: %w", err)
+	}
+
+	// 4. The workload exits (killed) while the pod - and the platform's job
+	// bookkeeping - lingers. This is the moment a real job's driver exits.
+	jobA.mu.Lock()
+	podName := jobA.createdPods[0]
+	jobA.mu.Unlock()
+	logger.Logf("[Test] Killing the GPU process in pod %s (pod stays alive)...", podName)
+	out, err := execInPod(ctx, podName, "pytorch-container",
+		"sh", "-c", "kill -9 $(cat /tmp/gpu.pid) && echo killed")
+	if err != nil {
+		return fmt.Errorf("failed to kill GPU process in %s: %w (output: %s)", podName, err, out)
+	}
+
+	// 5. Confirm the ghost: the agent still reports the dead job RUNNING.
+	time.Sleep(5 * time.Second)
+	statusResp, err := client.GetGroupStatus(ctx, &pb.GetGroupStatusRequest{GroupId: "samplers"})
+	if err != nil {
+		return fmt.Errorf("failed to get samplers status after kill: %w", err)
+	}
+	ghostSeen := false
+	for _, s := range statusResp.AgentJobStates {
+		if s.JobId == ghostJob && s.JobState == pb.SnapshotAgentJobState_STATE_RUNNING {
+			ghostSeen = true
+		}
+	}
+	if !ghostSeen {
+		return fmt.Errorf("expected stale RUNNING record for %s after its processes exited (ghost precondition)", ghostJob)
+	}
+	logger.Logf("[Test] Confirmed ghost: %s processes are dead but the agent still reports RUNNING", ghostJob)
+
+	// 6. The survivor acquires: this triggers lazy eviction of the ghost.
+	// Without the fix this fails with "group samplers is faulted".
+	logger.Logf("[Test] %s acquiring samplers (triggers lazy eviction of the ghost)...", survivorJob)
+	acquireCtx, cancel := context.WithTimeout(ctx, 3*time.Minute)
+	defer cancel()
+	if _, err := client.Acquire(acquireCtx, &pb.AcquireRequest{
+		GroupId: "samplers",
+		JobId:   survivorJob,
+	}); err != nil {
+		return fmt.Errorf(
+			"teardown race: survivor's Acquire failed after the ghost job's processes exited "+
+				"(lazy eviction of the dead job likely FAULTED the group): %w", err)
+	}
+	logger.Logf("[Test] %s acquired samplers - ghost eviction handled", survivorJob)
+
+	// 7. The ghost must have settled to IDLE (evicted with nothing to save).
+	if err := waitAgentJobState(ctx, client, "samplers", ghostJob,
+		pb.SnapshotAgentJobState_STATE_IDLE, time.Minute); err != nil {
+		return fmt.Errorf("ghost job did not settle to IDLE after eviction: %w", err)
+	}
+
+	// 8. Release the survivor's lock so later scenarios start clean.
+	if _, err := client.Yield(ctx, &pb.YieldRequest{GroupId: "samplers", JobId: survivorJob}); err != nil {
+		logger.Errorf("Failed to yield survivor lock: %v", err)
+	}
+
+	logger.Log("Teardown Race Scenario completed successfully")
 	return nil
 }


### PR DESCRIPTION
## What does this PR do?

When lazy eviction snapshots a job whose workload no longer exists, the agent now completes the operation and returns the job to IDLE instead of marking it FAULTED. A new ErrRestoreNotAttempted-style sentinel (ErrNoLiveProcesses) is wrapped around the PID-discovery failures ("no pods found" / "no GPU PIDs found"), and the snapshot state machine treats it as "workload exited": op COMPLETE, job → IDLE, cached PIDs cleared. Explicit-PID configs still fail hard. Also adds TestOrchestrator/TeardownRace, an integration scenario that manufactures this exact situation (workload killed while its pod lingers) — the suite previously never covered post-mortem eviction.

## Why is this change needed?

When a job finishes, it releases its lock with no waiters, so its snapshot is deferred and the agent keeps reporting it RUNNING. The job then exits. The surviving job's next Acquire triggers eviction of this ghost — a checkpoint of processes that no longer exist — which fails PID discovery, marks the dead job FAULTED, and isGroupFaulted then rejects every Acquire with "group X is faulted", killing or hanging the survivor on its final step (issue #164; observed 7/7 on TPU pair-runs and 2/2 on H200 slime runs). The eviction's goal — a free accelerator — is already met when the workload is gone; treating it as a fault bricks the group for no reason. Returning to IDLE lets reconciliation proceed to restore the survivor immediately.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed

  Without the fix (stock main agent) — fails, with the exact issue #164 signature, in 38s:

  [Test] Confirmed ghost: ghost-job processes are dead but the agent still reports RUNNING
  TeardownRace scenario failed: survivor's Acquire failed after the ghost job's processes
  exited (lazy eviction of the dead job likely FAULTED the group):
    rpc error: code = Unavailable desc = group samplers is faulted
  --- FAIL: TestOrchestrator/TeardownRace (38.39s)

  With the fix (agent from this branch) — entire suite green:

  --- PASS: TestOrchestrator (440.27s)
      --- PASS: TestOrchestrator/TeardownRace (23.90s)
      --- PASS: TestOrchestrator/SingleRLJob  (10.15s)
      --- PASS: TestOrchestrator/QueuedRLJobs (405.38s) (passed with pr #183 fix)


## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

Issue #164

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an end-of-run race where workloads that exited before deferred snapshots could leave jobs stuck in a failed state.
  - Jobs with no remaining live processes now complete snapshot handling successfully, return to an idle state, and become available for reuse.

- **Tests**
  - Added coverage for workload teardown scenarios, including deleted pods and lingering pods without GPU processes.
  - Added end-to-end validation for lazy eviction and recovery during orchestrator operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->