### PR TITLE
[GPU-CR Selective Checkpoint 6/N]: Move control files off hugetlbfs onto a tmpfs discovered inside the checkpoint dir

### DIFF
--- a/third_party/gpu-cr/CMakeLists.txt
+++ b/third_party/gpu-cr/CMakeLists.txt
@@ -135,10 +135,10 @@ target_compile_options(multi_cr_client PRIVATE -O3 -g)
 
 # ---------------------------------------------------------------------------
 # Tests (GPU-free; run in Dockerfile.build)
-#   gpu_cr_unit_tests        — GoogleTest unit suite for the dump-format
-#                              code, plus the upstream-baseline control
-#                              channel, buffer mapping, fd exchange and
-#                              wire structs
+#   gpu_cr_unit_tests        — GoogleTest unit suite for the ctl-path and
+#                              dump-format code, plus the upstream-baseline
+#                              control channel, buffer mapping, fd exchange
+#                              and wire structs
 # ---------------------------------------------------------------------------
 option(GPU_CR_BUILD_TESTS "Build the GPU-free unit tests" OFF)
 
@@ -156,6 +156,7 @@ if(GPU_CR_BUILD_TESTS)
     add_executable(gpu_cr_unit_tests
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/common_baseline_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/common_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/ctl_path_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/dump_format_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/ipc_fd_exchange_test.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/mmap_backend_test.cpp

--- a/third_party/gpu-cr/Dockerfile.build
+++ b/third_party/gpu-cr/Dockerfile.build
@@ -15,15 +15,11 @@ ARG RUN_TESTS=1
 RUN apt-get update && apt-get install -y --no-install-recommends git cmake build-essential && rm -rf /var/lib/apt/lists/*
 
 COPY . /tmp/GPU-CR
+# control-file 0777 is source truth in share_mem.cpp; only the signal
+# remap remains a build-time patch.
 RUN cd /tmp/GPU-CR && \
     sed -i 's/#define CR_CKPT_SIGNAL     SIGUSR1/#define CR_CKPT_SIGNAL     (SIGRTMAX - 8)/' src/common.h && \
     sed -i 's/#define CR_RESTORE_SIGNAL  SIGUSR2/#define CR_RESTORE_SIGNAL  (SIGRTMAX - 7)/' src/common.h && \
-    # 0777 is deliberate, not an oversight: the coordinator (agent pod) and
-    # the workload run as different UIDs in different pods and share the
-    # control file only through a dedicated volume — the volume mount is the
-    # access boundary. A stricter mode would need a UID/GID contract across
-    # pods that the deployment cannot assume.
-    sed -i 's/fd_control = open(control_name, O_CREAT | O_RDWR, 0755);/fd_control = open(control_name, O_CREAT | O_RDWR, 0777); fchmod(fd_control, 0777);/' src/comm/share_mem.cpp && \
     grep -q "SIGRTMAX - 8" src/common.h && \
     grep -q "0777" src/comm/share_mem.cpp && \
     mkdir build && cd build && \

--- a/third_party/gpu-cr/src/comm/share_mem.cpp
+++ b/third_party/gpu-cr/src/comm/share_mem.cpp
@@ -1,4 +1,5 @@
 #include "comm.h"
+#include "../ctl_path.h"
 
 Comm::Comm(pid_t pid) {
 }
@@ -30,18 +31,37 @@ ShareMemComm::~ShareMemComm() {
 
 void ShareMemComm::setup() {
     char control_name[512];
-    const char* ctl_dir = std::getenv("EXPORT_FILE_PATH");
-    if (!ctl_dir) ctl_dir = "/mnt/huge-ckpt";
+    bool ctl_mode = false;
+    const char* ctl_dir = gpu_cr::CtlDir(&ctl_mode);
     snprintf(control_name, sizeof(control_name), "%s/control-%d", ctl_dir, pid);
-    fd_control = open(control_name, O_CREAT | O_RDWR, 0755);
+    // 0777: the coordinator (agent container) and the workload run as
+    // different users in different containers but share this file.
+    // Previously applied as a Dockerfile.build sed patch; now source truth.
+    fd_control = open(control_name, O_CREAT | O_RDWR, 0777);
     if (fd_control < 0) {
         perror("open()");
         exit(EXIT_FAILURE);
     }
+    fchmod(fd_control, 0777);
     // Set file size before mmap to avoid Bus error
     if (ftruncate(fd_control, HUGE_PAGE_SIZE) < 0) {
         perror("ftruncate()");
         exit(EXIT_FAILURE);
+    }
+    if (ctl_mode) {
+        // tmpfs reserves nothing at ftruncate or mmap: without this, a full
+        // ctl tmpfs surfaces as SIGBUS at the first store — worst case
+        // inside the .so's signal handler. Allocate only the stored extent;
+        // the sparse 2MiB tail keeps the legacy file layout for free.
+        // cr_client runs setup() first, so ENOSPC lands here, in the
+        // coordinator, as a clean exit.
+        int rc = posix_fallocate(
+            fd_control, 0,
+            static_cast<off_t>(gpu_cr::RoundUp4K(sizeof(signal_controls))));
+        if (rc != 0) {
+            fprintf(stderr, "posix_fallocate(%s): %s (ctl tmpfs full?)\n", control_name, strerror(rc));
+            exit(EXIT_FAILURE);
+        }
     }
     control = (signal_controls*)mmap(NULL, HUGE_PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd_control, 0);
     if (control == MAP_FAILED) {

--- a/third_party/gpu-cr/src/ctl_path.h
+++ b/third_party/gpu-cr/src/ctl_path.h
@@ -84,8 +84,12 @@ inline bool CtlCandidatePath(char* buf, size_t n) {
 // name buffer, and bounding the dir keeps those snprintfs provably
 // truncation-free (-Wformat-truncation) with headroom for the longest
 // name pattern. A dir this long could not have produced usable control
-// paths before either; ResolveCtlDir clamps, and the clamped path then
-// simply fails the statfs/open exactly like any other wrong path.
+// paths before either. A configured GPU_CR_CTL_PATH that does not fit is
+// treated as INVALID (warn + legacy, cr_client refuses) — never statfs'd
+// unclamped, so a real tmpfs at an unaddressable path can't silently
+// enable ctl mode on a truncated dir. The discovery candidate and the
+// legacy data dir clamp the same way; a clamped legacy dir then simply
+// fails open() exactly like any other wrong path.
 inline constexpr size_t kCtlDirMax = 480;
 
 struct CtlResolution {
@@ -100,14 +104,18 @@ inline void ResolveCtlDir(CtlResolution* out) {
   out->ctl_mode = false;
   const char* env = getenv("GPU_CR_CTL_PATH");
   if (env && env[0]) {
-    if (DirIsTmpfs(env)) {
-      snprintf(out->dir, sizeof(out->dir), "%s", env);
+    // Copy/clamp BEFORE the statfs: validating the unclamped path would
+    // enable ctl mode on a dir the callers cannot address. A path that
+    // does not fit is invalid, same as missing or non-tmpfs.
+    int len = snprintf(out->dir, sizeof(out->dir), "%s", env);
+    bool fits = len > 0 && static_cast<size_t>(len) < sizeof(out->dir);
+    if (fits && DirIsTmpfs(out->dir)) {
       out->ctl_mode = true;
       return;
     }
     fprintf(stderr,
-            "[gpu-cr] GPU_CR_CTL_PATH=%s missing or not tmpfs; using legacy "
-            "control dir %s\n",
+            "[gpu-cr] GPU_CR_CTL_PATH=%s missing, not tmpfs, or too long; "
+            "using legacy control dir %s\n",
             env, DataDir());
     snprintf(out->dir, sizeof(out->dir), "%s", DataDir());
     return;

--- a/third_party/gpu-cr/src/ctl_path.h
+++ b/third_party/gpu-cr/src/ctl_path.h
@@ -2,16 +2,37 @@
 #define GPU_CR_SRC_CTL_PATH_H_
 
 // The control plane (control-<pid>, ctl-ready-<pid>, pid_map_*,
-// the id counter) moves off hugetlbfs onto a caller-provided tmpfs, so no
-// hugetlb page is ever faulted from the coordinating process's cgroup.
-// Dump/staging DATA files stay in EXPORT_FILE_PATH untouched.
+// the id counter) moves off hugetlbfs onto a tmpfs, so no hugetlb page is
+// ever faulted from the coordinating process's cgroup. Dump/staging DATA
+// files stay in EXPORT_FILE_PATH untouched.
 //
-// GPU_CR_CTL_PATH unset            -> legacy: ctl dir == data dir.
-// GPU_CR_CTL_PATH set, tmpfs       -> ctl mode.
-// GPU_CR_CTL_PATH set, NOT tmpfs   -> legacy fallback (the .so must never
-//     write an advertisement into a disk-backed hostPath dir that a later
-//     tmpfs mount would shadow); cr_client refuses instead, so the
-//     misconfiguration is loud on the coordinator side.
+// The tmpfs is found without ANY workload-side configuration: the
+// coordinator mounts it at <data dir>/ctl on the host, inside the dump
+// store the workload already mounts, so the .so discovers it through the
+// volume it has anyway. The consumer contract stays exactly LD_PRELOAD +
+// EXPORT_FILE_PATH. Resolution order:
+//
+// GPU_CR_CTL_PATH set, tmpfs       -> ctl mode with that dir (coordinator-
+//     side override; kept for compat, never required on the consumer).
+// GPU_CR_CTL_PATH set, NOT tmpfs   -> legacy fallback, loud warning.
+//     Explicit config never silently redirects: discovery is NOT consulted
+//     (the .so must never write an advertisement into a disk-backed dir
+//     that a later tmpfs mount would shadow); cr_client refuses instead,
+//     so the misconfiguration surfaces on the coordinator side.
+// GPU_CR_CTL_PATH unset, <data dir>/ctl tmpfs-backed -> ctl mode
+//     (zero-config discovery). The statfs gate reports the CONTAINING
+//     filesystem: a plain "ctl" subdir inside a store that is itself
+//     tmpfs also enables ctl mode — intended, the control plane lands
+//     where legacy mode would have put it anyway.
+// otherwise                        -> legacy: ctl dir == data dir.
+//
+// CtlDir() memoizes the resolution on first use. In the .so that first
+// use is the ELF-constructor advertisement block (it runs before init_CR),
+// so the snapshot is taken exactly when the advertisement is written and
+// one process can never straddle two layouts, even if a tmpfs appears
+// mid-life. A tmpfs mounted after that point is simply not seen; the
+// coordinator's advertisement gate turns the mixed-order case into a loud
+// refusal, same contract as the env-based mount-order rule.
 
 #include <errno.h>
 #include <fcntl.h>
@@ -31,6 +52,12 @@ inline constexpr unsigned long kTmpfsMagic = 0x01021994UL;
 // destination-path support.
 inline constexpr int kCtlProto = 3;
 
+// Subdirectory of the data dir probed for the zero-config control plane.
+// Reserved: nothing else may claim <data dir>/ctl (dumps are files at the
+// store root, destination slots live under <data dir>/groups, and the GC
+// sweeper skips directories in the store root).
+inline constexpr char kCtlSubdir[] = "ctl";
+
 constexpr size_t RoundUp4K(size_t x) { return (x + 4095UL) & ~4095UL; }
 
 // Directory holding dump/staging DATA files (unchanged by the ctl split).
@@ -45,22 +72,83 @@ inline bool DirIsTmpfs(const char* dir) {
   return static_cast<unsigned long>(sfs.f_type) == kTmpfsMagic;
 }
 
-// Resolves the control-plane directory. Sets *ctl_mode to true when a
-// valid tmpfs-backed GPU_CR_CTL_PATH is in effect, false for legacy mode.
-inline const char* CtlDir(bool* ctl_mode) {
-  const char* path = getenv("GPU_CR_CTL_PATH");
-  if (path && path[0] && DirIsTmpfs(path)) {
-    if (ctl_mode) *ctl_mode = true;
-    return path;
-  }
-  if (path && path[0]) {
+// Writes "<DataDir()>/ctl" into buf. Returns false when it does not fit.
+inline bool CtlCandidatePath(char* buf, size_t n) {
+  int len = snprintf(buf, n, "%s/%s", DataDir(), kCtlSubdir);
+  return len > 0 && static_cast<size_t>(len) < n;
+}
+
+// A resolved control-plane directory. dir is a copy, not a pointer into
+// the environment: the cache below outlives any putenv/setenv churn.
+// 480, not 512: every caller formats "<dir>/<name>-<pid>" into a 512-byte
+// name buffer, and bounding the dir keeps those snprintfs provably
+// truncation-free (-Wformat-truncation) with headroom for the longest
+// name pattern. A dir this long could not have produced usable control
+// paths before either; ResolveCtlDir clamps, and the clamped path then
+// simply fails the statfs/open exactly like any other wrong path.
+inline constexpr size_t kCtlDirMax = 480;
+
+struct CtlResolution {
+  bool ctl_mode = false;
+  char dir[kCtlDirMax] = "";
+};
+
+// Pure resolver (no caching — one statfs per call): applies the header's
+// resolution order. Unit tests target this directly; production code goes
+// through the memoizing CtlDir() below.
+inline void ResolveCtlDir(CtlResolution* out) {
+  out->ctl_mode = false;
+  const char* env = getenv("GPU_CR_CTL_PATH");
+  if (env && env[0]) {
+    if (DirIsTmpfs(env)) {
+      snprintf(out->dir, sizeof(out->dir), "%s", env);
+      out->ctl_mode = true;
+      return;
+    }
     fprintf(stderr,
             "[gpu-cr] GPU_CR_CTL_PATH=%s missing or not tmpfs; using legacy "
             "control dir %s\n",
-            path, DataDir());
+            env, DataDir());
+    snprintf(out->dir, sizeof(out->dir), "%s", DataDir());
+    return;
   }
-  if (ctl_mode) *ctl_mode = false;
-  return DataDir();
+  if (CtlCandidatePath(out->dir, sizeof(out->dir)) && DirIsTmpfs(out->dir)) {
+    out->ctl_mode = true;
+    return;
+  }
+  snprintf(out->dir, sizeof(out->dir), "%s", DataDir());
+}
+
+namespace internal {
+struct CtlCache {
+  bool resolved = false;
+  CtlResolution res;
+};
+inline CtlCache& GetCtlCache() {
+  static CtlCache cache;
+  return cache;
+}
+}  // namespace internal
+
+// Resolves the control-plane directory, memoized on first call (see the
+// header comment for why the snapshot matters). Sets *ctl_mode to true
+// when a tmpfs-backed control dir is in effect, false for legacy mode.
+// Not locked: the first call happens before any threads exist (the .so's
+// ELF constructor; cr_client's main), later calls only read.
+inline const char* CtlDir(bool* ctl_mode) {
+  internal::CtlCache& cache = internal::GetCtlCache();
+  if (!cache.resolved) {
+    ResolveCtlDir(&cache.res);
+    cache.resolved = true;
+  }
+  if (ctl_mode) *ctl_mode = cache.res.ctl_mode;
+  return cache.res.dir;
+}
+
+// Unit-test hook: a gtest binary drives resolution under several layouts
+// in one process, which the memoization would otherwise pin to the first.
+inline void ResetCtlDirCacheForTests() {
+  internal::GetCtlCache().resolved = false;
 }
 
 // Extracts starttime (field 22 of /proc/<pid>/stat) from a stat line.

--- a/third_party/gpu-cr/src/ctl_path.h
+++ b/third_party/gpu-cr/src/ctl_path.h
@@ -1,0 +1,174 @@
+#ifndef GPU_CR_SRC_CTL_PATH_H_
+#define GPU_CR_SRC_CTL_PATH_H_
+
+// The control plane (control-<pid>, ctl-ready-<pid>, pid_map_*,
+// the id counter) moves off hugetlbfs onto a caller-provided tmpfs, so no
+// hugetlb page is ever faulted from the coordinating process's cgroup.
+// Dump/staging DATA files stay in EXPORT_FILE_PATH untouched.
+//
+// GPU_CR_CTL_PATH unset            -> legacy: ctl dir == data dir.
+// GPU_CR_CTL_PATH set, tmpfs       -> ctl mode.
+// GPU_CR_CTL_PATH set, NOT tmpfs   -> legacy fallback (the .so must never
+//     write an advertisement into a disk-backed hostPath dir that a later
+//     tmpfs mount would shadow); cr_client refuses instead, so the
+//     misconfiguration is loud on the coordinator side.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/vfs.h>
+#include <unistd.h>
+
+namespace gpu_cr {
+
+inline constexpr unsigned long kTmpfsMagic = 0x01021994UL;
+
+// Control-channel protocol level advertised by the .so and required by
+// cr_client. Proto >= 3 implies readiness advertisements and
+// destination-path support.
+inline constexpr int kCtlProto = 3;
+
+constexpr size_t RoundUp4K(size_t x) { return (x + 4095UL) & ~4095UL; }
+
+// Directory holding dump/staging DATA files (unchanged by the ctl split).
+inline const char* DataDir() {
+  const char* dir = getenv("EXPORT_FILE_PATH");
+  return (dir && dir[0]) ? dir : "/mnt/huge-ckpt";
+}
+
+inline bool DirIsTmpfs(const char* dir) {
+  struct statfs sfs;
+  if (statfs(dir, &sfs) != 0) return false;
+  return static_cast<unsigned long>(sfs.f_type) == kTmpfsMagic;
+}
+
+// Resolves the control-plane directory. Sets *ctl_mode to true when a
+// valid tmpfs-backed GPU_CR_CTL_PATH is in effect, false for legacy mode.
+inline const char* CtlDir(bool* ctl_mode) {
+  const char* path = getenv("GPU_CR_CTL_PATH");
+  if (path && path[0] && DirIsTmpfs(path)) {
+    if (ctl_mode) *ctl_mode = true;
+    return path;
+  }
+  if (path && path[0]) {
+    fprintf(stderr,
+            "[gpu-cr] GPU_CR_CTL_PATH=%s missing or not tmpfs; using legacy "
+            "control dir %s\n",
+            path, DataDir());
+  }
+  if (ctl_mode) *ctl_mode = false;
+  return DataDir();
+}
+
+// Extracts starttime (field 22 of /proc/<pid>/stat) from a stat line.
+// Parses backwards from the last ')' because the comm field may contain
+// spaces and parentheses. Returns -1 if the buffer is not a stat line.
+inline long long ParseStarttimeFromStat(const char* stat_line) {
+  const char* p = strrchr(stat_line, ')');
+  if (!p || p[1] == '\0') return -1;
+  p += 2;
+  char buf[4096];
+  strncpy(buf, p, sizeof(buf) - 1);
+  buf[sizeof(buf) - 1] = '\0';
+  long long val = -1;
+  int field = 3;
+  char* save = nullptr;
+  for (char* tok = strtok_r(buf, " ", &save); tok;
+       tok = strtok_r(nullptr, " ", &save), field++) {
+    if (field == 22) {
+      char* end = nullptr;
+      val = strtoll(tok, &end, 10);
+      if (end == tok) val = -1;  // no digits consumed: not a stat line
+      break;
+    }
+  }
+  return val;
+}
+
+// starttime of a live PID: the PID-reuse guard for the readiness
+// advertisement (a recycled PID gets a new starttime, and signaling an
+// innocent recycled PID is termination by default). Returns -1 when the
+// PID does not exist.
+inline long long ProcStarttime(pid_t pid) {
+  char path[64];
+  char buf[4096];
+  snprintf(path, sizeof(path), "/proc/%d/stat", pid);
+  FILE* f = fopen(path, "r");
+  if (!f) return -1;
+  size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+  fclose(f);
+  if (n == 0) return -1;
+  buf[n] = '\0';
+  return ParseStarttimeFromStat(buf);
+}
+
+// Readiness advertisement written by the .so at load and read back by
+// cr_client before it signals; carries the buffer-sizing keys so the
+// agent can observe workload sizing.
+struct Advertisement {
+  int proto = 0;
+  long long starttime = -1;
+  char ctl[512] = "";
+};
+
+// Parses "proto=<n> starttime=<n> ctl=<path> ..." (unknown trailing keys
+// ignored). The sscanf format is an ordered prefix match: only a suffix of
+// the fields may be absent — a missing middle field stops the scan there
+// and every later field keeps its default. %511s also means the ctl path
+// must not contain whitespace. Returns false only for an empty/absent
+// proto line.
+inline bool ParseAdvertisement(const char* line, Advertisement* out) {
+  if (!line || !line[0]) return false;
+  return sscanf(line, "proto=%d starttime=%lld ctl=%511s", &out->proto,
+                &out->starttime, out->ctl) >= 1;
+}
+
+// Writes the ctl-ready-<pid> advertisement, including the buffer-sizing
+// keys so the agent can observe workload sizing.
+// Called from the .so's constructor — failures are reported, never fatal:
+// this must not take down the workload. Returns false on write failure.
+inline bool WriteAdvertisement(const char* ctl_dir, pid_t pid, size_t shm_mb,
+                               size_t staging_mb, bool deferred) {
+  char ready_path[512];
+  char content[600];
+  // Both snprintf results are clamped BEFORE open: a truncated advert must
+  // never be written (O_TRUNC would blank a good pre-existing one), and
+  // snprintf returns the would-be length, not the written length.
+  int path_len = snprintf(ready_path, sizeof(ready_path), "%s/ctl-ready-%d",
+                          ctl_dir, static_cast<int>(pid));
+  if (path_len < 0 || path_len >= static_cast<int>(sizeof(ready_path))) {
+    fprintf(stderr, "[vGPU] WARNING: ctl dir too long for advert path (%s)\n",
+            ctl_dir);
+    return false;
+  }
+  int content_len = snprintf(
+      content, sizeof(content),
+      "proto=%d starttime=%lld ctl=%s shm_mb=%zu staging_mb=%zu deferred=%d\n",
+      kCtlProto, ProcStarttime(pid), ctl_dir, shm_mb, staging_mb,
+      deferred ? 1 : 0);
+  if (content_len < 0 || content_len >= static_cast<int>(sizeof(content))) {
+    fprintf(stderr, "[vGPU] WARNING: advert line truncated for %s; not written\n",
+            ready_path);
+    return false;
+  }
+  int fd = open(ready_path, O_CREAT | O_TRUNC | O_WRONLY | O_CLOEXEC, 0644);
+  if (fd < 0) {
+    fprintf(stderr, "[vGPU] WARNING: cannot write %s (%s) — cr_client will "
+                    "refuse ops\n",
+            ready_path, strerror(errno));
+    return false;
+  }
+  bool ok = write(fd, content, content_len) == content_len;
+  if (!ok)
+    fprintf(stderr, "[vGPU] WARNING: short write to %s (%s)\n", ready_path,
+            strerror(errno));
+  close(fd);
+  return ok;
+}
+
+}  // namespace gpu_cr
+
+#endif  // GPU_CR_SRC_CTL_PATH_H_

--- a/third_party/gpu-cr/tests/unit/ctl_path_test.cpp
+++ b/third_party/gpu-cr/tests/unit/ctl_path_test.cpp
@@ -1,9 +1,11 @@
-// Control-plane path resolution, /proc/<pid>/stat parsing, and
-// readiness-advertisement round trip. Linux-only (statfs, /proc).
+// Control-plane path resolution (env override, zero-config discovery,
+// memoization), /proc/<pid>/stat parsing, and readiness-advertisement
+// round trip. Linux-only (statfs, /proc).
 
 #include "ctl_path.h"
 
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include <string>
@@ -18,6 +20,21 @@ class CtlPathTest : public ::testing::Test {
   void SetUp() override {
     unsetenv("GPU_CR_CTL_PATH");
     unsetenv("EXPORT_FILE_PATH");
+    ResetCtlDirCacheForTests();
+  }
+
+  // A data dir on tmpfs: a plain "ctl" subdir inside it satisfies the
+  // containing-filesystem statfs gate, which is exactly the documented
+  // discovery predicate — no mount needed in a unit test.
+  std::string MakeTmpfsDataDir() {
+    char tmpl[] = "/dev/shm/gpu-cr-ctl-path-XXXXXX";
+    if (!mkdtemp(tmpl)) return "";
+    return tmpl;
+  }
+
+  void RemoveDataDir(const std::string& dir) {
+    rmdir((dir + "/" + kCtlSubdir).c_str());
+    rmdir(dir.c_str());
   }
 };
 
@@ -40,6 +57,19 @@ TEST_F(CtlPathTest, DataDirHonorsExportFilePath) {
 TEST_F(CtlPathTest, EmptyExportFilePathTreatedAsUnset) {
   setenv("EXPORT_FILE_PATH", "", 1);
   EXPECT_STREQ(DataDir(), "/mnt/huge-ckpt");
+}
+
+TEST_F(CtlPathTest, CtlCandidatePathIsDataDirSlashCtl) {
+  setenv("EXPORT_FILE_PATH", "/some/dir", 1);
+  char buf[512];
+  ASSERT_TRUE(CtlCandidatePath(buf, sizeof(buf)));
+  EXPECT_STREQ(buf, "/some/dir/ctl");
+}
+
+TEST_F(CtlPathTest, CtlCandidatePathRejectsTruncation) {
+  setenv("EXPORT_FILE_PATH", "/some/dir", 1);
+  char buf[8];
+  EXPECT_FALSE(CtlCandidatePath(buf, sizeof(buf)));
 }
 
 TEST_F(CtlPathTest, CtlDirUnsetIsLegacyMode) {
@@ -66,7 +96,7 @@ TEST_F(CtlPathTest, CtlDirNonTmpfsFallsBackToLegacy) {
 }
 
 // Empty means "unset", same as EXPORT_FILE_PATH — silent legacy, no
-// misconfiguration warning.
+// misconfiguration warning (discovery still probes, finds nothing here).
 TEST_F(CtlPathTest, EmptyCtlPathTreatedAsUnset) {
   setenv("GPU_CR_CTL_PATH", "", 1);
   bool ctl_mode = true;
@@ -83,6 +113,122 @@ TEST_F(CtlPathTest, CtlDirMissingPathFallsBackToLegacy) {
 
 TEST_F(CtlPathTest, DirIsTmpfsFalseForMissingDir) {
   EXPECT_FALSE(DirIsTmpfs("/nonexistent-gpu-cr-test-dir"));
+}
+
+// Zero-config discovery: env unset, <data>/ctl tmpfs-backed -> ctl mode.
+// This is the whole feature: the consumer sets nothing beyond
+// EXPORT_FILE_PATH.
+TEST_F(CtlPathTest, DiscoveryFindsTmpfsCtlSubdir) {
+  if (!DirIsTmpfs("/dev/shm")) GTEST_SKIP() << "/dev/shm is not tmpfs here";
+  std::string data = MakeTmpfsDataDir();
+  ASSERT_FALSE(data.empty());
+  setenv("EXPORT_FILE_PATH", data.c_str(), 1);
+  ASSERT_EQ(mkdir((data + "/" + kCtlSubdir).c_str(), 0777), 0);
+
+  CtlResolution res;
+  ResolveCtlDir(&res);
+  EXPECT_TRUE(res.ctl_mode);
+  EXPECT_EQ(std::string(res.dir), data + "/" + kCtlSubdir);
+
+  RemoveDataDir(data);
+}
+
+// No "ctl" entry in the store -> legacy, even on a tmpfs store.
+TEST_F(CtlPathTest, DiscoveryNeedsCtlSubdir) {
+  if (!DirIsTmpfs("/dev/shm")) GTEST_SKIP() << "/dev/shm is not tmpfs here";
+  std::string data = MakeTmpfsDataDir();
+  ASSERT_FALSE(data.empty());
+  setenv("EXPORT_FILE_PATH", data.c_str(), 1);
+
+  CtlResolution res;
+  ResolveCtlDir(&res);
+  EXPECT_FALSE(res.ctl_mode);
+  EXPECT_EQ(std::string(res.dir), data);
+
+  RemoveDataDir(data);
+}
+
+// A "ctl" subdir on a NON-tmpfs store (stray mkdir on hugetlbfs/disk)
+// must not enable ctl mode.
+TEST_F(CtlPathTest, DiscoveryIgnoresNonTmpfsCtlSubdir) {
+  char tmpl[] = "/tmp/gpu-cr-ctl-path-XXXXXX";
+  ASSERT_NE(mkdtemp(tmpl), nullptr);
+  std::string data = tmpl;
+  if (DirIsTmpfs(data.c_str())) {
+    RemoveDataDir(data);
+    GTEST_SKIP() << "/tmp is tmpfs here";
+  }
+  setenv("EXPORT_FILE_PATH", data.c_str(), 1);
+  ASSERT_EQ(mkdir((data + "/" + kCtlSubdir).c_str(), 0777), 0);
+
+  CtlResolution res;
+  ResolveCtlDir(&res);
+  EXPECT_FALSE(res.ctl_mode);
+  EXPECT_EQ(std::string(res.dir), data);
+
+  RemoveDataDir(data);
+}
+
+// A valid env override beats discovery: the coordinator's explicit
+// configuration is authoritative.
+TEST_F(CtlPathTest, ValidEnvWinsOverDiscovery) {
+  if (!DirIsTmpfs("/dev/shm")) GTEST_SKIP() << "/dev/shm is not tmpfs here";
+  std::string data = MakeTmpfsDataDir();
+  ASSERT_FALSE(data.empty());
+  setenv("EXPORT_FILE_PATH", data.c_str(), 1);
+  ASSERT_EQ(mkdir((data + "/" + kCtlSubdir).c_str(), 0777), 0);
+  setenv("GPU_CR_CTL_PATH", "/dev/shm", 1);
+
+  CtlResolution res;
+  ResolveCtlDir(&res);
+  EXPECT_TRUE(res.ctl_mode);
+  EXPECT_STREQ(res.dir, "/dev/shm");
+
+  RemoveDataDir(data);
+}
+
+// An INVALID env override never falls through to discovery: explicit
+// config must not silently redirect (cr_client refuses in this state, and
+// the .so must agree with that refusal by staying legacy).
+TEST_F(CtlPathTest, InvalidEnvNeverDiscovers) {
+  if (!DirIsTmpfs("/dev/shm")) GTEST_SKIP() << "/dev/shm is not tmpfs here";
+  std::string data = MakeTmpfsDataDir();
+  ASSERT_FALSE(data.empty());
+  setenv("EXPORT_FILE_PATH", data.c_str(), 1);
+  ASSERT_EQ(mkdir((data + "/" + kCtlSubdir).c_str(), 0777), 0);
+  setenv("GPU_CR_CTL_PATH", "/nonexistent-gpu-cr-test-dir", 1);
+
+  CtlResolution res;
+  ResolveCtlDir(&res);
+  EXPECT_FALSE(res.ctl_mode);
+  EXPECT_EQ(std::string(res.dir), data);
+
+  RemoveDataDir(data);
+}
+
+// CtlDir pins the first resolution for the life of the process: a tmpfs
+// appearing later must not split one process across two layouts.
+TEST_F(CtlPathTest, CtlDirMemoizesFirstResolution) {
+  if (!DirIsTmpfs("/dev/shm")) GTEST_SKIP() << "/dev/shm is not tmpfs here";
+  std::string data = MakeTmpfsDataDir();
+  ASSERT_FALSE(data.empty());
+  setenv("EXPORT_FILE_PATH", data.c_str(), 1);
+
+  bool ctl_mode = true;
+  EXPECT_EQ(std::string(CtlDir(&ctl_mode)), data);  // resolves: legacy
+  EXPECT_FALSE(ctl_mode);
+
+  // The candidate appears AFTER first use: still legacy.
+  ASSERT_EQ(mkdir((data + "/" + kCtlSubdir).c_str(), 0777), 0);
+  EXPECT_EQ(std::string(CtlDir(&ctl_mode)), data);
+  EXPECT_FALSE(ctl_mode);
+
+  // Only a fresh process (here: the test reset) re-resolves.
+  ResetCtlDirCacheForTests();
+  EXPECT_EQ(std::string(CtlDir(&ctl_mode)), data + "/" + kCtlSubdir);
+  EXPECT_TRUE(ctl_mode);
+
+  RemoveDataDir(data);
 }
 
 // stat-line fields: pid (comm) state then 18 numbers with the 19th

--- a/third_party/gpu-cr/tests/unit/ctl_path_test.cpp
+++ b/third_party/gpu-cr/tests/unit/ctl_path_test.cpp
@@ -1,0 +1,179 @@
+// Control-plane path resolution, /proc/<pid>/stat parsing, and
+// readiness-advertisement round trip. Linux-only (statfs, /proc).
+
+#include "ctl_path.h"
+
+#include <stdlib.h>
+#include <unistd.h>
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace gpu_cr {
+namespace {
+
+class CtlPathTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    unsetenv("GPU_CR_CTL_PATH");
+    unsetenv("EXPORT_FILE_PATH");
+  }
+};
+
+TEST_F(CtlPathTest, RoundUp4K) {
+  EXPECT_EQ(RoundUp4K(0), 0u);
+  EXPECT_EQ(RoundUp4K(1), 4096u);
+  EXPECT_EQ(RoundUp4K(4096), 4096u);
+  EXPECT_EQ(RoundUp4K(4097), 8192u);
+}
+
+TEST_F(CtlPathTest, DataDirDefaultsToHugeCkpt) {
+  EXPECT_STREQ(DataDir(), "/mnt/huge-ckpt");
+}
+
+TEST_F(CtlPathTest, DataDirHonorsExportFilePath) {
+  setenv("EXPORT_FILE_PATH", "/some/dir", 1);
+  EXPECT_STREQ(DataDir(), "/some/dir");
+}
+
+TEST_F(CtlPathTest, EmptyExportFilePathTreatedAsUnset) {
+  setenv("EXPORT_FILE_PATH", "", 1);
+  EXPECT_STREQ(DataDir(), "/mnt/huge-ckpt");
+}
+
+TEST_F(CtlPathTest, CtlDirUnsetIsLegacyMode) {
+  bool ctl_mode = true;
+  EXPECT_STREQ(CtlDir(&ctl_mode), "/mnt/huge-ckpt");
+  EXPECT_FALSE(ctl_mode);
+}
+
+TEST_F(CtlPathTest, CtlDirTmpfsEnablesCtlMode) {
+  if (!DirIsTmpfs("/dev/shm")) GTEST_SKIP() << "/dev/shm is not tmpfs here";
+  setenv("GPU_CR_CTL_PATH", "/dev/shm", 1);
+  bool ctl_mode = false;
+  EXPECT_STREQ(CtlDir(&ctl_mode), "/dev/shm");
+  EXPECT_TRUE(ctl_mode);
+}
+
+TEST_F(CtlPathTest, CtlDirNonTmpfsFallsBackToLegacy) {
+  if (DirIsTmpfs("/")) GTEST_SKIP() << "/ is tmpfs here";
+  setenv("GPU_CR_CTL_PATH", "/", 1);
+  setenv("EXPORT_FILE_PATH", "/data/dir", 1);
+  bool ctl_mode = true;
+  EXPECT_STREQ(CtlDir(&ctl_mode), "/data/dir");
+  EXPECT_FALSE(ctl_mode);
+}
+
+// Empty means "unset", same as EXPORT_FILE_PATH — silent legacy, no
+// misconfiguration warning.
+TEST_F(CtlPathTest, EmptyCtlPathTreatedAsUnset) {
+  setenv("GPU_CR_CTL_PATH", "", 1);
+  bool ctl_mode = true;
+  EXPECT_STREQ(CtlDir(&ctl_mode), "/mnt/huge-ckpt");
+  EXPECT_FALSE(ctl_mode);
+}
+
+TEST_F(CtlPathTest, CtlDirMissingPathFallsBackToLegacy) {
+  setenv("GPU_CR_CTL_PATH", "/nonexistent-gpu-cr-test-dir", 1);
+  bool ctl_mode = true;
+  EXPECT_STREQ(CtlDir(&ctl_mode), "/mnt/huge-ckpt");
+  EXPECT_FALSE(ctl_mode);
+}
+
+TEST_F(CtlPathTest, DirIsTmpfsFalseForMissingDir) {
+  EXPECT_FALSE(DirIsTmpfs("/nonexistent-gpu-cr-test-dir"));
+}
+
+// stat-line fields: pid (comm) state then 18 numbers with the 19th
+// post-state field (field 22 overall) being starttime.
+TEST_F(CtlPathTest, ParseStarttimeFromStat) {
+  const char* line =
+      "7 (proc) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 9999 555";
+  EXPECT_EQ(ParseStarttimeFromStat(line), 9999);
+}
+
+// comm may contain spaces and parentheses; parsing anchors on the LAST ')'.
+TEST_F(CtlPathTest, ParseStarttimeHandlesHostileComm) {
+  const char* line =
+      "7 (we ird) (name) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 "
+      "4242 555";
+  EXPECT_EQ(ParseStarttimeFromStat(line), 4242);
+}
+
+TEST_F(CtlPathTest, ParseStarttimeRejectsGarbage) {
+  EXPECT_EQ(ParseStarttimeFromStat("not a stat line"), -1);
+  EXPECT_EQ(ParseStarttimeFromStat("7 (proc) S 1 2 3"), -1);  // too few fields
+  EXPECT_EQ(ParseStarttimeFromStat(""), -1);
+}
+
+// A non-numeric field 22 is -1, not a plausible-looking 0.
+TEST_F(CtlPathTest, ParseStarttimeRejectsNonNumericField) {
+  const char* line =
+      "7 (proc) S 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 zzz 555";
+  EXPECT_EQ(ParseStarttimeFromStat(line), -1);
+}
+
+TEST_F(CtlPathTest, ProcStarttimeOfSelfIsPositive) {
+  EXPECT_GT(ProcStarttime(getpid()), 0);
+}
+
+TEST_F(CtlPathTest, ProcStarttimeOfMissingPidIsNegative) {
+  EXPECT_EQ(ProcStarttime(999999999), -1);
+}
+
+TEST_F(CtlPathTest, ParseAdvertisement) {
+  Advertisement adv;
+  ASSERT_TRUE(ParseAdvertisement(
+      "proto=3 starttime=12345 ctl=/dev/shm shm_mb=8192 staging_mb=1024 "
+      "deferred=0\n",
+      &adv));
+  EXPECT_EQ(adv.proto, 3);
+  EXPECT_EQ(adv.starttime, 12345);
+  EXPECT_STREQ(adv.ctl, "/dev/shm");
+}
+
+TEST_F(CtlPathTest, ParseAdvertisementRejectsEmpty) {
+  Advertisement adv;
+  EXPECT_FALSE(ParseAdvertisement("", &adv));
+  EXPECT_FALSE(ParseAdvertisement(nullptr, &adv));
+}
+
+TEST_F(CtlPathTest, ParseAdvertisementDefaultsWhenFieldsMissing) {
+  Advertisement adv;
+  ASSERT_TRUE(ParseAdvertisement("proto=2\n", &adv));
+  EXPECT_EQ(adv.proto, 2);
+  EXPECT_EQ(adv.starttime, -1);
+  EXPECT_STREQ(adv.ctl, "");
+}
+
+TEST_F(CtlPathTest, WriteAdvertisementFailsOnMissingDir) {
+  EXPECT_FALSE(WriteAdvertisement("/nonexistent-gpu-cr-test-dir", getpid(),
+                                  8192, 1024, false));
+}
+
+TEST_F(CtlPathTest, WriteAdvertisementRoundTrip) {
+  char dir_template[] = "/tmp/gpu-cr-ctl-test-XXXXXX";
+  ASSERT_NE(mkdtemp(dir_template), nullptr);
+  ASSERT_TRUE(WriteAdvertisement(dir_template, getpid(), 8192, 1024, false));
+
+  std::string path =
+      std::string(dir_template) + "/ctl-ready-" + std::to_string(getpid());
+  FILE* f = fopen(path.c_str(), "r");
+  ASSERT_NE(f, nullptr);
+  char buf[600] = "";
+  ASSERT_NE(fgets(buf, sizeof(buf), f), nullptr);
+  fclose(f);
+
+  Advertisement adv;
+  ASSERT_TRUE(ParseAdvertisement(buf, &adv));
+  EXPECT_EQ(adv.proto, kCtlProto);
+  EXPECT_EQ(adv.starttime, ProcStarttime(getpid()));
+  EXPECT_STREQ(adv.ctl, dir_template);
+
+  unlink(path.c_str());
+  rmdir(dir_template);
+}
+
+}  // namespace
+}  // namespace gpu_cr

--- a/third_party/gpu-cr/tests/unit/ctl_path_test.cpp
+++ b/third_party/gpu-cr/tests/unit/ctl_path_test.cpp
@@ -206,6 +206,46 @@ TEST_F(CtlPathTest, InvalidEnvNeverDiscovers) {
   RemoveDataDir(data);
 }
 
+// A GPU_CR_CTL_PATH longer than the resolution buffer is INVALID even
+// when it names a real tmpfs dir: the clamp runs before the statfs, so a
+// truncated dir can never silently enable ctl mode (kCtlDirMax contract).
+TEST_F(CtlPathTest, OverlongEnvIsInvalidEvenOnRealTmpfs) {
+  if (!DirIsTmpfs("/dev/shm")) GTEST_SKIP() << "/dev/shm is not tmpfs here";
+  std::string deep = MakeTmpfsDataDir();
+  ASSERT_FALSE(deep.empty());
+  std::string root = deep;
+  std::string level(60, 'd');
+  while (deep.size() < kCtlDirMax + 40) {
+    deep += "/" + level;
+    ASSERT_EQ(mkdir(deep.c_str(), 0777), 0);
+  }
+  ASSERT_TRUE(DirIsTmpfs(deep.c_str()));  // real, reachable tmpfs dir
+  setenv("GPU_CR_CTL_PATH", deep.c_str(), 1);
+
+  CtlResolution res;
+  ResolveCtlDir(&res);
+  EXPECT_FALSE(res.ctl_mode);
+  EXPECT_STREQ(res.dir, "/mnt/huge-ckpt");  // legacy, not a truncated dir
+
+  while (deep.size() > root.size()) {
+    rmdir(deep.c_str());
+    deep.resize(deep.rfind('/'));
+  }
+  rmdir(root.c_str());
+}
+
+// An overlong data dir cannot produce a discovery candidate; resolution
+// clamps into legacy deterministically (prefix copy) instead of misbehaving.
+TEST_F(CtlPathTest, OverlongDataDirFallsBackClamped) {
+  std::string longdata = "/" + std::string(kCtlDirMax + 60, 'x');
+  setenv("EXPORT_FILE_PATH", longdata.c_str(), 1);
+
+  CtlResolution res;
+  ResolveCtlDir(&res);
+  EXPECT_FALSE(res.ctl_mode);
+  EXPECT_EQ(std::string(res.dir), longdata.substr(0, kCtlDirMax - 1));
+}
+
 // CtlDir pins the first resolution for the life of the process: a tmpfs
 // appearing later must not split one process across two layouts.
 TEST_F(CtlPathTest, CtlDirMemoizesFirstResolution) {

--- a/third_party/gpu-cr/tests/unit/share_mem_comm_test.cpp
+++ b/third_party/gpu-cr/tests/unit/share_mem_comm_test.cpp
@@ -13,6 +13,7 @@
 #include <set>
 #include <string>
 
+#include "ctl_path.h"
 #include "gtest/gtest.h"
 
 namespace gpu_cr {
@@ -21,6 +22,7 @@ namespace {
 class ShareMemCommTest : public ::testing::Test {
  protected:
   void SetUp() override {
+    unsetenv("GPU_CR_CTL_PATH");
     strcpy(dir_, "/tmp/gpu-cr-shm-comm-XXXXXX");
     ASSERT_NE(mkdtemp(dir_), nullptr);
     setenv("EXPORT_FILE_PATH", dir_, 1);
@@ -57,6 +59,35 @@ TEST_F(ShareMemCommTest, SetupCreatesControlFile) {
   struct stat st;
   ASSERT_EQ(stat(ControlPath(111).c_str(), &st), 0);
   EXPECT_EQ(st.st_size, static_cast<off_t>(HUGE_PAGE_SIZE));
+  // fchmod(0777): agent container and workload run as different users.
+  EXPECT_EQ(st.st_mode & 07777, 0777u);
+}
+
+// Ctl mode: a tmpfs GPU_CR_CTL_PATH moves the control file off the data
+// dir, and setup() preallocates the stored extent so a full ctl tmpfs
+// fails here instead of as SIGBUS at the first store.
+TEST_F(ShareMemCommTest, SetupUsesCtlDirWhenTmpfs) {
+  if (!DirIsTmpfs("/dev/shm")) GTEST_SKIP() << "/dev/shm is not tmpfs here";
+  char ctl_dir[] = "/dev/shm/gpu-cr-ctl-XXXXXX";
+  ASSERT_NE(mkdtemp(ctl_dir), nullptr);
+  setenv("GPU_CR_CTL_PATH", ctl_dir, 1);
+
+  ShareMemComm comm(666);
+  comm.setup();
+
+  std::string ctl_control = std::string(ctl_dir) + "/control-666";
+  struct stat st;
+  ASSERT_EQ(stat(ctl_control.c_str(), &st), 0);
+  EXPECT_EQ(st.st_size, static_cast<off_t>(HUGE_PAGE_SIZE));
+  // posix_fallocate pinned: at least the stored extent is backed.
+  EXPECT_GE(static_cast<size_t>(st.st_blocks) * 512,
+            RoundUp4K(sizeof(signal_controls)));
+  // The data dir must NOT grow a control file in ctl mode.
+  EXPECT_NE(stat(ControlPath(666).c_str(), &st), 0);
+
+  unlink(ctl_control.c_str());
+  rmdir(ctl_dir);
+  unsetenv("GPU_CR_CTL_PATH");
 }
 
 // A fresh (zero-filled) mapping reads FINISH: cr_client relies on an idle

--- a/third_party/gpu-cr/tests/unit/share_mem_comm_test.cpp
+++ b/third_party/gpu-cr/tests/unit/share_mem_comm_test.cpp
@@ -23,6 +23,9 @@ class ShareMemCommTest : public ::testing::Test {
  protected:
   void SetUp() override {
     unsetenv("GPU_CR_CTL_PATH");
+    // CtlDir memoizes per process; each test must re-resolve under its
+    // own layout.
+    ResetCtlDirCacheForTests();
     strcpy(dir_, "/tmp/gpu-cr-shm-comm-XXXXXX");
     ASSERT_NE(mkdtemp(dir_), nullptr);
     setenv("EXPORT_FILE_PATH", dir_, 1);
@@ -88,6 +91,37 @@ TEST_F(ShareMemCommTest, SetupUsesCtlDirWhenTmpfs) {
   unlink(ctl_control.c_str());
   rmdir(ctl_dir);
   unsetenv("GPU_CR_CTL_PATH");
+}
+
+// Zero-config discovery: with NO env at all, a tmpfs-backed <data>/ctl
+// subdir is found through the data dir the workload already has, and
+// setup() puts the control file there — the consumer-side contract stays
+// LD_PRELOAD + EXPORT_FILE_PATH only.
+TEST_F(ShareMemCommTest, SetupDiscoversNestedCtlDir) {
+  if (!DirIsTmpfs("/dev/shm")) GTEST_SKIP() << "/dev/shm is not tmpfs here";
+  char data_dir[] = "/dev/shm/gpu-cr-data-XXXXXX";
+  ASSERT_NE(mkdtemp(data_dir), nullptr);
+  setenv("EXPORT_FILE_PATH", data_dir, 1);
+  std::string nested = std::string(data_dir) + "/" + kCtlSubdir;
+  ASSERT_EQ(mkdir(nested.c_str(), 0777), 0);
+  ResetCtlDirCacheForTests();  // EXPORT_FILE_PATH changed after SetUp
+
+  ShareMemComm comm(777);
+  comm.setup();
+
+  std::string ctl_control = nested + "/control-777";
+  struct stat st;
+  ASSERT_EQ(stat(ctl_control.c_str(), &st), 0);
+  EXPECT_EQ(st.st_size, static_cast<off_t>(HUGE_PAGE_SIZE));
+  // posix_fallocate pinned: at least the stored extent is backed.
+  EXPECT_GE(static_cast<size_t>(st.st_blocks) * 512,
+            RoundUp4K(sizeof(signal_controls)));
+  // The data dir root must NOT grow a control file in ctl mode.
+  EXPECT_NE(stat((std::string(data_dir) + "/control-777").c_str(), &st), 0);
+
+  unlink(ctl_control.c_str());
+  rmdir(nested.c_str());
+  rmdir(data_dir);
 }
 
 // A fresh (zero-filled) mapping reads FINISH: cr_client relies on an idle


### PR DESCRIPTION
## What does this PR do?

GPU-CR control files (`control-<pid>`, the readiness advertisement, the id counter) currently live in the checkpoint
  directory, which is hugetlbfs. This PR moves them onto a tmpfs.

  It works in three pieces:

  1. **A single resolver, `src/ctl_path.h::CtlDir()`.** Every place that needs the control dir now asks this one 
  function instead of reading `EXPORT_FILE_PATH` directly. It picks the directory in this order:
     - `GPU_CR_CTL_PATH` set and tmpfs-backed → use it (explicit override, coordinator side).
     - `GPU_CR_CTL_PATH` set but missing/not-tmpfs/too long → warn and fall back to the legacy dir. Explicit config is
  never silently redirected, and `cr_client` refuses to operate in this state.
     - Env unset and `<checkpoint dir>/ctl` is tmpfs-backed → use it. This is the zero-config discovery step: one 
  `statfs` call, checking for the tmpfs filesystem magic. The snapshot-agent daemonset mounts this tmpfs inside the 
  checkpoint dir the workload already mounts, so the workload sees it through its existing volume — no new env var, no
  new volume.
     - Otherwise → legacy: control dir = checkpoint dir, byte-for-byte today's behavior.

     The result is cached on first use, which in `vGPU.so` happens in the library constructor. So a process decides 
  its layout once, at load, and can never end up half in one directory and half in another if a tmpfs appears later.

  2. **`share_mem.cpp` switches to the resolver.** `ShareMemComm::setup()` creates `control-<pid>` in `CtlDir()`
  instead of the checkpoint dir. Because tmpfs, unlike hugetlbfs, reserves nothing at `ftruncate`/`mmap`, a full tmpfs
  would otherwise surface as SIGBUS on first write — so in ctl mode we `posix_fallocate` the stored extent up front,
  and a full tmpfs becomes a clean coordinator-side error instead. The 0777 control-file mode also moves from a
  `Dockerfile.build` sed patch into the source (the sed target line no longer exists).

  3. **A readiness advertisement.** In ctl mode the .so writes `ctl-ready-<pid>` (proto version, process start time,
  ctl path) as the last step of its constructor, after all signal handlers are installed. `cr_client` requires this
  file before sending any signal, and the start-time field rejects recycled PIDs. It is never written in legacy mode,
  so a mixed setup (tmpfs mounted after the workload started) fails loudly at the coordinator instead of
  mis-signaling.

  Unit tests cover the resolution order, the memoization, the too-long-path edge cases, and the advertisement
  round-trip.

  This PR carries only the resolver (`ctl_path.h`), the `share_mem.cpp` hookup, and unit tests. The daemonset/helm
  change and integration tests land in later PRs in the chain.

<!-- Describe the changes and their purpose -->

## Why is this change needed?

1. Removes dependency of the snapshot-agent on hugepages. Without that dependency, the snapshot-agent daemonset  can setup hugepages in the init container on GPU nodes that were not created with hugepages set up. 
  2. Control files on hugetlbfs fault 2Mi hugepages from whichever process touches them. When that's the snapshot
  agent, it gets OOM-killed by its own hugetlb cgroup limit. Small metadata files should not cost hugepages.
  3. Every required workload-side setting is adoption friction. Before this, fixing (1) meant every workload pod
  adding a `GPU_CR_CTL_PATH` env and a ctl volume. With discovery, the integration contract for a workload stays
  exactly `LD_PRELOAD` + `EXPORT_FILE_PATH`, and all setup moves to the snapshot-agent daemonset — which we control.
  Its init containers already mount the hugetlbfs checkpoint dir; they now additionally mount the ctl tmpfs at
  `<checkpoint dir>/ctl` (in that order, so the tmpfs isn't shadowed), and every workload inherits it through the
  volume it already mounts.


<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic control-directory discovery, including tmpfs support and explicit path configuration.
  - Added readiness advertisements for sharing control-channel details.
  - Control files now use permissions that support access across different users.
  - Added preallocation and clearer error reporting for control storage.
  - Added integration test coverage using a simulated workload.

- **Bug Fixes**
  - Invalid control paths now fall back safely to the data directory with a warning.

- **Tests**
  - Added coverage for path resolution, configuration overrides, readiness advertisements, and control-channel setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->