### PR TITLE
[Snapshot-Agent Memory-Regions 4/N]: Python Client & Configs

### DIFF
--- a/pkg/client/python/README.md
+++ b/pkg/client/python/README.md
@@ -40,6 +40,59 @@ with SnapshotAgentClient(endpoint="localhost:9001") as client:
     print(f"Snapshot finished with status: {result.status}")
 ```
 
+### Memory-Regions Backend
+
+To selectively snapshot/restore explicit device-memory ranges of a running
+process (GPU-CR memory-regions backend), build the config with
+`memory_regions_config`. Regions can be `MemoryRegion` dataclasses,
+`(pid, address, size_bytes)` tuples, or `"pid:0xADDR:size"` strings;
+hex and decimal addresses are both accepted.
+
+`snapshot_name` names the agent-side snapshot slot (it defaults to the
+`job_id` when empty). Distinct names let multiple snapshots of the same
+process coexist and be swapped on demand. Use `snapshot_name` — not the
+request's `group` — for slot naming; `group` is orchestrator-owned.
+
+```python
+from timeslice.snapshot_agent import (
+    MemoryRegion,
+    SnapshotAgentClient,
+    memory_regions_config,
+)
+
+with SnapshotAgentClient(endpoint="localhost:9001") as client:
+    regions = [MemoryRegion(pid=12345, address=0x7F0000000000, size_bytes=1 << 30)]
+
+    # Save the regions into slot "slot-a"...
+    result = client.snapshot_and_wait(
+        job_id="my-job",
+        backend_config=memory_regions_config(regions, snapshot_name="slot-a"),
+    )
+    print(f"Snapshot finished with status: {result.status}")
+
+    # ...and load them back later (possibly alternating with other slots).
+    result = client.restore_and_wait(
+        job_id="my-job",
+        backend_config=memory_regions_config(regions, snapshot_name="slot-a"),
+    )
+    print(f"Restore finished with status: {result.status}")
+```
+
+The three region forms are interchangeable (and can be mixed in one call):
+
+```python
+# MemoryRegion dataclass
+config = memory_regions_config(
+    [MemoryRegion(pid=12345, address=0x7F0000000000, size_bytes=1 << 30)]
+)
+
+# (pid, address, size_bytes) tuple
+config = memory_regions_config([(12345, 0x7F0000000000, 1 << 30)])
+
+# "pid:address:size" string; address and size accept hex or decimal
+config = memory_regions_config(["12345:0x7F0000000000:1073741824"])
+```
+
 ---
 
 ## Development

--- a/pkg/client/python/README.md
+++ b/pkg/client/python/README.md
@@ -50,8 +50,10 @@ hex and decimal addresses are both accepted.
 
 `snapshot_name` names the agent-side snapshot slot (it defaults to the
 `job_id` when empty). Distinct names let multiple snapshots of the same
-process coexist and be swapped on demand. Use `snapshot_name` — not the
-request's `group` — for slot naming; `group` is orchestrator-owned.
+process coexist and be swapped on demand. The name becomes a directory
+on the agent, so it may only contain letters, digits, `-` and `_`. Use
+`snapshot_name` — not the request's `group` — for slot naming; `group`
+is orchestrator-owned.
 
 ```python
 from timeslice.snapshot_agent import (

--- a/pkg/client/python/tests/test_configs.py
+++ b/pkg/client/python/tests/test_configs.py
@@ -3,10 +3,12 @@
 import unittest
 
 from timeslice.snapshot_agent import (
+    MemoryRegion,
     app_channel_config,
     app_endpoint_config,
     cuda_config,
     direct_memory_config,
+    memory_regions_config,
     sglang_config,
     vllm_config,
 )
@@ -60,6 +62,19 @@ class TestBackendConfigBuilders(unittest.TestCase):
                 cuda_config(pids)
             with self.assertRaises((ValueError, TypeError)):
                 direct_memory_config(pids)
+
+    def test_memory_regions_config_builds_regions(self):
+        """Regions and snapshot_name land in the memory_regions oneof."""
+        cfg = memory_regions_config(
+            [MemoryRegion(pid=123, address=0x7F00, size_bytes=1024)],
+            snapshot_name="slot-a",
+        )
+        self.assertEqual(cfg.WhichOneof("backend"), "memory_regions")
+        self.assertEqual(cfg.memory_regions.snapshot_name, "slot-a")
+        region = cfg.memory_regions.regions[0]
+        self.assertEqual(region.pid, 123)
+        self.assertEqual(region.address, 0x7F00)
+        self.assertEqual(region.size_bytes, 1024)
 
     def test_app_endpoint_config_builds_full_config(self):
         cfg = app_endpoint_config(

--- a/pkg/client/python/tests/test_memory_regions.py
+++ b/pkg/client/python/tests/test_memory_regions.py
@@ -1,29 +1,40 @@
-import pytest
+"""Tests for the MemoryRegion type and the memory-regions config builder."""
+
+import unittest
 
 from timeslice.snapshot_agent import MemoryRegion, memory_regions_config
 from timeslice.snapshot_agent import snapshot_agent_pb2
 
 
-class TestMemoryRegionFromSpec:
-    @pytest.mark.parametrize(
-        "spec,expected",
-        [
-            ("123:0x7f00:1024", MemoryRegion(pid=123, address=0x7F00, size_bytes=1024)),
-            (
-                "123:139637976727552:1073741824",
-                MemoryRegion(pid=123, address=139637976727552, size_bytes=1073741824),
-            ),
-            ("1:0x0:1", MemoryRegion(pid=1, address=0, size_bytes=1)),
-            # hex size accepted too
-            ("42:0xABCD:0x100", MemoryRegion(pid=42, address=0xABCD, size_bytes=256)),
-        ],
-    )
-    def test_valid_specs(self, spec, expected):
-        assert MemoryRegion.from_spec(spec) == expected
+class TestMemoryRegionFromSpec(unittest.TestCase):
+    def test_parses_hex_address(self):
+        self.assertEqual(
+            MemoryRegion.from_spec("123:0x7f00:1024"),
+            MemoryRegion(pid=123, address=0x7F00, size_bytes=1024),
+        )
 
-    @pytest.mark.parametrize(
-        "spec",
-        [
+    def test_parses_decimal_address(self):
+        self.assertEqual(
+            MemoryRegion.from_spec("123:139637976727552:1073741824"),
+            MemoryRegion(pid=123, address=139637976727552, size_bytes=1073741824),
+        )
+
+    def test_parses_zero_address(self):
+        self.assertEqual(
+            MemoryRegion.from_spec("1:0x0:1"),
+            MemoryRegion(pid=1, address=0, size_bytes=1),
+        )
+
+    def test_parses_hex_size(self):
+        """Size accepts hex literals, not just the address."""
+        self.assertEqual(
+            MemoryRegion.from_spec("42:0xABCD:0x100"),
+            MemoryRegion(pid=42, address=0xABCD, size_bytes=256),
+        )
+
+    def test_rejects_malformed_specs(self):
+        """Wrong field count or non-numeric fields are a ValueError."""
+        for spec in (
             "invalid-format",
             "123:0x7f00",  # missing size
             "123:0x7f00:1024:extra",
@@ -31,83 +42,101 @@ class TestMemoryRegionFromSpec:
             "123:zz:1024",  # bad address
             "123:0x7f00:big",  # bad size
             "",
-        ],
-    )
-    def test_invalid_specs(self, spec):
-        with pytest.raises(ValueError):
-            MemoryRegion.from_spec(spec)
-
-    @pytest.mark.parametrize(
-        "kwargs",
-        [
-            dict(pid=0, address=1, size_bytes=1),
-            dict(pid=-1, address=1, size_bytes=1),
-            dict(pid=1, address=-1, size_bytes=1),
-            dict(pid=1, address=1, size_bytes=0),
-            dict(pid=1, address=1, size_bytes=-5),
-        ],
-    )
-    def test_validation(self, kwargs):
-        with pytest.raises(ValueError):
-            MemoryRegion(**kwargs)
+        ):
+            with self.assertRaises(ValueError):
+                MemoryRegion.from_spec(spec)
 
 
-class TestMemoryRegionsConfig:
-    @pytest.mark.parametrize(
-        "regions",
-        [
+class TestMemoryRegionValidation(unittest.TestCase):
+    def test_rejects_non_positive_pid(self):
+        for pid in (0, -1):
+            with self.assertRaises(ValueError):
+                MemoryRegion(pid=pid, address=1, size_bytes=1)
+
+    def test_rejects_negative_address(self):
+        with self.assertRaises(ValueError):
+            MemoryRegion(pid=1, address=-1, size_bytes=1)
+
+    def test_rejects_non_positive_size(self):
+        for size_bytes in (0, -5):
+            with self.assertRaises(ValueError):
+                MemoryRegion(pid=1, address=1, size_bytes=size_bytes)
+
+
+class TestMemoryRegionsConfig(unittest.TestCase):
+    def test_builds_config_from_dataclasses(self):
+        cfg = memory_regions_config(
             [MemoryRegion(pid=123, address=0x7F00, size_bytes=1024)],
-            [(123, 0x7F00, 1024)],
-            ["123:0x7f00:1024"],
-            # mixed input kinds
+            snapshot_name="slot-a",
+        )
+        self.assertEqual(cfg.WhichOneof("backend"), "memory_regions")
+        self.assertEqual(cfg.memory_regions.snapshot_name, "slot-a")
+        self.assertEqual(len(cfg.memory_regions.regions), 1)
+        region = cfg.memory_regions.regions[0]
+        self.assertEqual(region.pid, 123)
+        self.assertEqual(region.address, 0x7F00)
+        self.assertEqual(region.size_bytes, 1024)
+
+    def test_builds_config_from_tuples(self):
+        cfg = memory_regions_config([(123, 0x7F00, 1024)])
+        region = cfg.memory_regions.regions[0]
+        self.assertEqual(region.pid, 123)
+        self.assertEqual(region.address, 0x7F00)
+        self.assertEqual(region.size_bytes, 1024)
+
+    def test_builds_config_from_spec_strings(self):
+        cfg = memory_regions_config(["123:0x7f00:1024"])
+        region = cfg.memory_regions.regions[0]
+        self.assertEqual(region.pid, 123)
+        self.assertEqual(region.address, 0x7F00)
+        self.assertEqual(region.size_bytes, 1024)
+
+    def test_builds_config_from_mixed_region_kinds(self):
+        """Dataclasses, tuples, and spec strings can be mixed in one call."""
+        cfg = memory_regions_config(
             [
                 MemoryRegion(pid=123, address=0x7F00, size_bytes=1024),
                 (123, 0x8F00, 2048),
                 "456:0x9f00:4096",
-            ],
-        ],
-    )
-    def test_builds_backend_config(self, regions):
-        config = memory_regions_config(regions, snapshot_name="slot-a")
-        assert isinstance(config, snapshot_agent_pb2.BackendConfig)
-        assert config.WhichOneof("backend") == "memory_regions"
-        assert config.memory_regions.snapshot_name == "slot-a"
-        assert len(config.memory_regions.regions) == len(regions)
-        first = config.memory_regions.regions[0]
-        assert first.pid == 123
-        assert first.address == 0x7F00
-        assert first.size_bytes == 1024
+            ]
+        )
+        self.assertEqual(len(cfg.memory_regions.regions), 3)
+        self.assertEqual(cfg.memory_regions.regions[1].address, 0x8F00)
+        self.assertEqual(cfg.memory_regions.regions[2].pid, 456)
 
     def test_snapshot_name_defaults_to_empty(self):
-        config = memory_regions_config([(1, 0x10, 16)])
-        assert config.memory_regions.snapshot_name == ""
+        """Empty snapshot_name defers slot naming to the agent (job_id)."""
+        cfg = memory_regions_config([(1, 0x10, 16)])
+        self.assertEqual(cfg.memory_regions.snapshot_name, "")
 
     def test_large_address_round_trips(self):
-        addr = 139637976727552  # > 2**32: uint64 on the wire
-        config = memory_regions_config([(123, addr, 2**33)])
-        assert config.memory_regions.regions[0].address == addr
-        assert config.memory_regions.regions[0].size_bytes == 2**33
-        # serialization round-trip
-        parsed = snapshot_agent_pb2.BackendConfig.FromString(
-            config.SerializeToString()
-        )
-        assert parsed.memory_regions.regions[0].address == addr
+        """Addresses above 2**32 survive serialization (uint64 on the wire)."""
+        addr = 139637976727552
+        cfg = memory_regions_config([(123, addr, 2**33)])
+        self.assertEqual(cfg.memory_regions.regions[0].address, addr)
+        self.assertEqual(cfg.memory_regions.regions[0].size_bytes, 2**33)
+        parsed = snapshot_agent_pb2.BackendConfig.FromString(cfg.SerializeToString())
+        self.assertEqual(parsed.memory_regions.regions[0].address, addr)
 
-    @pytest.mark.parametrize("regions", [[], None])
-    def test_empty_regions_rejected(self, regions):
-        with pytest.raises(ValueError, match="at least one memory region"):
-            memory_regions_config(regions)
+    def test_rejects_empty_regions(self):
+        for regions in ([], None):
+            with self.assertRaisesRegex(ValueError, "at least one memory region"):
+                memory_regions_config(regions)
 
-    @pytest.mark.parametrize(
-        "region,exc",
-        [
-            ("bad-spec", ValueError),
-            ((1, 2), ValueError),  # wrong arity
-            ((0, 2, 3), ValueError),  # zero pid
-            ((1, 2, 0), ValueError),  # zero size
-            (12345, TypeError),  # unsupported type
-        ],
-    )
-    def test_invalid_regions_rejected(self, region, exc):
-        with pytest.raises(exc):
-            memory_regions_config([region])
+    def test_rejects_invalid_regions(self):
+        for region in (
+            "bad-spec",
+            (1, 2),  # wrong arity
+            (0, 2, 3),  # zero pid
+            (1, 2, 0),  # zero size
+        ):
+            with self.assertRaises(ValueError):
+                memory_regions_config([region])
+
+    def test_rejects_unsupported_region_type(self):
+        with self.assertRaises(TypeError):
+            memory_regions_config([12345])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pkg/client/python/tests/test_memory_regions.py
+++ b/pkg/client/python/tests/test_memory_regions.py
@@ -1,0 +1,113 @@
+import pytest
+
+from timeslice.snapshot_agent import MemoryRegion, memory_regions_config
+from timeslice.snapshot_agent import snapshot_agent_pb2
+
+
+class TestMemoryRegionFromSpec:
+    @pytest.mark.parametrize(
+        "spec,expected",
+        [
+            ("123:0x7f00:1024", MemoryRegion(pid=123, address=0x7F00, size_bytes=1024)),
+            (
+                "123:139637976727552:1073741824",
+                MemoryRegion(pid=123, address=139637976727552, size_bytes=1073741824),
+            ),
+            ("1:0x0:1", MemoryRegion(pid=1, address=0, size_bytes=1)),
+            # hex size accepted too
+            ("42:0xABCD:0x100", MemoryRegion(pid=42, address=0xABCD, size_bytes=256)),
+        ],
+    )
+    def test_valid_specs(self, spec, expected):
+        assert MemoryRegion.from_spec(spec) == expected
+
+    @pytest.mark.parametrize(
+        "spec",
+        [
+            "invalid-format",
+            "123:0x7f00",  # missing size
+            "123:0x7f00:1024:extra",
+            "abc:0x7f00:1024",  # non-numeric pid
+            "123:zz:1024",  # bad address
+            "123:0x7f00:big",  # bad size
+            "",
+        ],
+    )
+    def test_invalid_specs(self, spec):
+        with pytest.raises(ValueError):
+            MemoryRegion.from_spec(spec)
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            dict(pid=0, address=1, size_bytes=1),
+            dict(pid=-1, address=1, size_bytes=1),
+            dict(pid=1, address=-1, size_bytes=1),
+            dict(pid=1, address=1, size_bytes=0),
+            dict(pid=1, address=1, size_bytes=-5),
+        ],
+    )
+    def test_validation(self, kwargs):
+        with pytest.raises(ValueError):
+            MemoryRegion(**kwargs)
+
+
+class TestMemoryRegionsConfig:
+    @pytest.mark.parametrize(
+        "regions",
+        [
+            [MemoryRegion(pid=123, address=0x7F00, size_bytes=1024)],
+            [(123, 0x7F00, 1024)],
+            ["123:0x7f00:1024"],
+            # mixed input kinds
+            [
+                MemoryRegion(pid=123, address=0x7F00, size_bytes=1024),
+                (123, 0x8F00, 2048),
+                "456:0x9f00:4096",
+            ],
+        ],
+    )
+    def test_builds_backend_config(self, regions):
+        config = memory_regions_config(regions, snapshot_name="slot-a")
+        assert isinstance(config, snapshot_agent_pb2.BackendConfig)
+        assert config.WhichOneof("backend") == "memory_regions"
+        assert config.memory_regions.snapshot_name == "slot-a"
+        assert len(config.memory_regions.regions) == len(regions)
+        first = config.memory_regions.regions[0]
+        assert first.pid == 123
+        assert first.address == 0x7F00
+        assert first.size_bytes == 1024
+
+    def test_snapshot_name_defaults_to_empty(self):
+        config = memory_regions_config([(1, 0x10, 16)])
+        assert config.memory_regions.snapshot_name == ""
+
+    def test_large_address_round_trips(self):
+        addr = 139637976727552  # > 2**32: uint64 on the wire
+        config = memory_regions_config([(123, addr, 2**33)])
+        assert config.memory_regions.regions[0].address == addr
+        assert config.memory_regions.regions[0].size_bytes == 2**33
+        # serialization round-trip
+        parsed = snapshot_agent_pb2.BackendConfig.FromString(
+            config.SerializeToString()
+        )
+        assert parsed.memory_regions.regions[0].address == addr
+
+    @pytest.mark.parametrize("regions", [[], None])
+    def test_empty_regions_rejected(self, regions):
+        with pytest.raises(ValueError, match="at least one memory region"):
+            memory_regions_config(regions)
+
+    @pytest.mark.parametrize(
+        "region,exc",
+        [
+            ("bad-spec", ValueError),
+            ((1, 2), ValueError),  # wrong arity
+            ((0, 2, 3), ValueError),  # zero pid
+            ((1, 2, 0), ValueError),  # zero size
+            (12345, TypeError),  # unsupported type
+        ],
+    )
+    def test_invalid_regions_rejected(self, region, exc):
+        with pytest.raises(exc):
+            memory_regions_config([region])

--- a/pkg/client/python/tests/test_memory_regions.py
+++ b/pkg/client/python/tests/test_memory_regions.py
@@ -62,6 +62,39 @@ class TestMemoryRegionValidation(unittest.TestCase):
             with self.assertRaises(ValueError):
                 MemoryRegion(pid=1, address=1, size_bytes=size_bytes)
 
+    def test_accepts_wire_format_maxima(self):
+        """The largest representable values (int32 pid, uint64 fields) pass."""
+        region = MemoryRegion(pid=2**31 - 1, address=2**64 - 1, size_bytes=2**64 - 1)
+        self.assertEqual(region.pid, 2**31 - 1)
+        self.assertEqual(region.address, 2**64 - 1)
+        self.assertEqual(region.size_bytes, 2**64 - 1)
+
+    def test_rejects_pid_above_int32(self):
+        with self.assertRaises(ValueError):
+            MemoryRegion(pid=2**31, address=1, size_bytes=1)
+
+    def test_rejects_address_above_uint64(self):
+        with self.assertRaises(ValueError):
+            MemoryRegion(pid=1, address=2**64, size_bytes=1)
+
+    def test_rejects_size_above_uint64(self):
+        with self.assertRaises(ValueError):
+            MemoryRegion(pid=1, address=1, size_bytes=2**64)
+
+    def test_rejects_non_integer_fields(self):
+        """Non-int values (including bool, an int subclass) are a TypeError."""
+        for kwargs in (
+            {"pid": 1.5, "address": 1, "size_bytes": 1},
+            {"pid": "1", "address": 1, "size_bytes": 1},
+            {"pid": True, "address": 1, "size_bytes": 1},
+            {"pid": 1, "address": 1.0, "size_bytes": 1},
+            {"pid": 1, "address": True, "size_bytes": 1},
+            {"pid": 1, "address": 1, "size_bytes": "1024"},
+            {"pid": 1, "address": 1, "size_bytes": True},
+        ):
+            with self.assertRaises(TypeError):
+                MemoryRegion(**kwargs)
+
 
 class TestMemoryRegionsConfig(unittest.TestCase):
     def test_builds_config_from_dataclasses(self):

--- a/pkg/client/python/tests/test_memory_regions.py
+++ b/pkg/client/python/tests/test_memory_regions.py
@@ -155,9 +155,17 @@ class TestMemoryRegionsConfig(unittest.TestCase):
             "slot/a",  # forward slash (nested path)
             "slot\\a",  # backslash
             "slot:a",  # colon
-            "slot a",  # whitespace
-            " slot-a",
-            "slot-a\n",
+            "slot a",  # interior whitespace
+            " slot-a",  # leading whitespace
+            "slot-a ",  # trailing whitespace
+            "\tslot-a",
+            "slot-a\t",
+            "slot-a\n",  # trailing newline (the $-anchor blind spot)
+            " ",  # all-whitespace
+            "   ",
+            "\t",
+            "\n",
+            "\r\n",
             "..",  # traversal
             ".",
             "../../etc",

--- a/pkg/client/python/tests/test_memory_regions.py
+++ b/pkg/client/python/tests/test_memory_regions.py
@@ -142,6 +142,35 @@ class TestMemoryRegionsConfig(unittest.TestCase):
         cfg = memory_regions_config([(1, 0x10, 16)])
         self.assertEqual(cfg.memory_regions.snapshot_name, "")
 
+    def test_accepts_safe_snapshot_names(self):
+        """Letters, digits, '-' and '_' are the allowed slot-name charset."""
+        for name in ("slot-a", "Slot_B", "0", "a-b_c-42"):
+            cfg = memory_regions_config([(1, 0x10, 16)], snapshot_name=name)
+            self.assertEqual(cfg.memory_regions.snapshot_name, name)
+
+    def test_rejects_unsafe_snapshot_names(self):
+        """snapshot_name becomes a directory on the agent: path separators,
+        traversal, and shell-hostile characters are rejected client-side."""
+        for name in (
+            "slot/a",  # forward slash (nested path)
+            "slot\\a",  # backslash
+            "slot:a",  # colon
+            "slot a",  # whitespace
+            " slot-a",
+            "slot-a\n",
+            "..",  # traversal
+            ".",
+            "../../etc",
+            "slot.a",  # dot
+        ):
+            with self.assertRaisesRegex(ValueError, "snapshot_name"):
+                memory_regions_config([(1, 0x10, 16)], snapshot_name=name)
+
+    def test_rejects_non_string_snapshot_name(self):
+        for name in (123, None, b"slot-a"):
+            with self.assertRaises(TypeError):
+                memory_regions_config([(1, 0x10, 16)], snapshot_name=name)
+
     def test_large_address_round_trips(self):
         """Addresses above 2**32 survive serialization (uint64 on the wire)."""
         addr = 139637976727552

--- a/pkg/client/python/timeslice/snapshot_agent/__init__.py
+++ b/pkg/client/python/timeslice/snapshot_agent/__init__.py
@@ -4,18 +4,22 @@ from .configs import (
     app_endpoint_config,
     cuda_config,
     direct_memory_config,
+    memory_regions_config,
     sglang_config,
     vllm_config,
 )
+from .types import MemoryRegion
 from .workload import WorkloadHandle, register_workload
 
 __all__ = [
+    "MemoryRegion",
     "SnapshotAgentClient",
     "WorkloadHandle",
     "app_channel_config",
     "app_endpoint_config",
     "cuda_config",
     "direct_memory_config",
+    "memory_regions_config",
     "register_workload",
     "sglang_config",
     "vllm_config",

--- a/pkg/client/python/timeslice/snapshot_agent/configs.py
+++ b/pkg/client/python/timeslice/snapshot_agent/configs.py
@@ -178,7 +178,8 @@ def memory_regions_config(
     Accepts MemoryRegion dataclasses, (pid, address, size_bytes) tuples, or
     'pid:0xADDR:size' spec strings. Hex or decimal addresses are
     accepted; validation mirrors the agent's (non-empty regions, positive
-    pid and size).
+    pid and size) plus the wire-format bounds (int32 pid, uint64 address
+    and size).
 
     snapshot_name names the agent-side snapshot slot (defaults to the
     request's job_id server-side when empty). Use it — not the request's

--- a/pkg/client/python/timeslice/snapshot_agent/configs.py
+++ b/pkg/client/python/timeslice/snapshot_agent/configs.py
@@ -1,8 +1,11 @@
 """Helpers for building BackendConfig protos."""
 
-from typing import Optional, Sequence, Union
+from typing import Optional, Sequence, Tuple, Union
 
 from . import snapshot_agent_pb2
+from .types import MemoryRegion
+
+RegionLike = Union[MemoryRegion, Tuple[int, int, int], str]
 
 
 def _process_target(pids: Sequence[int]) -> snapshot_agent_pb2.ProcessTarget:
@@ -162,5 +165,55 @@ def app_channel_config(
     return snapshot_agent_pb2.BackendConfig(
         app_channel=snapshot_agent_pb2.AppChannelConfig(
             mode=_suspend_mode(mode), tags=_tags(tags)
+        )
+    )
+
+
+def memory_regions_config(
+    regions: Sequence[RegionLike],
+    snapshot_name: str = "",
+) -> snapshot_agent_pb2.BackendConfig:
+    """Builds a BackendConfig selecting the memory-regions backend.
+
+    Accepts MemoryRegion dataclasses, (pid, address, size_bytes) tuples, or
+    'pid:0xADDR:size' spec strings. Hex or decimal addresses are
+    accepted; validation mirrors the agent's (non-empty regions, positive
+    pid and size).
+
+    snapshot_name names the agent-side snapshot slot (defaults to the
+    request's job_id server-side when empty). Use it — not the request's
+    `group` — for slot naming: group identifies a set of related jobs for
+    the orchestrator and does not name agent-side storage.
+    """
+    if not regions:
+        raise ValueError("at least one memory region is required")
+
+    pb_regions = []
+    for region in regions:
+        if isinstance(region, MemoryRegion):
+            r = region
+        elif isinstance(region, str):
+            r = MemoryRegion.from_spec(region)
+        elif isinstance(region, tuple):
+            if len(region) != 3:
+                raise ValueError(
+                    f"memory region tuple must be (pid, address, size_bytes), got {region!r}"
+                )
+            r = MemoryRegion(pid=region[0], address=region[1], size_bytes=region[2])
+        else:
+            raise TypeError(
+                "memory region must be a MemoryRegion, (pid, address, size_bytes) "
+                f"tuple, or 'pid:0xADDR:size' string, got {type(region).__name__}"
+            )
+        pb_regions.append(
+            snapshot_agent_pb2.MemoryRegion(
+                pid=r.pid, address=r.address, size_bytes=r.size_bytes
+            )
+        )
+
+    return snapshot_agent_pb2.BackendConfig(
+        memory_regions=snapshot_agent_pb2.MemoryRegionsBackendConfig(
+            regions=pb_regions,
+            snapshot_name=snapshot_name,
         )
     )

--- a/pkg/client/python/timeslice/snapshot_agent/configs.py
+++ b/pkg/client/python/timeslice/snapshot_agent/configs.py
@@ -1,11 +1,18 @@
 """Helpers for building BackendConfig protos."""
 
+import re
 from typing import Optional, Sequence, Tuple, Union
 
 from . import snapshot_agent_pb2
 from .types import MemoryRegion
 
 RegionLike = Union[MemoryRegion, Tuple[int, int, int], str]
+
+# The agent uses the snapshot slot name as a directory name under its
+# store, so restrict it to characters that are safe as a single path
+# segment on any filesystem. Matched with fullmatch: unlike "$", it does
+# not tolerate a trailing newline.
+_SNAPSHOT_NAME_RE = re.compile(r"[A-Za-z0-9_-]+")
 
 
 def _process_target(pids: Sequence[int]) -> snapshot_agent_pb2.ProcessTarget:
@@ -182,10 +189,21 @@ def memory_regions_config(
     and size).
 
     snapshot_name names the agent-side snapshot slot (defaults to the
-    request's job_id server-side when empty). Use it — not the request's
-    `group` — for slot naming: group identifies a set of related jobs for
-    the orchestrator and does not name agent-side storage.
+    request's job_id server-side when empty). It becomes a directory name
+    under the agent's store, so it is restricted to letters, digits, "-"
+    and "_". Use it — not the request's `group` — for slot naming: group
+    identifies a set of related jobs for the orchestrator and does not
+    name agent-side storage.
     """
+    if not isinstance(snapshot_name, str):
+        raise TypeError(
+            f"snapshot_name must be a string, got {type(snapshot_name).__name__}"
+        )
+    if snapshot_name and not _SNAPSHOT_NAME_RE.fullmatch(snapshot_name):
+        raise ValueError(
+            "snapshot_name names a directory on the agent and may only "
+            f"contain letters, digits, '-' and '_', got {snapshot_name!r}"
+        )
     if not regions:
         raise ValueError("at least one memory region is required")
 

--- a/pkg/client/python/timeslice/snapshot_agent/types.py
+++ b/pkg/client/python/timeslice/snapshot_agent/types.py
@@ -1,6 +1,12 @@
 from dataclasses import dataclass
 from typing import List, Optional
 
+# Wire-format bounds: MemoryRegion.pid is an int32, address and size_bytes
+# are uint64 (see snapshot_agent.proto). Checked here so callers get a
+# clear error at construction rather than at protobuf assignment.
+_INT32_MAX = 2**31 - 1
+_UINT64_MAX = 2**64 - 1
+
 
 @dataclass(frozen=True)
 class MemoryRegion:
@@ -16,15 +22,28 @@ class MemoryRegion:
     size_bytes: int
 
     def __post_init__(self):
-        if self.pid <= 0:
-            raise ValueError(f"memory region pid must be positive, got {self.pid}")
-        if self.address < 0:
+        for name, value in (
+            ("pid", self.pid),
+            ("address", self.address),
+            ("size_bytes", self.size_bytes),
+        ):
+            if not isinstance(value, int) or isinstance(value, bool):
+                raise TypeError(
+                    f"memory region {name} must be an int, got {type(value).__name__}"
+                )
+        if not 0 < self.pid <= _INT32_MAX:
             raise ValueError(
-                f"memory region address must be non-negative, got {self.address}"
+                f"memory region pid must be positive and fit in int32, got {self.pid}"
             )
-        if self.size_bytes <= 0:
+        if not 0 <= self.address <= _UINT64_MAX:
             raise ValueError(
-                f"memory region size_bytes must be positive, got {self.size_bytes}"
+                "memory region address must be non-negative and fit in uint64, "
+                f"got {self.address}"
+            )
+        if not 0 < self.size_bytes <= _UINT64_MAX:
+            raise ValueError(
+                "memory region size_bytes must be positive and fit in uint64, "
+                f"got {self.size_bytes}"
             )
 
     @classmethod

--- a/pkg/client/python/timeslice/snapshot_agent/types.py
+++ b/pkg/client/python/timeslice/snapshot_agent/types.py
@@ -3,6 +3,51 @@ from typing import List, Optional
 
 
 @dataclass(frozen=True)
+class MemoryRegion:
+    """One device-memory range owned by a process.
+
+    Addresses are plain integers; helpers accept hex strings ("0x7f...")
+    and convert. On the wire the address travels as a uint64 (grpcurl JSON
+    renders it as a decimal string).
+    """
+
+    pid: int
+    address: int
+    size_bytes: int
+
+    def __post_init__(self):
+        if self.pid <= 0:
+            raise ValueError(f"memory region pid must be positive, got {self.pid}")
+        if self.address < 0:
+            raise ValueError(
+                f"memory region address must be non-negative, got {self.address}"
+            )
+        if self.size_bytes <= 0:
+            raise ValueError(
+                f"memory region size_bytes must be positive, got {self.size_bytes}"
+            )
+
+    @classmethod
+    def from_spec(cls, spec: str) -> "MemoryRegion":
+        """Parses a 'pid:0xADDR:size' spec string.
+
+        Address and size accept hex ("0x...") or decimal literals.
+        """
+        parts = spec.split(":")
+        if len(parts) != 3:
+            raise ValueError(
+                f"invalid memory region spec {spec!r}, expected 'pid:address:size'"
+            )
+        try:
+            pid = int(parts[0], 0)
+            address = int(parts[1], 0)
+            size_bytes = int(parts[2], 0)
+        except ValueError as e:
+            raise ValueError(f"invalid memory region spec {spec!r}: {e}") from e
+        return cls(pid=pid, address=address, size_bytes=size_bytes)
+
+
+@dataclass(frozen=True)
 class SnapshotResponse:
     """Response message for Snapshot RPC."""
 


### PR DESCRIPTION
## What does this PR do?

Adds `MemoryRegion` type to the Python Client, docs, and Configs to simplify usage (similar to #187 and #171)

<!-- Describe the changes and their purpose -->

## Why is this change needed?
Adds support for the MemoryRegions backend to the Python Client

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ ] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selectively snapshotting and restoring explicit device-memory regions.
  * Added flexible region configuration using typed objects, tuples, or `pid:address:size` strings with decimal or hexadecimal values.
  * Added optional snapshot slot naming, defaulting to the job ID.
  * Exposed memory-region configuration tools through the Python client.
* **Bug Fixes**
  * Added validation for process IDs, addresses, sizes, snapshot names, and malformed region specifications.
* **Documentation**
  * Added usage guidance and examples for configuring memory-region snapshots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->