### PR TITLE
Support concurrent TPU checkpoint

### DIFF
--- a/pkg/timeslice-orchestrator/controller/controller.go
+++ b/pkg/timeslice-orchestrator/controller/controller.go
@@ -260,11 +260,31 @@ func (c *Controller) reconcileGroup(ctx context.Context, groupID string) error {
 	activeJob := group.Spec().ActiveJob()
 
 	// 3. Act
-	// TODO: add optional fan out parallelism for node reconciliation
+	// 3a. Per-node early exits (active job already running / faulted / transitioning).
 	for _, node := range group.Status().Nodes() {
 		if err := c.reconcileNode(ctx, group.ID(), node, activeJob); err != nil {
 			return fmt.Errorf("failed to reconcile node %s: %w", node, err)
 		}
+	}
+
+	// 3b. Park (snapshot) any OTHER job that still has context loaded, fanning
+	// the snapshots out CONCURRENTLY across all nodes. A healthy host's snapshot
+	// is per-host independent, but issuing serially and blocking per node lets a
+	// single host's checkpoint stall freeze the whole group pass, delay the peer
+	// hosts' snapshots, and cascade into the waiting job's restore faulting.
+	if err := c.reconcileOtherJobsSnapshot(ctx, group, activeJob); err != nil {
+		return fmt.Errorf("failed to snapshot non-active jobs: %w", err)
+	}
+
+	// 3c. Restore the active job onto every node whose context is SAVED, fanning
+	// the restores out CONCURRENTLY. On multi-host accelerator slices (e.g. TPU
+	// libtpu) restore is a slice-wide rendezvous: every host's restore must be
+	// in flight simultaneously or none complete. Issuing them one node at a time
+	// and blocking on each deadlocks a multi-host restore — the first host parks
+	// in the rendezvous waiting for peers that are never triggered, until it
+	// times out and the job FAULTS.
+	if err := c.reconcileActiveJobRestore(ctx, group, activeJob); err != nil {
+		return fmt.Errorf("failed to restore active job: %w", err)
 	}
 
 	// 4. Update Status
@@ -317,62 +337,204 @@ func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activ
 		}
 	}
 
-	// 3. Ensure no other jobs have their context loaded
-	for jobID, state := range agentJobStates {
-		if jobID == activeJobID {
-			continue
-		}
+	// Snapshotting OTHER jobs (RUNNING -> SAVED) and restoring the active job
+	// (SAVED -> RUNNING) are intentionally NOT done here. Both are handled after
+	// this per-node pass so the operations can be issued concurrently across all
+	// hosts of the slice (required for the multi-host libtpu restore rendezvous,
+	// and containment for single-host checkpoint stalls — see reconcileGroup
+	// steps 3b/3c).
+	return nil
+}
 
-		switch state {
-		case pb.SnapshotAgentJobState_STATE_RUNNING:
-			slog.InfoContext(ctx, "Triggering snapshot for job", "jobID", jobID, "state", state)
-			resp, err := c.agentStore.Snapshot(ctx, nodeName, jobID, groupID)
-			if err != nil {
-				return fmt.Errorf("failed to trigger snapshot for job %s on node %s: %w", jobID, nodeName, err)
+// reconcileOtherJobsSnapshot parks (snapshots) every non-active job that still
+// has accelerator context loaded on any node of the group, issuing all
+// snapshots before waiting on any of them (mirroring reconcileActiveJobRestore).
+//
+// Unlike restore, a snapshot has no hard concurrency requirement on a healthy
+// host — but a serial issue-then-block loop turns ONE host's intermittent
+// checkpoint stall into a group-wide freeze that delays the peers' snapshots
+// and cascades into the waiting job's restore faulting. Concurrent issuance
+// contains the blast radius.
+func (c *Controller) reconcileOtherJobsSnapshot(ctx context.Context, group *store.Group, activeJobID string) error {
+	jobs, err := c.jobStore.ListByGroup(ctx, group.ID())
+	if err != nil {
+		return fmt.Errorf("failed to list jobs for group %s: %w", group.ID(), err)
+	}
+
+	// Nodes where the active job is already RUNNING are fully reconciled: another
+	// job holding context there is an impossible state that must surface as an
+	// error in updateGroupStatus (for human attention), not be silently parked.
+	activeRunningNodes := make(map[string]bool)
+	if activeJobID != "" {
+		activeJob, err := c.jobStore.Get(ctx, group.ID(), activeJobID)
+		if err != nil && !errors.Is(err, store.ErrNotFound) {
+			return fmt.Errorf("failed to get active job %s: %w", activeJobID, err)
+		}
+		if activeJob != nil {
+			for node, state := range activeJob.ContextState() {
+				if state == pb.SnapshotAgentJobState_STATE_RUNNING {
+					activeRunningNodes[node] = true
+				}
 			}
-			if err := c.waitForOperation(ctx, groupID, jobID, nodeName, resp.OperationId, "snapshot"); err != nil {
-				return fmt.Errorf("failed while waiting for snapshot operation %s for job %s on node %s: %w",
-					resp.OperationId, jobID, nodeName, err)
-			}
-			if err := c.observeNodeJobContext(ctx, groupID, nodeName); err != nil {
-				return fmt.Errorf("failed to refresh agent state after snapshot: %w", err)
-			}
-		case pb.SnapshotAgentJobState_STATE_IDLE:
-			// Pods exist but have no accelerator context — nothing resident
-			// to preempt. A job only touches the GPU while holding the lock,
-			// so a parked pre-provisioned job must not stall the active one.
-			slog.DebugContext(ctx, "Other job is IDLE (nothing resident), skipping", "jobID", jobID)
-		case pb.SnapshotAgentJobState_STATE_TRANSITIONING:
-			slog.InfoContext(ctx, "Other job is TRANSITIONING, waiting for it to finish", "jobID", jobID)
-			return fmt.Errorf("preemption pending: job %s is currently transitioning", jobID)
 		}
 	}
 
+	// Collect every (node, job) pair whose context is still loaded.
+	type target struct {
+		node  string
+		jobID string
+	}
+	var targets []target
+	for _, job := range jobs {
+		if job.JobID() == activeJobID {
+			continue
+		}
+		contextState := job.ContextState()
+		for _, node := range group.Status().Nodes() {
+			if activeRunningNodes[node] {
+				continue
+			}
+			state, ok := contextState[node]
+			if !ok {
+				continue
+			}
+			switch state {
+			case pb.SnapshotAgentJobState_STATE_RUNNING:
+				targets = append(targets, target{node: node, jobID: job.JobID()})
+			case pb.SnapshotAgentJobState_STATE_IDLE:
+				// Pods exist but have no accelerator context — nothing resident
+				// to preempt. A job only touches the GPU while holding the lock,
+				// so a parked pre-provisioned job must not stall the active one.
+				slog.DebugContext(ctx, "Other job is IDLE (nothing resident), skipping",
+					"jobID", job.JobID(), "node", node)
+			case pb.SnapshotAgentJobState_STATE_TRANSITIONING:
+				slog.InfoContext(ctx, "Other job is TRANSITIONING, waiting for it to finish",
+					"jobID", job.JobID(), "node", node)
+				return fmt.Errorf("preemption pending: job %s is currently transitioning", job.JobID())
+			}
+		}
+	}
+	if len(targets) == 0 {
+		return nil
+	}
+
+	// Phase 1: issue every snapshot. The agent's Snapshot RPC is async (it
+	// registers the operation and returns an operation ID immediately), so all
+	// hosts' snapshots are in flight simultaneously once this loop returns.
+	type targetOp struct {
+		target
+		opID string
+	}
+	ops := make([]targetOp, 0, len(targets))
+	for _, t := range targets {
+		slog.InfoContext(ctx, "Triggering snapshot for job", "jobID", t.jobID, "node", t.node)
+		resp, err := c.agentStore.Snapshot(ctx, t.node, t.jobID, group.ID())
+		if err != nil {
+			return fmt.Errorf("failed to trigger snapshot for job %s on node %s: %w", t.jobID, t.node, err)
+		}
+		ops = append(ops, targetOp{target: t, opID: resp.OperationId})
+	}
+
+	// Phase 2: wait for all snapshot operations concurrently, then refresh state.
+	var wg sync.WaitGroup
+	errs := make([]error, len(ops))
+	for i, op := range ops {
+		wg.Add(1)
+		go func(i int, op targetOp) {
+			defer wg.Done()
+			defer handleCrash(ctx)
+			if err := c.waitForOperation(ctx, group.ID(), op.jobID, op.node, op.opID, "snapshot"); err != nil {
+				errs[i] = fmt.Errorf("failed while waiting for snapshot operation %s for job %s on node %s: %w",
+					op.opID, op.jobID, op.node, err)
+				return
+			}
+			if err := c.observeNodeJobContext(ctx, group.ID(), op.node); err != nil {
+				errs[i] = fmt.Errorf("failed to refresh agent state after snapshot on %s: %w", op.node, err)
+			}
+		}(i, op)
+	}
+	wg.Wait()
+
+	return errors.Join(errs...)
+}
+
+// reconcileActiveJobRestore restores the active job's accelerator context onto
+// every node of the group where it is currently SAVED, issuing all restores
+// before waiting on any of them.
+//
+// Multi-host accelerator restore (libtpu) is a slice-wide rendezvous: each
+// host's restore call parks until every peer host's restore is also in flight.
+// The snapshot agent's Restore RPC is asynchronous (it registers the operation
+// and returns an operation ID immediately), so this fans the restores out to all
+// SAVED nodes first, then waits for their operations concurrently. A serial
+// issue-then-block loop would deadlock: the first host would park in the
+// rendezvous forever waiting for peers that were never triggered.
+func (c *Controller) reconcileActiveJobRestore(ctx context.Context, group *store.Group, activeJobID string) error {
 	if activeJobID == "" {
 		return nil
 	}
 
-	// 4. Ensure active job is loaded where there is available context
-	state, ok := agentJobStates[activeJobID]
-	if !ok || state != pb.SnapshotAgentJobState_STATE_SAVED {
+	activeJob, err := c.jobStore.Get(ctx, group.ID(), activeJobID)
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			// No pods for this job yet (e.g. lock acquired before deploy); nothing to restore.
+			return nil
+		}
+		return fmt.Errorf("failed to get active job %s: %w", activeJobID, err)
+	}
+
+	// Collect the nodes whose context is SAVED and therefore need a restore.
+	contextState := activeJob.ContextState()
+	var restoreNodes []string
+	for _, node := range group.Status().Nodes() {
+		if contextState[node] == pb.SnapshotAgentJobState_STATE_SAVED {
+			restoreNodes = append(restoreNodes, node)
+		}
+	}
+	if len(restoreNodes) == 0 {
 		return nil
 	}
 
-	slog.InfoContext(ctx, "Triggering restore for active job", "jobID", activeJobID, "state", state)
-	resp, err := c.agentStore.Restore(ctx, nodeName, activeJobID, groupID)
-	if err != nil {
-		return fmt.Errorf("failed to trigger restore for active job %s on node %s: %w",
-			activeJobID, nodeName, err)
+	// Phase 1: issue every restore. Restore is async, so all hosts' restores are
+	// pending simultaneously once this loop returns — forming the slice-wide
+	// rendezvous. If any issue fails, abort before waiting (nothing has to be
+	// retried; the partially-triggered restores will fault and be observed).
+	type nodeOp struct {
+		node string
+		opID string
 	}
-	if err := c.waitForOperation(ctx, groupID, activeJobID, nodeName, resp.OperationId, "restore"); err != nil {
-		return fmt.Errorf("failed waiting for restore op %s for job %s on %s: %w",
-			resp.OperationId, activeJobID, nodeName, err)
-	}
-	if err := c.observeNodeJobContext(ctx, groupID, nodeName); err != nil {
-		return fmt.Errorf("failed to refresh agent state after restore: %w", err)
+	ops := make([]nodeOp, 0, len(restoreNodes))
+	for _, node := range restoreNodes {
+		slog.InfoContext(ctx, "Triggering restore for active job", "jobID", activeJobID, "node", node)
+		resp, err := c.agentStore.Restore(ctx, node, activeJobID, group.ID())
+		if err != nil {
+			return fmt.Errorf("failed to trigger restore for active job %s on node %s: %w",
+				activeJobID, node, err)
+		}
+		ops = append(ops, nodeOp{node: node, opID: resp.OperationId})
 	}
 
-	return nil
+	// Phase 2: wait for all restore operations concurrently, then refresh state.
+	var wg sync.WaitGroup
+	errs := make([]error, len(ops))
+	for i, op := range ops {
+		wg.Add(1)
+		go func(i int, op nodeOp) {
+			defer wg.Done()
+			defer handleCrash(ctx)
+			if err := c.waitForOperation(ctx, group.ID(), activeJobID, op.node, op.opID, "restore"); err != nil {
+				errs[i] = fmt.Errorf("failed waiting for restore op %s for job %s on %s: %w",
+					op.opID, activeJobID, op.node, err)
+				return
+			}
+			if err := c.observeNodeJobContext(ctx, group.ID(), op.node); err != nil {
+				errs[i] = fmt.Errorf("failed to refresh agent state after restore on %s: %w", op.node, err)
+			}
+		}(i, op)
+	}
+	wg.Wait()
+
+	return errors.Join(errs...)
 }
 
 // waitForGrantSettlement holds promotion of the next waiter while the current

--- a/pkg/timeslice-orchestrator/controller/controller.go
+++ b/pkg/timeslice-orchestrator/controller/controller.go
@@ -347,9 +347,62 @@ func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activ
 	return nil
 }
 
+// nodeOperation identifies one async agent operation: a job to act on and the
+// node to act on it.
+type nodeOperation struct {
+	node  string
+	jobID string
+}
+
+// runNodeOperations triggers one async agent operation per target and waits for
+// all of them, fully concurrently: each target gets its own goroutine that
+// triggers the operation, polls it to completion, and refreshes the node's
+// agent state. Triggering inside the goroutine matters twice over: multi-host
+// restore is a slice-wide rendezvous (a serial trigger loop lets one
+// slow-to-ACK agent burn into its peers' rendezvous timeout), and one host's
+// stalled snapshot must not delay the peers' snapshots. A goroutine panic is
+// converted into that target's error — swallowing it would report a
+// half-finished fan-out as a successful reconcile.
+func (c *Controller) runNodeOperations(
+	ctx context.Context, groupID, opType string, targets []nodeOperation,
+	trigger func(ctx context.Context, node, jobID string) (string, error),
+) error {
+	var wg sync.WaitGroup
+	errs := make([]error, len(targets))
+	for idx, target := range targets {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					slog.ErrorContext(ctx, "Observed a panic", "panic", r, "stack", string(debug.Stack()))
+					errs[idx] = fmt.Errorf("panic during %s for job %s on node %s: %v", opType, target.jobID, target.node, r)
+				}
+			}()
+			slog.InfoContext(ctx, "Triggering agent operation for job",
+				"opType", opType, "jobID", target.jobID, "node", target.node)
+			opID, err := trigger(ctx, target.node, target.jobID)
+			if err != nil {
+				errs[idx] = fmt.Errorf("failed to trigger %s for job %s on node %s: %w", opType, target.jobID, target.node, err)
+				return
+			}
+			if err := c.waitForOperation(ctx, groupID, target.jobID, target.node, opID, opType); err != nil {
+				errs[idx] = fmt.Errorf("failed while waiting for %s operation %s for job %s on node %s: %w",
+					opType, opID, target.jobID, target.node, err)
+				return
+			}
+			if err := c.observeNodeJobContext(ctx, groupID, target.node); err != nil {
+				errs[idx] = fmt.Errorf("failed to refresh agent state after %s on %s: %w", opType, target.node, err)
+			}
+		}()
+	}
+	wg.Wait()
+	return errors.Join(errs...)
+}
+
 // reconcileNonActiveJobsSnapshot parks (snapshots) every non-active job that
-// still has accelerator context loaded on any node of the group, issuing all
-// snapshots before waiting on any of them (mirroring reconcileActiveJobRestore).
+// still has accelerator context loaded on any node of the group, fanning the
+// snapshots out concurrently (mirroring reconcileActiveJobRestore).
 //
 // Unlike restore, a snapshot has no hard concurrency requirement on a healthy
 // host — but a serial issue-then-block loop turns ONE host's intermittent
@@ -366,32 +419,31 @@ func (c *Controller) reconcileNonActiveJobsSnapshot(ctx context.Context, group *
 	// job holding context there is an impossible state that must surface as an
 	// error in updateGroupStatus (for human attention), not be silently parked.
 	activeRunningNodes := make(map[string]bool)
-	if activeJobID != "" {
-		activeJob, err := c.jobStore.Get(ctx, group.ID(), activeJobID)
-		if err != nil && !errors.Is(err, store.ErrNotFound) {
-			return fmt.Errorf("failed to get active job %s: %w", activeJobID, err)
+	for _, job := range jobs {
+		if job.JobID() != activeJobID {
+			continue
 		}
-		if activeJob != nil {
-			for node, state := range activeJob.ContextState() {
-				if state == pb.SnapshotAgentJobState_STATE_RUNNING {
-					activeRunningNodes[node] = true
-				}
+		for node, state := range job.ContextState() {
+			if state == pb.SnapshotAgentJobState_STATE_RUNNING {
+				activeRunningNodes[node] = true
 			}
 		}
 	}
 
-	// Collect every (node, job) pair whose context is still loaded.
-	type target struct {
-		node  string
-		jobID string
-	}
-	var targets []target
+	// Collect every (node, job) pair whose context is still loaded. A
+	// TRANSITIONING pair cannot be snapshotted this pass, but must not block the
+	// healthy pairs' snapshots either: record it as a pending error so the group
+	// still requeues (and the restore below it stays blocked) while the other
+	// nodes make per-node progress across requeues.
+	nodes := group.Status().Nodes()
+	var targets []nodeOperation
+	var pendingErrs []error
 	for _, job := range jobs {
 		if job.JobID() == activeJobID {
 			continue
 		}
 		contextState := job.ContextState()
-		for _, node := range group.Status().Nodes() {
+		for _, node := range nodes {
 			if activeRunningNodes[node] {
 				continue
 			}
@@ -401,7 +453,7 @@ func (c *Controller) reconcileNonActiveJobsSnapshot(ctx context.Context, group *
 			}
 			switch state {
 			case pb.SnapshotAgentJobState_STATE_RUNNING:
-				targets = append(targets, target{node: node, jobID: job.JobID()})
+				targets = append(targets, nodeOperation{node: node, jobID: job.JobID()})
 			case pb.SnapshotAgentJobState_STATE_IDLE:
 				// Pods exist but have no accelerator context — nothing resident
 				// to preempt. A job only touches the GPU while holding the lock,
@@ -411,65 +463,33 @@ func (c *Controller) reconcileNonActiveJobsSnapshot(ctx context.Context, group *
 			case pb.SnapshotAgentJobState_STATE_TRANSITIONING:
 				slog.InfoContext(ctx, "Other job is TRANSITIONING, waiting for it to finish",
 					"jobID", job.JobID(), "node", node)
-				return fmt.Errorf("preemption pending: job %s is currently transitioning", job.JobID())
+				pendingErrs = append(pendingErrs,
+					fmt.Errorf("preemption pending: job %s is currently transitioning on node %s", job.JobID(), node))
 			}
 		}
 	}
-	if len(targets) == 0 {
-		return nil
-	}
 
-	// Phase 1: issue every snapshot. The agent's Snapshot RPC is async (it
-	// registers the operation and returns an operation ID immediately), so all
-	// hosts' snapshots are in flight simultaneously once this loop returns.
-	type targetOp struct {
-		target
-		opID string
-	}
-	ops := make([]targetOp, 0, len(targets))
-	for _, t := range targets {
-		slog.InfoContext(ctx, "Triggering snapshot for job", "jobID", t.jobID, "node", t.node)
-		resp, err := c.agentStore.Snapshot(ctx, t.node, t.jobID, group.ID())
-		if err != nil {
-			return fmt.Errorf("failed to trigger snapshot for job %s on node %s: %w", t.jobID, t.node, err)
-		}
-		ops = append(ops, targetOp{target: t, opID: resp.OperationId})
-	}
-
-	// Phase 2: wait for all snapshot operations concurrently, then refresh state.
-	var wg sync.WaitGroup
-	errs := make([]error, len(ops))
-	for i, op := range ops {
-		wg.Add(1)
-		go func(i int, op targetOp) {
-			defer wg.Done()
-			defer handleCrash(ctx)
-			if err := c.waitForOperation(ctx, group.ID(), op.jobID, op.node, op.opID, "snapshot"); err != nil {
-				errs[i] = fmt.Errorf("failed while waiting for snapshot operation %s for job %s on node %s: %w",
-					op.opID, op.jobID, op.node, err)
-				return
+	if err := c.runNodeOperations(ctx, group.ID(), "snapshot", targets,
+		func(ctx context.Context, node, jobID string) (string, error) {
+			resp, err := c.agentStore.Snapshot(ctx, node, jobID, group.ID())
+			if err != nil {
+				return "", err
 			}
-			if err := c.observeNodeJobContext(ctx, group.ID(), op.node); err != nil {
-				errs[i] = fmt.Errorf("failed to refresh agent state after snapshot on %s: %w", op.node, err)
-			}
-		}(i, op)
+			return resp.OperationId, nil
+		}); err != nil {
+		pendingErrs = append(pendingErrs, err)
 	}
-	wg.Wait()
-
-	return errors.Join(errs...)
+	return errors.Join(pendingErrs...)
 }
 
 // reconcileActiveJobRestore restores the active job's accelerator context onto
-// every node of the group where it is currently SAVED, issuing all restores
-// before waiting on any of them.
+// every node of the group where it is currently SAVED, fanning the restores out
+// concurrently (one trigger-and-wait goroutine per node).
 //
 // Multi-host accelerator restore (libtpu) is a slice-wide rendezvous: each
 // host's restore call parks until every peer host's restore is also in flight.
-// The snapshot agent's Restore RPC is asynchronous (it registers the operation
-// and returns an operation ID immediately), so this fans the restores out to all
-// SAVED nodes first, then waits for their operations concurrently. A serial
-// issue-then-block loop would deadlock: the first host would park in the
-// rendezvous forever waiting for peers that were never triggered.
+// A serial issue-then-block loop would deadlock: the first host would park in
+// the rendezvous forever waiting for peers that were never triggered.
 func (c *Controller) reconcileActiveJobRestore(ctx context.Context, group *store.Group, activeJobID string) error {
 	if activeJobID == "" {
 		return nil
@@ -486,56 +506,21 @@ func (c *Controller) reconcileActiveJobRestore(ctx context.Context, group *store
 
 	// Collect the nodes whose context is SAVED and therefore need a restore.
 	contextState := activeJob.ContextState()
-	var restoreNodes []string
+	var targets []nodeOperation
 	for _, node := range group.Status().Nodes() {
 		if contextState[node] == pb.SnapshotAgentJobState_STATE_SAVED {
-			restoreNodes = append(restoreNodes, node)
+			targets = append(targets, nodeOperation{node: node, jobID: activeJobID})
 		}
 	}
-	if len(restoreNodes) == 0 {
-		return nil
-	}
 
-	// Phase 1: issue every restore. Restore is async, so all hosts' restores are
-	// pending simultaneously once this loop returns — forming the slice-wide
-	// rendezvous. If any issue fails, abort before waiting (nothing has to be
-	// retried; the partially-triggered restores will fault and be observed).
-	type nodeOp struct {
-		node string
-		opID string
-	}
-	ops := make([]nodeOp, 0, len(restoreNodes))
-	for _, node := range restoreNodes {
-		slog.InfoContext(ctx, "Triggering restore for active job", "jobID", activeJobID, "node", node)
-		resp, err := c.agentStore.Restore(ctx, node, activeJobID, group.ID())
-		if err != nil {
-			return fmt.Errorf("failed to trigger restore for active job %s on node %s: %w",
-				activeJobID, node, err)
-		}
-		ops = append(ops, nodeOp{node: node, opID: resp.OperationId})
-	}
-
-	// Phase 2: wait for all restore operations concurrently, then refresh state.
-	var wg sync.WaitGroup
-	errs := make([]error, len(ops))
-	for i, op := range ops {
-		wg.Add(1)
-		go func(i int, op nodeOp) {
-			defer wg.Done()
-			defer handleCrash(ctx)
-			if err := c.waitForOperation(ctx, group.ID(), activeJobID, op.node, op.opID, "restore"); err != nil {
-				errs[i] = fmt.Errorf("failed waiting for restore op %s for job %s on %s: %w",
-					op.opID, activeJobID, op.node, err)
-				return
+	return c.runNodeOperations(ctx, group.ID(), "restore", targets,
+		func(ctx context.Context, node, jobID string) (string, error) {
+			resp, err := c.agentStore.Restore(ctx, node, jobID, group.ID())
+			if err != nil {
+				return "", err
 			}
-			if err := c.observeNodeJobContext(ctx, group.ID(), op.node); err != nil {
-				errs[i] = fmt.Errorf("failed to refresh agent state after restore on %s: %w", op.node, err)
-			}
-		}(i, op)
-	}
-	wg.Wait()
-
-	return errors.Join(errs...)
+			return resp.OperationId, nil
+		})
 }
 
 // waitForGrantSettlement holds promotion of the next waiter while the current

--- a/pkg/timeslice-orchestrator/controller/controller.go
+++ b/pkg/timeslice-orchestrator/controller/controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"runtime/debug"
+	"sort"
 	"sync"
 	"time"
 
@@ -259,33 +260,53 @@ func (c *Controller) reconcileGroup(ctx context.Context, groupID string) error {
 
 	activeJob := group.Spec().ActiveJob()
 
-	// 3. Act
-	// 3a. Per-node early exits (active job already running / faulted / transitioning).
-	for _, node := range group.Status().Nodes() {
-		if err := c.reconcileNode(ctx, group.ID(), node, activeJob); err != nil {
-			return fmt.Errorf("failed to reconcile node %s: %w", node, err)
-		}
+	// 3. Act: reconcile every node of the group CONCURRENTLY. On one node the
+	// work is sequential — early exits, then park (snapshot) any non-active job
+	// still holding context there, then restore the active job — but no node
+	// waits on a peer's pass. Multi-host checkpoint AND restore are slice-wide
+	// rendezvous (libtpu): the operation only completes once every host has the
+	// same operation in flight, so the concurrent per-node passes are what let
+	// the cohorts form (a serial issue-then-block loop parks the first host in
+	// the rendezvous forever). The snapshot rendezvous doubles as a natural
+	// barrier: no node reaches its restore before every node's snapshot is done.
+	//
+	// A failed trigger on one node cancels the peers' passes via cancelPeers:
+	// once a cohort member is missing, a rendezvoused operation can never
+	// complete, so waiting on the peers only burns into the agent-side
+	// operation timeout and escalates a retryable trigger error into a FAULTED
+	// job. Abort the whole pass instead and let the requeue retry it;
+	// already-triggered operations resolve agent-side and are re-observed at
+	// the start of the next pass.
+	//
+	// CAVEAT (asymmetric states): a node whose snapshot cannot run this pass
+	// (non-active job TRANSITIONING there) no longer blocks the peers'
+	// restores; a peer's restore then parks in the rendezvous until the next
+	// pass catches the node up. On the symmetric path (job loaded on every
+	// node of the slice) this does not occur.
+	nodes := group.Status().Nodes()
+	opCtx, cancelPeers := context.WithCancel(ctx)
+	defer cancelPeers()
+	nodeErrs := make([]error, len(nodes))
+	var wg sync.WaitGroup
+	for idx, node := range nodes {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					slog.ErrorContext(ctx, "Observed a panic", "panic", r, "stack", string(debug.Stack()))
+					nodeErrs[idx] = fmt.Errorf("panic while reconciling node %s: %v", node, r)
+					cancelPeers()
+				}
+			}()
+			if err := c.reconcileNode(opCtx, group.ID(), node, activeJob, cancelPeers); err != nil {
+				nodeErrs[idx] = fmt.Errorf("failed to reconcile node %s: %w", node, err)
+			}
+		}()
 	}
-
-	// 3b. Park (snapshot) any non-active job that still has context loaded,
-	// fanning the snapshots out CONCURRENTLY across all nodes. A healthy host's
-	// snapshot is per-host independent, but issuing serially and blocking per
-	// node lets a single host's checkpoint stall freeze the whole group pass,
-	// delay the peer hosts' snapshots, and cascade into the waiting job's
-	// restore faulting.
-	if err := c.reconcileNonActiveJobsSnapshot(ctx, group, activeJob); err != nil {
-		return fmt.Errorf("failed to snapshot non-active jobs: %w", err)
-	}
-
-	// 3c. Restore the active job onto every node whose context is SAVED, fanning
-	// the restores out CONCURRENTLY. On multi-host accelerator slices (e.g. TPU
-	// libtpu) restore is a slice-wide rendezvous: every host's restore must be
-	// in flight simultaneously or none complete. Issuing them one node at a time
-	// and blocking on each deadlocks a multi-host restore — the first host parks
-	// in the rendezvous waiting for peers that are never triggered, until it
-	// times out and the job FAULTS.
-	if err := c.reconcileActiveJobRestore(ctx, group, activeJob); err != nil {
-		return fmt.Errorf("failed to restore active job: %w", err)
+	wg.Wait()
+	if err := errors.Join(nodeErrs...); err != nil {
+		return err
 	}
 
 	// 4. Update Status
@@ -298,8 +319,16 @@ func (c *Controller) reconcileGroup(ctx context.Context, groupID string) error {
 	return nil
 }
 
-// reconcileNode reconciles the state of a single node for the active job.
-func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activeJobID string) error {
+// reconcileNode reconciles the state of a single node: early exits, then
+// parks (snapshots) every non-active job still holding context on the node,
+// then restores the active job if its context is SAVED here. Snapshot-then-
+// restore is sequential ON the node; reconcileGroup runs one reconcileNode
+// per node concurrently so the slice-wide rendezvous cohorts can form.
+// cancelPeers aborts the peers' node passes when this node's trigger fails
+// (see reconcileGroup step 3).
+func (c *Controller) reconcileNode(
+	ctx context.Context, groupID, nodeName, activeJobID string, cancelPeers context.CancelFunc,
+) error {
 	ctx = logging.WithNodeName(ctx, nodeName)
 	jobs, err := c.jobStore.ListByGroup(ctx, groupID)
 	if err != nil {
@@ -338,164 +367,52 @@ func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activ
 		}
 	}
 
-	// Snapshotting non-active jobs (RUNNING -> SAVED) and restoring the active job
-	// (SAVED -> RUNNING) are intentionally NOT done here. Both are handled after
-	// this per-node pass so the operations can be issued concurrently across all
-	// hosts of the slice (required for the multi-host libtpu restore rendezvous,
-	// and containment for single-host checkpoint stalls — see reconcileGroup
-	// steps 3b/3c).
-	return nil
-}
-
-// nodeOperation identifies one async agent operation: a job to act on and the
-// node to act on it.
-type nodeOperation struct {
-	node  string
-	jobID string
-}
-
-// runNodeOperations triggers one async agent operation per target and waits for
-// all of them, fully concurrently: each target gets its own goroutine that
-// triggers the operation, polls it to completion, and refreshes the node's
-// agent state. Triggering inside the goroutine matters twice over: multi-host
-// restore is a slice-wide rendezvous (a serial trigger loop lets one
-// slow-to-ACK agent burn into its peers' rendezvous timeout), and one host's
-// stalled snapshot must not delay the peers' snapshots. A goroutine panic is
-// converted into that target's error — swallowing it would report a
-// half-finished fan-out as a successful reconcile.
-func (c *Controller) runNodeOperations(
-	ctx context.Context, groupID, opType string, targets []nodeOperation,
-	trigger func(ctx context.Context, node, jobID string) (string, error),
-) error {
-	var wg sync.WaitGroup
-	errs := make([]error, len(targets))
-	for idx, target := range targets {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			defer func() {
-				if r := recover(); r != nil {
-					slog.ErrorContext(ctx, "Observed a panic", "panic", r, "stack", string(debug.Stack()))
-					errs[idx] = fmt.Errorf("panic during %s for job %s on node %s: %v", opType, target.jobID, target.node, r)
-				}
-			}()
-			slog.InfoContext(ctx, "Triggering agent operation for job",
-				"opType", opType, "jobID", target.jobID, "node", target.node)
-			opID, err := trigger(ctx, target.node, target.jobID)
-			if err != nil {
-				errs[idx] = fmt.Errorf("failed to trigger %s for job %s on node %s: %w", opType, target.jobID, target.node, err)
-				return
-			}
-			if err := c.waitForOperation(ctx, groupID, target.jobID, target.node, opID, opType); err != nil {
-				errs[idx] = fmt.Errorf("failed while waiting for %s operation %s for job %s on node %s: %w",
-					opType, opID, target.jobID, target.node, err)
-				return
-			}
-			if err := c.observeNodeJobContext(ctx, groupID, target.node); err != nil {
-				errs[idx] = fmt.Errorf("failed to refresh agent state after %s on %s: %w", opType, target.node, err)
-			}
-		}()
-	}
-	wg.Wait()
-	return errors.Join(errs...)
-}
-
-// reconcileNonActiveJobsSnapshot parks (snapshots) every non-active job that
-// still has accelerator context loaded on any node of the group, fanning the
-// snapshots out concurrently (mirroring reconcileActiveJobRestore).
-//
-// Unlike restore, a snapshot has no hard concurrency requirement on a healthy
-// host — but a serial issue-then-block loop turns ONE host's intermittent
-// checkpoint stall into a group-wide freeze that delays the peers' snapshots
-// and cascades into the waiting job's restore faulting. Concurrent issuance
-// contains the blast radius.
-func (c *Controller) reconcileNonActiveJobsSnapshot(ctx context.Context, group *store.Group, activeJobID string) error {
-	jobs, err := c.jobStore.ListByGroup(ctx, group.ID())
-	if err != nil {
-		return fmt.Errorf("failed to list jobs for group %s: %w", group.ID(), err)
-	}
-
-	// Nodes where the active job is already RUNNING are fully reconciled: another
-	// job holding context there is an impossible state that must surface as an
-	// error in updateGroupStatus (for human attention), not be silently parked.
-	activeRunningNodes := make(map[string]bool)
-	for _, job := range jobs {
-		if job.JobID() != activeJobID {
-			continue
-		}
-		for node, state := range job.ContextState() {
-			if state == pb.SnapshotAgentJobState_STATE_RUNNING {
-				activeRunningNodes[node] = true
-			}
-		}
-	}
-
-	// Collect every (node, job) pair whose context is still loaded. A
-	// TRANSITIONING pair cannot be snapshotted this pass, but must not block the
-	// healthy pairs' snapshots either: record it as a pending error so the group
-	// still requeues (and the restore below it stays blocked) while the other
-	// nodes make per-node progress across requeues.
-	nodes := group.Status().Nodes()
-	var targets []nodeOperation
+	// 2. Park (snapshot) every non-active job still holding context on this
+	// node. Deterministic job order across nodes so multi-job rendezvous
+	// cohorts cannot interleave into a cross-node deadlock. A TRANSITIONING
+	// job cannot be snapshotted this pass, but must not block another job's
+	// snapshot: record it as a pending error so the group requeues (and this
+	// node's restore below stays blocked) while the node still makes progress.
+	sort.Slice(jobs, func(i, j int) bool { return jobs[i].JobID() < jobs[j].JobID() })
 	var pendingErrs []error
 	for _, job := range jobs {
 		if job.JobID() == activeJobID {
 			continue
 		}
-		contextState := job.ContextState()
-		for _, node := range nodes {
-			if activeRunningNodes[node] {
-				continue
+		switch agentJobStates[job.JobID()] {
+		case pb.SnapshotAgentJobState_STATE_RUNNING:
+			if err := c.runAgentOperation(ctx, groupID, "snapshot", nodeName, job.JobID(), cancelPeers,
+				func(ctx context.Context) (string, error) {
+					resp, err := c.agentStore.Snapshot(ctx, nodeName, job.JobID(), groupID)
+					if err != nil {
+						return "", err
+					}
+					return resp.OperationId, nil
+				}); err != nil {
+				pendingErrs = append(pendingErrs, err)
 			}
-			state, ok := contextState[node]
-			if !ok {
-				continue
-			}
-			switch state {
-			case pb.SnapshotAgentJobState_STATE_RUNNING:
-				targets = append(targets, nodeOperation{node: node, jobID: job.JobID()})
-			case pb.SnapshotAgentJobState_STATE_IDLE:
-				// Pods exist but have no accelerator context — nothing resident
-				// to preempt. A job only touches the GPU while holding the lock,
-				// so a parked pre-provisioned job must not stall the active one.
-				slog.DebugContext(ctx, "Other job is IDLE (nothing resident), skipping",
-					"jobID", job.JobID(), "node", node)
-			case pb.SnapshotAgentJobState_STATE_TRANSITIONING:
-				slog.InfoContext(ctx, "Other job is TRANSITIONING, waiting for it to finish",
-					"jobID", job.JobID(), "node", node)
-				pendingErrs = append(pendingErrs,
-					fmt.Errorf("preemption pending: job %s is currently transitioning on node %s", job.JobID(), node))
-			}
+		case pb.SnapshotAgentJobState_STATE_IDLE:
+			// Pods exist but have no accelerator context — nothing resident
+			// to preempt. A job only touches the GPU while holding the lock,
+			// so a parked pre-provisioned job must not stall the active one.
+			slog.DebugContext(ctx, "Other job is IDLE (nothing resident), skipping",
+				"jobID", job.JobID(), "node", nodeName)
+		case pb.SnapshotAgentJobState_STATE_TRANSITIONING:
+			slog.InfoContext(ctx, "Other job is TRANSITIONING, waiting for it to finish",
+				"jobID", job.JobID(), "node", nodeName)
+			pendingErrs = append(pendingErrs,
+				fmt.Errorf("preemption pending: job %s is currently transitioning on node %s", job.JobID(), nodeName))
 		}
 	}
-
-	if err := c.runNodeOperations(ctx, group.ID(), "snapshot", targets,
-		func(ctx context.Context, node, jobID string) (string, error) {
-			resp, err := c.agentStore.Snapshot(ctx, node, jobID, group.ID())
-			if err != nil {
-				return "", err
-			}
-			return resp.OperationId, nil
-		}); err != nil {
-		pendingErrs = append(pendingErrs, err)
+	if err := errors.Join(pendingErrs...); err != nil {
+		return err
 	}
-	return errors.Join(pendingErrs...)
-}
 
-// reconcileActiveJobRestore restores the active job's accelerator context onto
-// every node of the group where it is currently SAVED, fanning the restores out
-// concurrently (one trigger-and-wait goroutine per node).
-//
-// Multi-host accelerator restore (libtpu) is a slice-wide rendezvous: each
-// host's restore call parks until every peer host's restore is also in flight.
-// A serial issue-then-block loop would deadlock: the first host would park in
-// the rendezvous forever waiting for peers that were never triggered.
-func (c *Controller) reconcileActiveJobRestore(ctx context.Context, group *store.Group, activeJobID string) error {
+	// 3. Restore the active job if its context on this node is SAVED.
 	if activeJobID == "" {
 		return nil
 	}
-
-	activeJob, err := c.jobStore.Get(ctx, group.ID(), activeJobID)
+	activeJob, err := c.jobStore.Get(ctx, groupID, activeJobID)
 	if err != nil {
 		if errors.Is(err, store.ErrNotFound) {
 			// No pods for this job yet (e.g. lock acquired before deploy); nothing to restore.
@@ -503,19 +420,12 @@ func (c *Controller) reconcileActiveJobRestore(ctx context.Context, group *store
 		}
 		return fmt.Errorf("failed to get active job %s: %w", activeJobID, err)
 	}
-
-	// Collect the nodes whose context is SAVED and therefore need a restore.
-	contextState := activeJob.ContextState()
-	var targets []nodeOperation
-	for _, node := range group.Status().Nodes() {
-		if contextState[node] == pb.SnapshotAgentJobState_STATE_SAVED {
-			targets = append(targets, nodeOperation{node: node, jobID: activeJobID})
-		}
+	if activeJob.ContextState()[nodeName] != pb.SnapshotAgentJobState_STATE_SAVED {
+		return nil
 	}
-
-	return c.runNodeOperations(ctx, group.ID(), "restore", targets,
-		func(ctx context.Context, node, jobID string) (string, error) {
-			resp, err := c.agentStore.Restore(ctx, node, jobID, group.ID())
+	return c.runAgentOperation(ctx, groupID, "restore", nodeName, activeJobID, cancelPeers,
+		func(ctx context.Context) (string, error) {
+			resp, err := c.agentStore.Restore(ctx, nodeName, activeJobID, groupID)
 			if err != nil {
 				return "", err
 			}
@@ -591,6 +501,35 @@ func (c *Controller) clearSettle(groupID string) {
 	c.settleMu.Lock()
 	delete(c.settleSince, groupID)
 	c.settleMu.Unlock()
+}
+
+// runAgentOperation triggers one async agent operation on a node, polls it to
+// completion, and refreshes the node's agent state. A trigger failure cancels
+// the peer nodes' passes via cancelPeers: once a cohort member is missing, a
+// rendezvoused operation can never complete, so waiting on the peers only
+// burns into the agent-side operation timeout and escalates a retryable
+// trigger error into a FAULTED job (or, against an agent with no timeout,
+// parks this worker forever). Already-triggered operations resolve agent-side
+// and are re-observed at the start of the next pass.
+func (c *Controller) runAgentOperation(
+	ctx context.Context, groupID, opType, node, jobID string,
+	cancelPeers context.CancelFunc, trigger func(ctx context.Context) (string, error),
+) error {
+	slog.InfoContext(ctx, "Triggering agent operation for job",
+		"opType", opType, "jobID", jobID, "node", node)
+	opID, err := trigger(ctx)
+	if err != nil {
+		cancelPeers()
+		return fmt.Errorf("failed to trigger %s for job %s on node %s: %w", opType, jobID, node, err)
+	}
+	if err := c.waitForOperation(ctx, groupID, jobID, node, opID, opType); err != nil {
+		return fmt.Errorf("failed while waiting for %s operation %s for job %s on node %s: %w",
+			opType, opID, jobID, node, err)
+	}
+	if err := c.observeNodeJobContext(ctx, groupID, node); err != nil {
+		return fmt.Errorf("failed to refresh agent state after %s on %s: %w", opType, node, err)
+	}
+	return nil
 }
 
 // tryDeduceActiveJob is a best-effort helper that deduces and sets the active job after a controller

--- a/pkg/timeslice-orchestrator/controller/controller.go
+++ b/pkg/timeslice-orchestrator/controller/controller.go
@@ -301,6 +301,7 @@ func (c *Controller) reconcileGroup(ctx context.Context, groupID string) error {
 			}()
 			if err := c.reconcileNode(opCtx, group.ID(), node, activeJob, cancelPeers); err != nil {
 				nodeErrs[idx] = fmt.Errorf("failed to reconcile node %s: %w", node, err)
+				cancelPeers()
 			}
 		}()
 	}

--- a/pkg/timeslice-orchestrator/controller/controller.go
+++ b/pkg/timeslice-orchestrator/controller/controller.go
@@ -267,12 +267,13 @@ func (c *Controller) reconcileGroup(ctx context.Context, groupID string) error {
 		}
 	}
 
-	// 3b. Park (snapshot) any OTHER job that still has context loaded, fanning
-	// the snapshots out CONCURRENTLY across all nodes. A healthy host's snapshot
-	// is per-host independent, but issuing serially and blocking per node lets a
-	// single host's checkpoint stall freeze the whole group pass, delay the peer
-	// hosts' snapshots, and cascade into the waiting job's restore faulting.
-	if err := c.reconcileOtherJobsSnapshot(ctx, group, activeJob); err != nil {
+	// 3b. Park (snapshot) any non-active job that still has context loaded,
+	// fanning the snapshots out CONCURRENTLY across all nodes. A healthy host's
+	// snapshot is per-host independent, but issuing serially and blocking per
+	// node lets a single host's checkpoint stall freeze the whole group pass,
+	// delay the peer hosts' snapshots, and cascade into the waiting job's
+	// restore faulting.
+	if err := c.reconcileNonActiveJobsSnapshot(ctx, group, activeJob); err != nil {
 		return fmt.Errorf("failed to snapshot non-active jobs: %w", err)
 	}
 
@@ -337,7 +338,7 @@ func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activ
 		}
 	}
 
-	// Snapshotting OTHER jobs (RUNNING -> SAVED) and restoring the active job
+	// Snapshotting non-active jobs (RUNNING -> SAVED) and restoring the active job
 	// (SAVED -> RUNNING) are intentionally NOT done here. Both are handled after
 	// this per-node pass so the operations can be issued concurrently across all
 	// hosts of the slice (required for the multi-host libtpu restore rendezvous,
@@ -346,8 +347,8 @@ func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activ
 	return nil
 }
 
-// reconcileOtherJobsSnapshot parks (snapshots) every non-active job that still
-// has accelerator context loaded on any node of the group, issuing all
+// reconcileNonActiveJobsSnapshot parks (snapshots) every non-active job that
+// still has accelerator context loaded on any node of the group, issuing all
 // snapshots before waiting on any of them (mirroring reconcileActiveJobRestore).
 //
 // Unlike restore, a snapshot has no hard concurrency requirement on a healthy
@@ -355,7 +356,7 @@ func (c *Controller) reconcileNode(ctx context.Context, groupID, nodeName, activ
 // checkpoint stall into a group-wide freeze that delays the peers' snapshots
 // and cascades into the waiting job's restore faulting. Concurrent issuance
 // contains the blast radius.
-func (c *Controller) reconcileOtherJobsSnapshot(ctx context.Context, group *store.Group, activeJobID string) error {
+func (c *Controller) reconcileNonActiveJobsSnapshot(ctx context.Context, group *store.Group, activeJobID string) error {
 	jobs, err := c.jobStore.ListByGroup(ctx, group.ID())
 	if err != nil {
 		return fmt.Errorf("failed to list jobs for group %s: %w", group.ID(), err)

--- a/pkg/timeslice-orchestrator/controller/controller_test.go
+++ b/pkg/timeslice-orchestrator/controller/controller_test.go
@@ -2518,6 +2518,80 @@ func TestController_Reconcile_MultiNodeRestore_FailurePropagates(t *testing.T) {
 	}
 }
 
+// A failed trigger on one node must cancel the peers' operation waits: with a
+// cohort member missing the rendezvous can never complete, so without the
+// cancellation the peer would poll a forever-PENDING operation and wedge the
+// reconcile worker.
+func TestController_Reconcile_MultiNodeRestore_TriggerFailureCancelsPeers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
+
+	groupID := "group-1"
+	nodeNames := []string{"node-1", "node-2"}
+
+	group, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	group.Status().SetNodes(nodeNames)
+	group.Spec().SetActiveJob("job-1")
+
+	job1 := store.NewJob(groupID, "job-1")
+	for _, node := range nodeNames {
+		job1.UpdateContextState(node, pb.SnapshotAgentJobState_STATE_SAVED)
+	}
+	if err := jobStore.Put(ctx, job1); err != nil {
+		t.Fatalf("failed to put job1: %v", err)
+	}
+
+	mockAgentStore := &controller.MockSnapshotAgentStore{
+		RestoreFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.RestoreResponse, error) {
+			// node-2's trigger fails outright; node-1's succeeds.
+			if node == "node-2" {
+				return nil, fmt.Errorf("agent unreachable on node-2")
+			}
+			return &agentpb.RestoreResponse{OperationId: "op-restore-" + node}, nil
+		},
+		OperationFunc: func(ctx context.Context, node, operationID string) (*agentpb.GetOperationResponse, error) {
+			// node-1's restore parks in the rendezvous and never completes.
+			return &agentpb.GetOperationResponse{Status: agentpb.OperationStatus_OPERATION_STATUS_PENDING}, nil
+		},
+	}
+
+	mockOrch := &mockInfrastructureOrchestrator{
+		observeFunc: func(ctx context.Context, gID string) error {
+			return nil
+		},
+	}
+
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
+
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+
+	testQueue.Add(groupID)
+
+	// The trigger failure must abort the whole fan-out (cancelling node-1's
+	// wait) so the reconcile fails and requeues instead of hanging.
+	err = waitWithTimeout(func() bool { return testQueue.getAddRateLimitedCount() > 0 }, 5*time.Second)
+	if err != nil {
+		t.Fatal("Timed out waiting for requeue: peer wait was not cancelled after the trigger failure")
+	}
+}
+
 func TestController_Reconcile_PreemptionSafetyGates_ActiveJobTransitioning(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/pkg/timeslice-orchestrator/controller/controller_test.go
+++ b/pkg/timeslice-orchestrator/controller/controller_test.go
@@ -2204,6 +2204,320 @@ func TestController_Reconcile_DeduceActiveJob_RestartCase(t *testing.T) {
 	}
 }
 
+// TestController_Reconcile_MultiNodeRestore_Rendezvous verifies that restores for the
+// active job are issued to ALL saved nodes before the controller blocks waiting on any
+// of them. It simulates the multi-host accelerator rendezvous (e.g. TPU libtpu): a
+// restore operation only completes once restores on every node of the group are in
+// flight. A serial issue-then-wait loop would deadlock here (the first node's operation
+// would stay pending forever) and the test would time out.
+func TestController_Reconcile_MultiNodeRestore_Rendezvous(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
+
+	groupID := "group-1"
+	nodeNames := []string{"node-1", "node-2", "node-3"}
+
+	group, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	group.Status().SetNodes(nodeNames)
+	group.Spec().SetActiveJob("job-1")
+
+	// job-1 (active) is SAVED on every node and needs a restore on all of them.
+	job1 := store.NewJob(groupID, "job-1")
+	for _, node := range nodeNames {
+		job1.UpdateContextState(node, pb.SnapshotAgentJobState_STATE_SAVED)
+	}
+	if err := jobStore.Put(ctx, job1); err != nil {
+		t.Fatalf("failed to put job1: %v", err)
+	}
+
+	var mu sync.Mutex
+	restoredNodes := make(map[string]bool)
+	mockAgentStore := &controller.MockSnapshotAgentStore{
+		GetStatusFunc: func(ctx context.Context, node string) (*agentpb.StatusResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			state := agentpb.JobState_JOB_STATE_SAVED
+			// Once the rendezvous is complete, the node reports the job as running.
+			if len(restoredNodes) == len(nodeNames) {
+				state = agentpb.JobState_JOB_STATE_RUNNING
+			}
+			return &agentpb.StatusResponse{
+				JobStatuses: []*agentpb.JobStatus{{JobId: "job-1", State: state}},
+			}, nil
+		},
+		RestoreFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.RestoreResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			restoredNodes[node] = true
+			return &agentpb.RestoreResponse{OperationId: "op-restore-" + node}, nil
+		},
+		OperationFunc: func(ctx context.Context, node, operationID string) (*agentpb.GetOperationResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			// Rendezvous: no restore completes until restores on ALL nodes are in flight.
+			if len(restoredNodes) < len(nodeNames) {
+				return &agentpb.GetOperationResponse{Status: agentpb.OperationStatus_OPERATION_STATUS_PENDING}, nil
+			}
+			return &agentpb.GetOperationResponse{Status: agentpb.OperationStatus_OPERATION_STATUS_COMPLETE}, nil
+		},
+	}
+
+	mockOrch := &mockInfrastructureOrchestrator{
+		observeFunc: func(ctx context.Context, gID string) error {
+			return nil
+		},
+	}
+
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
+
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+
+	testQueue.Add(groupID)
+
+	// A serial restore loop would never get past the first node's pending operation.
+	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 5*time.Second)
+	if err != nil {
+		t.Fatal("Timed out waiting for reconcile: multi-node restore rendezvous deadlocked " +
+			"(restores were not issued concurrently across nodes)")
+	}
+
+	mu.Lock()
+	if len(restoredNodes) != len(nodeNames) {
+		t.Errorf("Expected restore to be issued on all %d nodes, got %d: %v",
+			len(nodeNames), len(restoredNodes), restoredNodes)
+	}
+	mu.Unlock()
+
+	if testQueue.getAddRateLimitedCount() != 0 {
+		t.Errorf("Expected no rate-limited requeues, got %d", testQueue.getAddRateLimitedCount())
+	}
+
+	// The refresh after each restore should have observed the job RUNNING on every node.
+	j, err := jobStore.Get(ctx, groupID, "job-1")
+	if err != nil {
+		t.Fatalf("failed to get job-1: %v", err)
+	}
+	for _, node := range nodeNames {
+		if state := j.ContextState()[node]; state != pb.SnapshotAgentJobState_STATE_RUNNING {
+			t.Errorf("Expected job-1 to be RUNNING on %s after restore, got %v", node, state)
+		}
+	}
+}
+
+// TestController_Reconcile_MultiNodeSnapshot_Concurrent verifies that snapshots of a
+// non-active job are issued to ALL nodes before the controller blocks waiting on any of
+// them, so one node's slow checkpoint cannot delay the peers' snapshots. Snapshot
+// operations here only complete once snapshots on every node are in flight, which a
+// serial issue-then-wait loop would never achieve.
+func TestController_Reconcile_MultiNodeSnapshot_Concurrent(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
+
+	groupID := "group-1"
+	nodeNames := []string{"node-1", "node-2", "node-3"}
+
+	group, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	group.Status().SetNodes(nodeNames)
+	group.Spec().SetActiveJob("job-1")
+
+	// job-2 (NOT the active job) is RUNNING on every node and must be snapshotted
+	// everywhere. job-1 has no pods yet, so no restore follows.
+	job2 := store.NewJob(groupID, "job-2")
+	for _, node := range nodeNames {
+		job2.UpdateContextState(node, pb.SnapshotAgentJobState_STATE_RUNNING)
+	}
+	if err := jobStore.Put(ctx, job2); err != nil {
+		t.Fatalf("failed to put job2: %v", err)
+	}
+
+	var mu sync.Mutex
+	snapshottedNodes := make(map[string]bool)
+	mockAgentStore := &controller.MockSnapshotAgentStore{
+		GetStatusFunc: func(ctx context.Context, node string) (*agentpb.StatusResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			state := agentpb.JobState_JOB_STATE_RUNNING
+			if len(snapshottedNodes) == len(nodeNames) {
+				state = agentpb.JobState_JOB_STATE_SAVED
+			}
+			return &agentpb.StatusResponse{
+				JobStatuses: []*agentpb.JobStatus{{JobId: "job-2", State: state}},
+			}, nil
+		},
+		SnapshotFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.SnapshotResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			snapshottedNodes[node] = true
+			return &agentpb.SnapshotResponse{OperationId: "op-snap-" + node}, nil
+		},
+		OperationFunc: func(ctx context.Context, node, operationID string) (*agentpb.GetOperationResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			// No snapshot completes until snapshots on ALL nodes are in flight.
+			if len(snapshottedNodes) < len(nodeNames) {
+				return &agentpb.GetOperationResponse{Status: agentpb.OperationStatus_OPERATION_STATUS_PENDING}, nil
+			}
+			return &agentpb.GetOperationResponse{Status: agentpb.OperationStatus_OPERATION_STATUS_COMPLETE}, nil
+		},
+	}
+
+	mockOrch := &mockInfrastructureOrchestrator{
+		observeFunc: func(ctx context.Context, gID string) error {
+			return nil
+		},
+	}
+
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
+
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+
+	testQueue.Add(groupID)
+
+	err = waitWithTimeout(func() bool { return testQueue.getDoneCount() > 0 }, 5*time.Second)
+	if err != nil {
+		t.Fatal("Timed out waiting for reconcile: multi-node snapshots were not issued concurrently across nodes")
+	}
+
+	mu.Lock()
+	if len(snapshottedNodes) != len(nodeNames) {
+		t.Errorf("Expected snapshot to be issued on all %d nodes, got %d: %v",
+			len(nodeNames), len(snapshottedNodes), snapshottedNodes)
+	}
+	mu.Unlock()
+
+	// The refresh after each snapshot should have observed the job SAVED on every node.
+	j, err := jobStore.Get(ctx, groupID, "job-2")
+	if err != nil {
+		t.Fatalf("failed to get job-2: %v", err)
+	}
+	for _, node := range nodeNames {
+		if state := j.ContextState()[node]; state != pb.SnapshotAgentJobState_STATE_SAVED {
+			t.Errorf("Expected job-2 to be SAVED on %s after snapshot, got %v", node, state)
+		}
+	}
+}
+
+// TestController_Reconcile_MultiNodeRestore_FailurePropagates verifies that when one
+// node's restore operation fails, the restores are still issued to all nodes (fan-out
+// happens before waiting) and the reconcile fails so the group is requeued.
+func TestController_Reconcile_MultiNodeRestore_FailurePropagates(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+	testQueue := &trackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test"},
+		),
+	}
+
+	groupID := "group-1"
+	nodeNames := []string{"node-1", "node-2"}
+
+	group, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	group.Status().SetNodes(nodeNames)
+	group.Spec().SetActiveJob("job-1")
+
+	job1 := store.NewJob(groupID, "job-1")
+	for _, node := range nodeNames {
+		job1.UpdateContextState(node, pb.SnapshotAgentJobState_STATE_SAVED)
+	}
+	if err := jobStore.Put(ctx, job1); err != nil {
+		t.Fatalf("failed to put job1: %v", err)
+	}
+
+	var mu sync.Mutex
+	restoredNodes := make(map[string]bool)
+	mockAgentStore := &controller.MockSnapshotAgentStore{
+		RestoreFunc: func(ctx context.Context, node, jobID, gID string) (*agentpb.RestoreResponse, error) {
+			mu.Lock()
+			defer mu.Unlock()
+			restoredNodes[node] = true
+			return &agentpb.RestoreResponse{OperationId: "op-restore-" + node}, nil
+		},
+		OperationFunc: func(ctx context.Context, node, operationID string) (*agentpb.GetOperationResponse, error) {
+			// node-2's restore fails; node-1's succeeds.
+			if node == "node-2" {
+				errMsg := "restore failed on node-2"
+				return &agentpb.GetOperationResponse{
+					Status: agentpb.OperationStatus_OPERATION_STATUS_FAILED,
+					Error:  &errMsg,
+				}, nil
+			}
+			return &agentpb.GetOperationResponse{Status: agentpb.OperationStatus_OPERATION_STATUS_COMPLETE}, nil
+		},
+	}
+
+	mockOrch := &mockInfrastructureOrchestrator{
+		observeFunc: func(ctx context.Context, gID string) error {
+			return nil
+		},
+	}
+
+	c := controller.NewController(groupStore, jobStore, testQueue, mockOrch, mockAgentStore)
+
+	go func() {
+		if err := c.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+
+	testQueue.Add(groupID)
+
+	// The failed restore must fail the reconcile and requeue the group.
+	err = waitWithTimeout(func() bool { return testQueue.getAddRateLimitedCount() > 0 }, 5*time.Second)
+	if err != nil {
+		t.Fatal("Timed out waiting for item to be re-queued (reconciliation should have failed)")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(restoredNodes) != len(nodeNames) {
+		t.Errorf("Expected restore to be issued on all %d nodes despite the failure, got %d: %v",
+			len(nodeNames), len(restoredNodes), restoredNodes)
+	}
+}
+
 func TestController_Reconcile_PreemptionSafetyGates_ActiveJobTransitioning(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/tests/integration/orchestrator/harness.go
+++ b/tests/integration/orchestrator/harness.go
@@ -115,7 +115,7 @@ func NewComposedHarness(t *testing.T) *ComposedHarness {
 	h.exclusiveLabel(t, trainerNode, integTrainers)
 
 	// Optional second sampler node: makes the samplers group multi-node for
-	// the MultiNodeSamplers scenario (labeled AFTER exclusiveLabel so it is
+	// the MultiNodeGroups scenario (labeled AFTER exclusiveLabel so it is
 	// not stripped).
 	if nodeB := os.Getenv("TEST_NODE_SAMPLERS_B"); nodeB != "" {
 		if nodeB == samplerNode || nodeB == trainerNode {

--- a/tests/integration/orchestrator/harness.go
+++ b/tests/integration/orchestrator/harness.go
@@ -110,21 +110,24 @@ func NewComposedHarness(t *testing.T) *ComposedHarness {
 		t.Logf("snapshot-agent chart pod ready at %s:%d on %s", ip, agentPort, node)
 	}
 
-	// Label each group node exclusively.
-	h.exclusiveLabel(t, samplerNode, integSamplers)
-	h.exclusiveLabel(t, trainerNode, integTrainers)
-
-	// Optional second sampler node: makes the samplers group multi-node for
-	// the MultiNodeGroups scenario (labeled AFTER exclusiveLabel so it is
-	// not stripped).
-	if nodeB := os.Getenv("TEST_NODE_SAMPLERS_B"); nodeB != "" {
+	// Optional second sampler node for the MultiNodeGroups scenario. Only
+	// validated here — the label is applied by that subtest itself, so the
+	// samplers group stays single-node for every other scenario (a second
+	// labeled node would give their jobs a second pod on the one shared claim).
+	nodeB := os.Getenv("TEST_NODE_SAMPLERS_B")
+	if nodeB != "" {
 		if nodeB == samplerNode || nodeB == trainerNode {
 			t.Fatalf("TEST_NODE_SAMPLERS_B %q must differ from TEST_NODE_SAMPLERS and TEST_NODE_TRAINERS", nodeB)
 		}
 		ip := h.WaitPodReadyByLabel(t, chartNamespace, saSelector, nodeB, orchPodTimeout)
 		t.Logf("snapshot-agent chart pod ready at %s:%d on %s (samplers node B)", ip, agentPort, nodeB)
-		h.labelNode(t, nodeB, integSamplers)
 	}
+
+	// Label each group node exclusively. nodeB is test-managed: a samplers
+	// label found on it is a leftover from an aborted run, stripped without a
+	// restore-on-cleanup.
+	h.exclusiveLabel(t, samplerNode, integSamplers, nodeB)
+	h.exclusiveLabel(t, trainerNode, integTrainers)
 
 	// Pre-clean: remove any leaked pods from a previous failed run.
 	h.cleanLeakedPods(t)
@@ -135,10 +138,23 @@ func NewComposedHarness(t *testing.T) *ComposedHarness {
 // exclusiveLabel ensures TEST_NODE is the ONLY node with the given group
 // label: it removes the label from all other nodes (restoring on cleanup)
 // and adds it to TEST_NODE (removing on cleanup).
-func (h *ComposedHarness) exclusiveLabel(t *testing.T, testNode, group string) {
+//
+// testManagedNodes are nodes this test run labels and unlabels itself (e.g.
+// TEST_NODE_SAMPLERS_B): a group label found on one is a leftover from an
+// aborted run, so it is stripped WITHOUT a restore cleanup — cleanups run
+// LIFO, so a restore registered here would run after the test's own label
+// removal and resurrect the leak.
+func (h *ComposedHarness) exclusiveLabel(t *testing.T, testNode, group string, testManagedNodes ...string) {
 	t.Helper()
 	ctx := context.Background()
 	labelKey := fmt.Sprintf("group.timeslice.io/%s", group)
+
+	testManaged := make(map[string]bool, len(testManagedNodes))
+	for _, n := range testManagedNodes {
+		if n != "" {
+			testManaged[n] = true
+		}
+	}
 
 	nodes, err := h.Client.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
@@ -155,6 +171,10 @@ func (h *ComposedHarness) exclusiveLabel(t *testing.T, testNode, group string) {
 		delete(n.Labels, labelKey)
 		if _, err := h.Client.CoreV1().Nodes().Update(ctx, n, metav1.UpdateOptions{}); err != nil {
 			t.Fatalf("removing label %s from node %s: %v", labelKey, n.Name, err)
+		}
+		if testManaged[n.Name] {
+			t.Logf("removed stale label %s from test-managed node %s (no restore)", labelKey, n.Name)
+			continue
 		}
 		t.Logf("temporarily removed label %s from node %s", labelKey, n.Name)
 		nodeName := n.Name

--- a/tests/integration/orchestrator/harness.go
+++ b/tests/integration/orchestrator/harness.go
@@ -114,6 +114,18 @@ func NewComposedHarness(t *testing.T) *ComposedHarness {
 	h.exclusiveLabel(t, samplerNode, integSamplers)
 	h.exclusiveLabel(t, trainerNode, integTrainers)
 
+	// Optional second sampler node: makes the samplers group multi-node for
+	// the MultiNodeSamplers scenario (labeled AFTER exclusiveLabel so it is
+	// not stripped).
+	if nodeB := os.Getenv("TEST_NODE_SAMPLERS_B"); nodeB != "" {
+		if nodeB == samplerNode || nodeB == trainerNode {
+			t.Fatalf("TEST_NODE_SAMPLERS_B %q must differ from TEST_NODE_SAMPLERS and TEST_NODE_TRAINERS", nodeB)
+		}
+		ip := h.WaitPodReadyByLabel(t, chartNamespace, saSelector, nodeB, orchPodTimeout)
+		t.Logf("snapshot-agent chart pod ready at %s:%d on %s (samplers node B)", ip, agentPort, nodeB)
+		h.labelNode(t, nodeB, integSamplers)
+	}
+
 	// Pre-clean: remove any leaked pods from a previous failed run.
 	h.cleanLeakedPods(t)
 

--- a/tests/integration/orchestrator/orchestrator_test.go
+++ b/tests/integration/orchestrator/orchestrator_test.go
@@ -112,7 +112,7 @@ func TestOrchestrator(t *testing.T) {
 		}
 	})
 
-	t.Run("MultiNodeSamplers", func(t *testing.T) {
+	t.Run("MultiNodeGroups", func(t *testing.T) {
 		if os.Getenv("TEST_NODE_SAMPLERS_B") == "" {
 			t.Skip("TEST_NODE_SAMPLERS_B not set; multi-node samplers topology not provisioned")
 		}
@@ -130,7 +130,7 @@ func TestOrchestrator(t *testing.T) {
 
 		client := pb.NewTimeSliceOrchestratorServiceClient(conn)
 
-		err = scenarios.RunMultiNodeSamplersScenario(
+		err = scenarios.RunMultiNodeGroupsScenario(
 			ctx,
 			h.Client,
 			client,
@@ -139,7 +139,7 @@ func TestOrchestrator(t *testing.T) {
 			"",  // trainer template key (default: PyTorch GPU burner)
 		)
 		if err != nil {
-			t.Fatalf("MultiNodeSamplers scenario failed: %v", err)
+			t.Fatalf("MultiNodeGroups scenario failed: %v", err)
 		}
 	})
 }

--- a/tests/integration/orchestrator/orchestrator_test.go
+++ b/tests/integration/orchestrator/orchestrator_test.go
@@ -113,9 +113,15 @@ func TestOrchestrator(t *testing.T) {
 	})
 
 	t.Run("MultiNodeGroups", func(t *testing.T) {
-		if os.Getenv("TEST_NODE_SAMPLERS_B") == "" {
+		nodeB := os.Getenv("TEST_NODE_SAMPLERS_B")
+		if nodeB == "" {
 			t.Skip("TEST_NODE_SAMPLERS_B not set; multi-node samplers topology not provisioned")
 		}
+		// Label nodeB here, not in harness setup, so the samplers group is
+		// multi-node only for this scenario (the earlier scenarios assume a
+		// single-node group); the subtest's cleanup removes the label.
+		h.labelNode(t, nodeB, integSamplers)
+
 		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 		defer cancel()
 

--- a/tests/integration/orchestrator/orchestrator_test.go
+++ b/tests/integration/orchestrator/orchestrator_test.go
@@ -112,4 +112,34 @@ func TestOrchestrator(t *testing.T) {
 		}
 	})
 
+	t.Run("MultiNodeSamplers", func(t *testing.T) {
+		if os.Getenv("TEST_NODE_SAMPLERS_B") == "" {
+			t.Skip("TEST_NODE_SAMPLERS_B not set; multi-node samplers topology not provisioned")
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+		defer cancel()
+
+		conn, err := grpc.NewClient(
+			h.OrchAddr,
+			grpc.WithTransportCredentials(insecure.NewCredentials()),
+		)
+		if err != nil {
+			t.Fatalf("dialing orchestrator at %s: %v", h.OrchAddr, err)
+		}
+		defer conn.Close()
+
+		client := pb.NewTimeSliceOrchestratorServiceClient(conn)
+
+		err = scenarios.RunMultiNodeSamplersScenario(
+			ctx,
+			h.Client,
+			client,
+			t,
+			"",  // sampler template key (default: PyTorch GPU burner)
+			"",  // trainer template key (default: PyTorch GPU burner)
+		)
+		if err != nil {
+			t.Fatalf("MultiNodeSamplers scenario failed: %v", err)
+		}
+	})
 }

--- a/tests/integration/orchestrator/scenarios/fake_rl_job.go
+++ b/tests/integration/orchestrator/scenarios/fake_rl_job.go
@@ -40,9 +40,25 @@ type FakeRLJob struct {
 	samplerSharedClaimName string
 	trainerSharedClaimName string
 
+	// perNodeClaims optionally maps groupID → nodeName → ResourceClaim name.
+	// When set for a group, deployPods pins one pod to each group node by
+	// hostname and wires it to that node's claim, producing a true multi-node
+	// group (context on every node). Without it, all of the group's pods use
+	// the single shared claim and DRA co-locates them on the claim's node.
+	perNodeClaims map[string]map[string]string
+
 	// Callbacks to control sampling/training behavior/duration
 	OnSampling func(ctx context.Context)
 	OnTraining func(ctx context.Context)
+}
+
+// SetPerNodeClaims registers a nodeName→claimName mapping for a group,
+// switching that group's pod deployment to one hostname-pinned pod per node.
+func (f *FakeRLJob) SetPerNodeClaims(groupID string, claimsByNode map[string]string) {
+	if f.perNodeClaims == nil {
+		f.perNodeClaims = make(map[string]map[string]string)
+	}
+	f.perNodeClaims[groupID] = claimsByNode
 }
 
 func NewFakeRLJob(
@@ -280,7 +296,8 @@ func (f *FakeRLJob) deployPods(ctx context.Context, groupID string) error {
 		return fmt.Errorf("no nodes found for group %s", groupID)
 	}
 
-	for range nodes.Items {
+	for i := range nodes.Items {
+		nodeName := nodes.Items[i].Name
 		podName := fmt.Sprintf("pod-%s-%s-%s", f.name, groupID, uuid.NewString()[:8])
 
 		var sharedClaimName string
@@ -289,6 +306,13 @@ func (f *FakeRLJob) deployPods(ctx context.Context, groupID string) error {
 			sharedClaimName = f.samplerSharedClaimName
 		case "trainers":
 			sharedClaimName = f.trainerSharedClaimName
+		}
+		if byNode := f.perNodeClaims[groupID]; byNode != nil {
+			claim, ok := byNode[nodeName]
+			if !ok {
+				return fmt.Errorf("no per-node claim registered for group %s node %s", groupID, nodeName)
+			}
+			sharedClaimName = claim
 		}
 
 		// Pull pod definition from factory using the correct template key
@@ -311,6 +335,11 @@ func (f *FakeRLJob) deployPods(ctx context.Context, groupID string) error {
 			pod.Spec.NodeSelector = make(map[string]string)
 		}
 		pod.Spec.NodeSelector[fmt.Sprintf("group.timeslice.io/%s", groupID)] = "true"
+		if f.perNodeClaims[groupID] != nil {
+			// Multi-node group: pin this pod to its node so each node gets
+			// exactly one pod wired to that node's claim.
+			pod.Spec.NodeSelector["kubernetes.io/hostname"] = nodeName
+		}
 
 		// Add tolerations for timeslice.io/shared and default GKE GPU taints
 		pod.Spec.Tolerations = append(pod.Spec.Tolerations,

--- a/tests/integration/orchestrator/scenarios/scenarios.go
+++ b/tests/integration/orchestrator/scenarios/scenarios.go
@@ -313,16 +313,19 @@ func RunMultiNodeGroupsScenario(
 		trainerClaims[node] = name
 		allClaims = append(allClaims, name)
 	}
+	var createdClaims []string
+	defer func() {
+		for _, name := range createdClaims {
+			if err := deleteSharedClaim(ctx, clientset, name); err != nil {
+				logger.Errorf("Failed to delete shared claim %s: %v", name, err)
+			}
+		}
+	}()
 	for _, name := range allClaims {
 		if err := createSharedClaim(ctx, clientset, name); err != nil {
 			return err
 		}
-		claimName := name
-		defer func() {
-			if err := deleteSharedClaim(ctx, clientset, claimName); err != nil {
-				logger.Errorf("Failed to delete shared claim %s: %v", claimName, err)
-			}
-		}()
+		createdClaims = append(createdClaims, name)
 	}
 
 	newJob := func(name string) *FakeRLJob {

--- a/tests/integration/orchestrator/scenarios/scenarios.go
+++ b/tests/integration/orchestrator/scenarios/scenarios.go
@@ -267,13 +267,13 @@ func RunQueuedRLJobsScenario(
 	return nil
 }
 
-// RunMultiNodeSamplersScenario validates concurrent multi-node checkpoint/
+// RunMultiNodeGroupsScenario validates concurrent multi-node checkpoint/
 // restore on a samplers group spanning two or more nodes. Each job deploys
 // one GPU pod pinned to EVERY sampler node (per-node shared claims), so each
 // samplers handoff must snapshot the outgoing job and restore the incoming
 // job on ALL nodes of the group — exercising the concurrent fan-out in
 // reconcileNonActiveJobsSnapshot / reconcileActiveJobRestore on real GPUs.
-func RunMultiNodeSamplersScenario(
+func RunMultiNodeGroupsScenario(
 	ctx context.Context,
 	clientset kubernetes.Interface,
 	client pb.TimeSliceOrchestratorServiceClient,
@@ -281,14 +281,14 @@ func RunMultiNodeSamplersScenario(
 	samplerTemplateKey string,
 	trainerTemplateKey string,
 ) error {
-	logger.Log("Starting Multi-Node Samplers Scenario")
+	logger.Log("Starting Multi-Node Groups Scenario")
 
 	samplerNodes, err := listGroupNodes(ctx, clientset, "samplers")
 	if err != nil {
 		return err
 	}
 	if len(samplerNodes) < 2 {
-		return fmt.Errorf("multi-node samplers scenario needs >=2 sampler nodes, found %d", len(samplerNodes))
+		return fmt.Errorf("multi-node groups scenario needs >=2 sampler nodes, found %d", len(samplerNodes))
 	}
 	trainerNodes, err := listGroupNodes(ctx, clientset, "trainers")
 	if err != nil {
@@ -411,7 +411,7 @@ func RunMultiNodeSamplersScenario(
 		return fmt.Errorf("timed out waiting for pods cleanup: %w", err)
 	}
 
-	logger.Log("Multi-Node Samplers Scenario completed successfully")
+	logger.Log("Multi-Node Groups Scenario completed successfully")
 	return nil
 }
 

--- a/tests/integration/orchestrator/scenarios/scenarios.go
+++ b/tests/integration/orchestrator/scenarios/scenarios.go
@@ -17,6 +17,7 @@ package scenarios
 import (
 	"context"
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -264,6 +265,170 @@ func RunQueuedRLJobsScenario(
 
 	logger.Log("Queued RL Jobs Scenario completed successfully")
 	return nil
+}
+
+// RunMultiNodeSamplersScenario validates concurrent multi-node checkpoint/
+// restore on a samplers group spanning two or more nodes. Each job deploys
+// one GPU pod pinned to EVERY sampler node (per-node shared claims), so each
+// samplers handoff must snapshot the outgoing job and restore the incoming
+// job on ALL nodes of the group — exercising the concurrent fan-out in
+// reconcileNonActiveJobsSnapshot / reconcileActiveJobRestore on real GPUs.
+func RunMultiNodeSamplersScenario(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	client pb.TimeSliceOrchestratorServiceClient,
+	logger Logger,
+	samplerTemplateKey string,
+	trainerTemplateKey string,
+) error {
+	logger.Log("Starting Multi-Node Samplers Scenario")
+
+	samplerNodes, err := listGroupNodes(ctx, clientset, "samplers")
+	if err != nil {
+		return err
+	}
+	if len(samplerNodes) < 2 {
+		return fmt.Errorf("multi-node samplers scenario needs >=2 sampler nodes, found %d", len(samplerNodes))
+	}
+	trainerNodes, err := listGroupNodes(ctx, clientset, "trainers")
+	if err != nil {
+		return err
+	}
+	if len(trainerNodes) == 0 {
+		return fmt.Errorf("no trainer nodes labeled")
+	}
+
+	// One shared claim per node per group; both jobs reference the same claim
+	// on a given node, so their pods co-reside on that node's GPU.
+	samplerClaims := make(map[string]string, len(samplerNodes))
+	trainerClaims := make(map[string]string, len(trainerNodes))
+	var allClaims []string
+	for i, node := range samplerNodes {
+		name := fmt.Sprintf("claim-mn-samplers-%d", i)
+		samplerClaims[node] = name
+		allClaims = append(allClaims, name)
+	}
+	for i, node := range trainerNodes {
+		name := fmt.Sprintf("claim-mn-trainers-%d", i)
+		trainerClaims[node] = name
+		allClaims = append(allClaims, name)
+	}
+	for _, name := range allClaims {
+		if err := createSharedClaim(ctx, clientset, name); err != nil {
+			return err
+		}
+		claimName := name
+		defer func() {
+			if err := deleteSharedClaim(ctx, clientset, claimName); err != nil {
+				logger.Errorf("Failed to delete shared claim %s: %v", claimName, err)
+			}
+		}()
+	}
+
+	newJob := func(name string) *FakeRLJob {
+		j := NewFakeRLJob(
+			name, client, clientset, 2, logger,
+			samplerTemplateKey, trainerTemplateKey,
+			"", "", // shared claim names unused: per-node claims below
+		)
+		j.SetPerNodeClaims("samplers", samplerClaims)
+		j.SetPerNodeClaims("trainers", trainerClaims)
+		return j
+	}
+	jobA := newJob("job-mn-a")
+	jobB := newJob("job-mn-b")
+
+	// Coordination mirrors RunQueuedRLJobsScenario: A blocks in its first
+	// sampling phase (holding the multi-node samplers lock) until the test
+	// has confirmed B is queued behind it.
+	jobASampling := make(chan struct{})
+	unblockJobA := make(chan struct{})
+	var coordOnce sync.Once
+	jobA.OnSampling = func(ctx context.Context) {
+		coordOnce.Do(func() {
+			logger.Log("[Test] Job A is sampling on the multi-node group, blocking...")
+			close(jobASampling)
+			select {
+			case <-unblockJobA:
+			case <-ctx.Done():
+			}
+		})
+	}
+	quick := func(ctx context.Context) { time.Sleep(10 * time.Millisecond) }
+	jobA.OnTraining = quick
+	jobB.OnSampling = quick
+	jobB.OnTraining = quick
+
+	jobAErr := make(chan error, 1)
+	go func() { jobAErr <- jobA.Run(ctx) }()
+
+	select {
+	case <-jobASampling:
+		logger.Log("[Test] Confirmed Job A holds the multi-node samplers lock")
+	case <-time.After(10 * time.Minute):
+		return fmt.Errorf("timed out waiting for Job A to start sampling")
+	}
+
+	jobBErr := make(chan error, 1)
+	go func() { jobBErr <- jobB.Run(ctx) }()
+	time.Sleep(1 * time.Second)
+
+	resp, err := client.GetGroupStatus(ctx, &pb.GetGroupStatusRequest{GroupId: "samplers"})
+	if err != nil {
+		return fmt.Errorf("failed to get samplers group status: %w", err)
+	}
+	if resp.Group.LockingJob != "job-mn-a" {
+		return fmt.Errorf("expected lockingJob job-mn-a, got %q", resp.Group.LockingJob)
+	}
+	logger.Log("[Test] Job B queued; unblocking Job A...")
+	close(unblockJobA)
+
+	for _, j := range []struct {
+		name string
+		ch   chan error
+	}{{"job-mn-a", jobAErr}, {"job-mn-b", jobBErr}} {
+		select {
+		case err := <-j.ch:
+			if err != nil {
+				return fmt.Errorf("%s failed: %w", j.name, err)
+			}
+		case <-time.After(15 * time.Minute):
+			return fmt.Errorf("timed out waiting for %s to complete", j.name)
+		}
+	}
+
+	// Post-cleanup: no pods left for either job.
+	err = wait.PollUntilContextTimeout(ctx, 500*time.Millisecond, 10*time.Second, true, func(ctx context.Context) (bool, error) {
+		pods, err := clientset.CoreV1().Pods("default").List(ctx, metav1.ListOptions{
+			LabelSelector: "timeslice.io/job-id in (job-mn-a, job-mn-b)",
+		})
+		if err != nil {
+			return false, err
+		}
+		return len(pods.Items) == 0, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for pods cleanup: %w", err)
+	}
+
+	logger.Log("Multi-Node Samplers Scenario completed successfully")
+	return nil
+}
+
+// listGroupNodes returns the sorted names of nodes labeled for the group.
+func listGroupNodes(ctx context.Context, clientset kubernetes.Interface, groupID string) ([]string, error) {
+	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("group.timeslice.io/%s=true", groupID),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list nodes for group %s: %w", groupID, err)
+	}
+	names := make([]string, 0, len(nodes.Items))
+	for i := range nodes.Items {
+		names = append(names, nodes.Items[i].Name)
+	}
+	sort.Strings(names)
+	return names, nil
 }
 
 //nolint:gocritic

--- a/tests/integration/orchestrator/scenarios/scenarios.go
+++ b/tests/integration/orchestrator/scenarios/scenarios.go
@@ -271,8 +271,8 @@ func RunQueuedRLJobsScenario(
 // restore on a samplers group spanning two or more nodes. Each job deploys
 // one GPU pod pinned to EVERY sampler node (per-node shared claims), so each
 // samplers handoff must snapshot the outgoing job and restore the incoming
-// job on ALL nodes of the group — exercising the concurrent fan-out in
-// reconcileNonActiveJobsSnapshot / reconcileActiveJobRestore on real GPUs.
+// job on ALL nodes of the group — exercising the concurrent per-node
+// reconcile fan-out (parallel reconcileNode) on real GPUs.
 func RunMultiNodeGroupsScenario(
 	ctx context.Context,
 	clientset kubernetes.Interface,
@@ -315,8 +315,11 @@ func RunMultiNodeGroupsScenario(
 	}
 	var createdClaims []string
 	defer func() {
+		// Survive scenario-deadline expiry: a leaked still-allocated claim
+		// poisons the next run (createSharedClaim tolerates AlreadyExists).
+		cleanupCtx := context.WithoutCancel(ctx)
 		for _, name := range createdClaims {
-			if err := deleteSharedClaim(ctx, clientset, name); err != nil {
+			if err := deleteSharedClaim(cleanupCtx, clientset, name); err != nil {
 				logger.Errorf("Failed to delete shared claim %s: %v", name, err)
 			}
 		}

--- a/tests/integration/orchestrator/simulate/fakes.go
+++ b/tests/integration/orchestrator/simulate/fakes.go
@@ -55,7 +55,19 @@ type FakeSnapshotAgentStore struct {
 	mu                sync.Mutex
 	jobStates         map[string]map[string]agentpb.JobState // node -> job -> state
 	pendingOperations map[string]pendingOp
+	releasedOps       map[string]bool // op IDs whose rendezvous cohort already met the threshold
 	opCounter         int
+
+	// RestoreRendezvous, when set to N > 1, models a multi-host accelerator
+	// slice (e.g. TPU libtpu): a restore operation for a job cannot complete
+	// until restores for that job are pending on at least N nodes
+	// simultaneously. GetOperation reports PENDING below the threshold, so a
+	// controller that issues restores serially and blocks per node deadlocks.
+	RestoreRendezvous int
+	// SnapshotRendezvous is the same gate for snapshot operations. Real
+	// hardware has no snapshot rendezvous; the gate lets tests verify the
+	// controller issues snapshots concurrently across nodes.
+	SnapshotRendezvous int
 
 	// Optional hooks for tests to observe events
 	OnSnapshot func(node, jobID string)
@@ -66,6 +78,7 @@ func NewFakeSnapshotAgentStore() *FakeSnapshotAgentStore {
 	return &FakeSnapshotAgentStore{
 		jobStates:         make(map[string]map[string]agentpb.JobState),
 		pendingOperations: make(map[string]pendingOp),
+		releasedOps:       make(map[string]bool),
 	}
 }
 
@@ -179,9 +192,36 @@ func (f *FakeSnapshotAgentStore) GetOperation(
 		return &agentpb.GetOperationResponse{Status: agentpb.OperationStatus_OPERATION_STATUS_FAILED}, nil
 	}
 
+	// Enforce the rendezvous gate: the operation stays pending until enough
+	// peer operations of the same type for the same job are in flight. Once the
+	// threshold is met the whole cohort is released together (completed members
+	// leaving pendingOperations must not re-block their peers).
+	required := 0
+	switch op.opType {
+	case "restore":
+		required = f.RestoreRendezvous
+	case "snapshot":
+		required = f.SnapshotRendezvous
+	}
+	if required > 1 && !f.releasedOps[operationID] {
+		cohort := []string{}
+		for id, p := range f.pendingOperations {
+			if p.opType == op.opType && p.job == op.job {
+				cohort = append(cohort, id)
+			}
+		}
+		if len(cohort) < required {
+			return &agentpb.GetOperationResponse{Status: agentpb.OperationStatus_OPERATION_STATUS_PENDING}, nil
+		}
+		for _, id := range cohort {
+			f.releasedOps[id] = true
+		}
+	}
+
 	// Apply the transition
 	f.jobStates[op.node][op.job] = op.targetState
 	delete(f.pendingOperations, operationID)
+	delete(f.releasedOps, operationID)
 
 	return &agentpb.GetOperationResponse{
 		Status:    agentpb.OperationStatus_OPERATION_STATUS_COMPLETE,

--- a/tests/integration/orchestrator/simulate/fakes.go
+++ b/tests/integration/orchestrator/simulate/fakes.go
@@ -64,9 +64,10 @@ type FakeSnapshotAgentStore struct {
 	// simultaneously. GetOperation reports PENDING below the threshold, so a
 	// controller that issues restores serially and blocks per node deadlocks.
 	RestoreRendezvous int
-	// SnapshotRendezvous is the same gate for snapshot operations. Real
-	// hardware has no snapshot rendezvous; the gate lets tests verify the
-	// controller issues snapshots concurrently across nodes.
+	// SnapshotRendezvous is the same gate for snapshot operations. Multi-host
+	// checkpoint is also effectively rendezvoused: a host cannot quiesce and
+	// park while its peers are still issuing collectives, so the checkpoint
+	// only completes once every host of the slice is snapshotting.
 	SnapshotRendezvous int
 
 	// Optional hooks for tests to observe events

--- a/tests/integration/orchestrator/simulate/fakes.go
+++ b/tests/integration/orchestrator/simulate/fakes.go
@@ -204,13 +204,18 @@ func (f *FakeSnapshotAgentStore) GetOperation(
 		required = f.SnapshotRendezvous
 	}
 	if required > 1 && !f.releasedOps[operationID] {
+		// The rendezvous requires DISTINCT nodes in flight — counting bare
+		// operations would let two ops on one node (e.g. a retried trigger)
+		// satisfy a "multi-node" threshold.
 		cohort := []string{}
+		cohortNodes := map[string]bool{}
 		for id, p := range f.pendingOperations {
 			if p.opType == op.opType && p.job == op.job {
 				cohort = append(cohort, id)
+				cohortNodes[p.node] = true
 			}
 		}
-		if len(cohort) < required {
+		if len(cohortNodes) < required {
 			return &agentpb.GetOperationResponse{Status: agentpb.OperationStatus_OPERATION_STATUS_PENDING}, nil
 		}
 		for _, id := range cohort {

--- a/tests/integration/orchestrator/simulate/multinode_test.go
+++ b/tests/integration/orchestrator/simulate/multinode_test.go
@@ -111,7 +111,7 @@ func TestSimulated_MultiNodeGroup_RendezvousSwitch(t *testing.T) {
 	// moment to catch up before asserting exact values.
 	// A timeout here just means the exact-count asserts below fail with details.
 	waitForCounts := func(counts map[string]int, want int) {
-		_ = wait.PollUntilContextTimeout(ctx, 50*time.Millisecond, 2*time.Second, true,
+		err := wait.PollUntilContextTimeout(ctx, 50*time.Millisecond, 2*time.Second, true,
 			func(ctx context.Context) (bool, error) {
 				mu.Lock()
 				defer mu.Unlock()
@@ -122,6 +122,9 @@ func TestSimulated_MultiNodeGroup_RendezvousSwitch(t *testing.T) {
 				}
 				return true, nil
 			})
+		if err != nil {
+			t.Logf("counters did not converge to %d: %v (exact-count asserts below report details)", want, err)
+		}
 	}
 
 	// 4. Switch 1: job-2 becomes active. The controller must checkpoint job-1 on all

--- a/tests/integration/orchestrator/simulate/multinode_test.go
+++ b/tests/integration/orchestrator/simulate/multinode_test.go
@@ -1,0 +1,175 @@
+package simulate_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	agentpb "github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/snapshot-agent/api/v1alpha1"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/timeslice-orchestrator/controller"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/pkg/timeslice-orchestrator/store"
+	"github.com/llm-d-incubation/llm-d-rl-time-slicing/tests/integration/orchestrator/simulate"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/util/workqueue"
+)
+
+// noopInfraOrchestrator satisfies controller.InfrastructureOrchestrator for tests
+// that set up group/job state in the stores directly.
+type noopInfraOrchestrator struct{}
+
+func (n *noopInfraOrchestrator) Init(ctx context.Context) error { return nil }
+func (n *noopInfraOrchestrator) ObserveGroupState(ctx context.Context, groupID string) error {
+	return nil
+}
+
+// TestSimulated_MultiNodeGroup_RendezvousSwitch drives the controller through two full
+// job switches on a 3-node group whose fake snapshot agents enforce slice-wide
+// rendezvous semantics (as multi-host TPU/libtpu does): a checkpoint or restore
+// operation only completes once the same operation is in flight on every node of the
+// group. If the controller issued the operations serially and blocked per node, the
+// first node's operation would stay pending forever and this test would time out.
+func TestSimulated_MultiNodeGroup_RendezvousSwitch(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	groupID := "trainers"
+	nodes := []string{"node-1", "node-2", "node-3"}
+
+	// 1. Stores with a 3-node group.
+	lockStore := store.NewMemLockStore()
+	groupStore := store.NewGroupStore(lockStore)
+	jobStore := store.NewJobStore()
+
+	group, _, err := groupStore.GetOrCreate(ctx, groupID)
+	if err != nil {
+		t.Fatalf("failed to create group: %v", err)
+	}
+	group.Status().SetNodes(nodes)
+
+	// 2. Fake agents with multi-host rendezvous on both operation types.
+	fakeAgentStore := simulate.NewFakeSnapshotAgentStore()
+	fakeAgentStore.RestoreRendezvous = len(nodes)
+	fakeAgentStore.SnapshotRendezvous = len(nodes)
+
+	// job-1 is loaded (RUNNING) on the whole slice; job-2 is parked (SAVED).
+	for _, node := range nodes {
+		fakeAgentStore.SetJobState(node, "job-1", agentpb.JobState_JOB_STATE_RUNNING)
+		fakeAgentStore.SetJobState(node, "job-2", agentpb.JobState_JOB_STATE_SAVED)
+	}
+
+	// Jobs must exist in the store for ObserveJobContext to track their states.
+	if err := jobStore.Put(ctx, store.NewJob(groupID, "job-1")); err != nil {
+		t.Fatalf("failed to put job-1: %v", err)
+	}
+	if err := jobStore.Put(ctx, store.NewJob(groupID, "job-2")); err != nil {
+		t.Fatalf("failed to put job-2: %v", err)
+	}
+
+	// Record which nodes each operation type was issued on.
+	var mu sync.Mutex
+	snapshotNodes := make(map[string]int)
+	restoreNodes := make(map[string]int)
+	fakeAgentStore.OnSnapshot = func(node, jobID string) {
+		mu.Lock()
+		defer mu.Unlock()
+		snapshotNodes[node]++
+	}
+	fakeAgentStore.OnRestore = func(node, jobID string) {
+		mu.Lock()
+		defer mu.Unlock()
+		restoreNodes[node]++
+	}
+
+	// 3. Controller.
+	queue := &simulate.TrackQueue{
+		TypedRateLimitingInterface: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "test-multinode-rendezvous"},
+		),
+	}
+	ctrl := controller.NewController(groupStore, jobStore, queue, &noopInfraOrchestrator{}, fakeAgentStore)
+	go func() {
+		if err := ctrl.Run(ctx, 1); err != nil {
+			t.Errorf("Controller Run failed: %v", err)
+		}
+	}()
+
+	waitForStates := func(jobID string, want agentpb.JobState) error {
+		return wait.PollUntilContextTimeout(ctx, 200*time.Millisecond, 20*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				for _, node := range nodes {
+					if fakeAgentStore.GetJobState(node, jobID) != want {
+						return false, nil
+					}
+				}
+				return true, nil
+			})
+	}
+
+	// The OnSnapshot/OnRestore hooks fire asynchronously, so give the counters a
+	// moment to catch up before asserting exact values.
+	// A timeout here just means the exact-count asserts below fail with details.
+	waitForCounts := func(counts map[string]int, want int) {
+		_ = wait.PollUntilContextTimeout(ctx, 50*time.Millisecond, 2*time.Second, true,
+			func(ctx context.Context) (bool, error) {
+				mu.Lock()
+				defer mu.Unlock()
+				for _, node := range nodes {
+					if counts[node] != want {
+						return false, nil
+					}
+				}
+				return true, nil
+			})
+	}
+
+	// 4. Switch 1: job-2 becomes active. The controller must checkpoint job-1 on all
+	// three nodes concurrently, then restore job-2 on all three nodes concurrently.
+	group.Spec().SetActiveJob("job-2")
+	queue.Add(groupID)
+
+	if err := waitForStates("job-1", agentpb.JobState_JOB_STATE_SAVED); err != nil {
+		t.Fatalf("switch 1: job-1 was not checkpointed on all nodes (rendezvous deadlock?): %v", err)
+	}
+	if err := waitForStates("job-2", agentpb.JobState_JOB_STATE_RUNNING); err != nil {
+		t.Fatalf("switch 1: job-2 was not restored on all nodes (rendezvous deadlock?): %v", err)
+	}
+
+	waitForCounts(snapshotNodes, 1)
+	waitForCounts(restoreNodes, 1)
+	mu.Lock()
+	for _, node := range nodes {
+		if snapshotNodes[node] != 1 {
+			t.Errorf("switch 1: expected exactly 1 snapshot on %s, got %d", node, snapshotNodes[node])
+		}
+		if restoreNodes[node] != 1 {
+			t.Errorf("switch 1: expected exactly 1 restore on %s, got %d", node, restoreNodes[node])
+		}
+	}
+	mu.Unlock()
+
+	// 5. Switch 2: back to job-1, proving repeated rendezvous switches converge.
+	group.Spec().SetActiveJob("job-1")
+	queue.Add(groupID)
+
+	if err := waitForStates("job-2", agentpb.JobState_JOB_STATE_SAVED); err != nil {
+		t.Fatalf("switch 2: job-2 was not checkpointed on all nodes: %v", err)
+	}
+	if err := waitForStates("job-1", agentpb.JobState_JOB_STATE_RUNNING); err != nil {
+		t.Fatalf("switch 2: job-1 was not restored on all nodes: %v", err)
+	}
+
+	waitForCounts(snapshotNodes, 2)
+	waitForCounts(restoreNodes, 2)
+	mu.Lock()
+	defer mu.Unlock()
+	for _, node := range nodes {
+		if snapshotNodes[node] != 2 {
+			t.Errorf("switch 2: expected 2 snapshots total on %s, got %d", node, snapshotNodes[node])
+		}
+		if restoreNodes[node] != 2 {
+			t.Errorf("switch 2: expected 2 restores total on %s, got %d", node, restoreNodes[node])
+		}
+	}
+}

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -59,7 +59,7 @@ while [[ $# -gt 0 ]]; do
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
 # TEST_RUN_PATTERN overrides the phase-derived go test -run pattern (e.g. a
-# single subtest like TestOrchestrator/MultiNodeSamplers).
+# single subtest like TestOrchestrator/MultiNodeGroups).
 RUN_PATTERN="${TEST_RUN_PATTERN:-$RUN_PATTERN}"
 done
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -58,9 +58,6 @@ while [[ $# -gt 0 ]]; do
     --skip-cleanup) SKIP_CLEANUP=true; shift ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
-# TEST_RUN_PATTERN overrides the phase-derived go test -run pattern (e.g. a
-# single subtest like TestOrchestrator/MultiNodeGroups).
-RUN_PATTERN="${TEST_RUN_PATTERN:-$RUN_PATTERN}"
 done
 
 usage() {
@@ -81,6 +78,9 @@ case "$PHASE" in
                 NEED_STANDALONE=true; NEED_SA_CHART=true; NEED_ORCH_CHART=true ;;
   *) echo "Unknown phase: $PHASE"; usage; exit 1 ;;
 esac
+# TEST_RUN_PATTERN overrides the phase-derived go test -run pattern (e.g. a
+# single subtest like TestOrchestrator/MultiNodeGroups).
+RUN_PATTERN="${TEST_RUN_PATTERN:-$RUN_PATTERN}"
 
 # --build produces the image(s) from the working directory via Cloud Build,
 # tagged with the current commit so repeated runs don't fight IfNotPresent

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -58,6 +58,9 @@ while [[ $# -gt 0 ]]; do
     --skip-cleanup) SKIP_CLEANUP=true; shift ;;
     *) echo "Unknown option: $1"; exit 1 ;;
   esac
+# TEST_RUN_PATTERN overrides the phase-derived go test -run pattern (e.g. a
+# single subtest like TestOrchestrator/MultiNodeSamplers).
+RUN_PATTERN="${TEST_RUN_PATTERN:-$RUN_PATTERN}"
 done
 
 usage() {
@@ -144,6 +147,9 @@ cleanup() {
     if [[ -n "${TEST_NODE_TRAINERS:-}" ]]; then
       $K label node "$TEST_NODE_TRAINERS" "group.timeslice.io/trainers-" 2>/dev/null || true
     fi
+    if [[ -n "${TEST_NODE_SAMPLERS_B:-}" ]]; then
+      $K label node "$TEST_NODE_SAMPLERS_B" "group.timeslice.io/samplers-" 2>/dev/null || true
+    fi
   fi
   if [[ "$NEED_SA_CHART" == "true" ]]; then
     $HELM uninstall sa-chart-test -n timeslice-system 2>/dev/null || true
@@ -219,7 +225,7 @@ if [[ "$NEED_SA_CHART" == "true" ]]; then
     log "Installing the official snapshot-agent chart (both group nodes, port ${CHART_AGENT_PORT})..."
     $HELM upgrade --install sa-chart-test "${REPO_ROOT}/deploy/snapshot-agent" "${SA_HELM_ARGS[@]}"
     SA_SELECTOR="app.kubernetes.io/name=snapshot-agent,app.kubernetes.io/instance=sa-chart-test"
-    for NODE in "$TEST_NODE_SAMPLERS" "$TEST_NODE_TRAINERS"; do
+    for NODE in "$TEST_NODE_SAMPLERS" "$TEST_NODE_TRAINERS" ${TEST_NODE_SAMPLERS_B:+"$TEST_NODE_SAMPLERS_B"}; do
       log "Waiting for the chart's DaemonSet pod to become Ready on ${NODE}..."
       wait_chart_pods_ready "$SA_SELECTOR" "$NODE" || chart_failure "snapshot-agent" "$SA_SELECTOR"
     done
@@ -286,6 +292,7 @@ EXIT=0
 $K exec test-runner -- env "MODEL=${MODEL}" "TEST_NODE=${TEST_NODE:-}" \
   "TEST_NODE_SAMPLERS=${TEST_NODE_SAMPLERS:-}" \
   "TEST_NODE_TRAINERS=${TEST_NODE_TRAINERS:-}" \
+  "TEST_NODE_SAMPLERS_B=${TEST_NODE_SAMPLERS_B:-}" \
   "SA_CHART_DEPLOYED=${SA_CHART_DEPLOYED}" \
   "ORCH_CHART_DEPLOYED=${ORCH_CHART_DEPLOYED}" \
   "CHART_AGENT_PORT=${CHART_AGENT_PORT}" \


### PR DESCRIPTION
## What does this PR do?

Support concurrent TPU checkpoint

## Why is this change needed?

Concurrent checkpoint across nodes is required for multi-node TPU training.

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [x] Unit tests added/updated
- [x] Integration/e2e tests added/updated
- [x] Manual testing performed



## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

Integration test results
  === RUN   TestOrchestrator
  === RUN   TestOrchestrator/SingleRLJob
      scenarios.go:41: Starting Single RL Job Scenario
      scenarios.go:100: Single RL Job Scenario completed successfully
  === RUN   TestOrchestrator/QueuedRLJobs (already failed test)
      fake_rl_job.go:108: [Job job-a] WARNING: Acquire for group trainers returned transient error
          (rpc error: code = Unavailable desc = group trainers is faulted), retrying in 500ms (attempt 20/20)...
      scenarios.go:185: [Test] Job A exited with error: loop failed: failed to acquire lock for trainers after retries
      orchestrator_test.go:86: QueuedRLJobs scenario failed: job A failed
  === RUN   TestOrchestrator/MultiNodeGroups
      scenarios.go:283: Starting Multi-Node Groups Scenario
  panic: Fail in goroutine after TestOrchestrator/QueuedRLJobs has completed
  FAIL    github.com/llm-d-incubation/llm-d-rl-time-slicing/tests/integration/orchestrator  436.338s


## Related Issues

https://github.com/llm-d-incubation/llm-d-rl-time-slicing/issues/155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Multi-node checkpoint snapshots and active-job restores now run concurrently across all nodes, supporting coordinated accelerator workloads.
  - Added configurable settling time before queued jobs are promoted.
  - Integration environments can optionally configure a second sampler node for multi-node scenarios.

- **Bug Fixes**
  - Restore failures now propagate correctly while ensuring all node operations are initiated before retry.
  - Missing active jobs are handled explicitly during restore operations.

- **Tests**
  - Added coverage for multi-node switching, rendezvous behavior, queued jobs, failure handling, and cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->