### PR TITLE
[GPU-CR Selective Checkpoint 8/N]: Enable runtime buffer sizing and ctl-mode coordination

### DIFF
--- a/third_party/gpu-cr/CMakeLists.txt
+++ b/third_party/gpu-cr/CMakeLists.txt
@@ -143,6 +143,8 @@ target_compile_options(multi_cr_client PRIVATE -O3 -g)
 #                              runtime-config code, plus the
 #                              upstream-baseline control channel, buffer
 #                              mapping, fd exchange and memcpy_multi
+#   gpu_cr_deferred_tests    — deferred dump-buffer mode (GPU_CR_SHM_MB=0);
+#                              its own process because Config() is cached
 #   fake_workload            — GPU-free stand-in for the vGPU.so side of the
 #                              control channel
 #   cr_client_integration    — drives the real cr_client binary against
@@ -185,19 +187,27 @@ if(GPU_CR_BUILD_TESTS)
         # selective_spec_test includes coordinator/selective_spec.h
         ${CMAKE_CURRENT_SOURCE_DIR}/coordinator
     )
-    # The file backend reserves the full dump-buffer size up front
-    # (posix_fallocate); pin the suite to the 1GiB minimum so the
-    # mmap-backend tests don't reserve the 25GiB production default per
-    # checkpoint id. Expressed as compile *options* (-U then -D) so the
-    # override lands after any directory-level -DSHM_SIZE_GB from the
-    # build harness in the generated compile command.
-    target_compile_options(gpu_cr_unit_tests PRIVATE -USHM_SIZE_GB -DSHM_SIZE_GB=1)
     target_link_libraries(gpu_cr_unit_tests PRIVATE GTest::gtest_main pthread)
     add_test(NAME unit COMMAND gpu_cr_unit_tests)
+
+    # Deferred dump-buffer mode needs its own process: Config() is a
+    # process-cached singleton, so GPU_CR_SHM_MB=0 cannot coexist with the
+    # eager-mode suite above.
+    add_executable(gpu_cr_deferred_tests
+        ${CMAKE_CURRENT_SOURCE_DIR}/tests/unit/mmap_backend_deferred_test.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/backend/mmap_backend.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu_cr_config.cpp
+    )
+    target_include_directories(gpu_cr_deferred_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+    )
+    target_link_libraries(gpu_cr_deferred_tests PRIVATE GTest::gtest_main pthread)
+    add_test(NAME unit_deferred COMMAND gpu_cr_deferred_tests)
 
     add_executable(fake_workload
         ${CMAKE_CURRENT_SOURCE_DIR}/tests/integration/fake_workload.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/src/comm/share_mem.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/gpu_cr_config.cpp
     )
     target_include_directories(fake_workload PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src

--- a/third_party/gpu-cr/README.llm-d.md
+++ b/third_party/gpu-cr/README.llm-d.md
@@ -27,7 +27,13 @@ required, cleaned up and tested:
 
 - memory-address (selective) checkpoint backend, unrounded allocation-size
   dumps, and granule-chunked copies
-- destination-path selective checkpoints
+- destination-path selective checkpoints,
+  control channel off hugetlbfs (readiness advertisements),
+  runtime-sizable checkpoint buffers (`GPU_CR_SHM_GB`/`_MB`,
+  `GPU_CR_STAGING_MB`) — destination-path-only deployments should set
+  `GPU_CR_SHM_MB=0`: dest-path ops never touch the dump buffer, so
+  deferred mode drops the reservation entirely (pool sizing rule in
+  `src/gpu_cr_config.h`)
 - Google C++ Style Guide cleanup of the added code, and cr_client
   hardening (`GPU_CR_CUDA_CHECKPOINT` override; restore fails on a failed
   cuda-checkpoint toggle)

--- a/third_party/gpu-cr/coordinator/cr_client.cpp
+++ b/third_party/gpu-cr/coordinator/cr_client.cpp
@@ -20,6 +20,7 @@
 #endif
 
 #include "common.h"
+#include "ctl_path.h"
 #include "dump_format.h"
 #include "selective_spec.h"
 #include "comm/comm.h"
@@ -28,7 +29,8 @@ namespace {
 
 // Exit codes (consumed by the snapshot agent):
 //   0 OK, 1 usage/parse, 2 op failed (op_status or invalid dump),
-//   3 refused pre-signal (.so not ready, or target dead), 4 timeout.
+//   3 refused pre-signal (.so not ready / no advertisement, or target
+//   dead), 4 timeout.
 // Exit 4 poisons the channel: the flock releases at exit while the
 // wedged handler may still be mid-op, so the workload must be restarted
 // (or proven idle) before another op targets this PID.
@@ -192,6 +194,53 @@ bool ValidateDestDump(const char* path) {
     return ok;
 }
 
+// Pre-signal gate: refuse to kill() unless the target's .so wrote
+// a readiness advertisement into OUR ctl dir. Presence in this dir proves
+// shared backing (the only way the file got here); proto proves the
+// library level; starttime kills the PID-reuse case, where the signal
+// would terminate an innocent recycled PID. Path equality is a warning
+// only (same tmpfs may be mounted at different container paths).
+bool CheckAdvertisement(const char* ctl_dir, int pid) {
+    char path[512];
+    snprintf(path, sizeof(path), "%s/ctl-ready-%d", ctl_dir, pid);
+    FILE* f = fopen(path, "r");
+    if (!f) {
+        fprintf(stderr, "Error: no readiness advertisement at %s — vGPU.so not loaded in PID %d, "
+                        "GPU_CR_CTL_PATH mismatch, or a library without ctl support\n", path, pid);
+        return false;
+    }
+    char buf[600] = "";
+    if (!fgets(buf, sizeof(buf), f)) {
+        fclose(f);
+        fprintf(stderr, "Error: empty advertisement %s\n", path);
+        return false;
+    }
+    fclose(f);
+    gpu_cr::Advertisement adv;
+    if (!gpu_cr::ParseAdvertisement(buf, &adv)) {
+        fprintf(stderr, "Error: unparsable advertisement %s\n", path);
+        return false;
+    }
+    if (adv.proto < gpu_cr::kCtlProto) {
+        fprintf(stderr, "Error: advertisement proto=%d too low (need >=%d)\n", adv.proto, gpu_cr::kCtlProto);
+        return false;
+    }
+    long long cur_start = gpu_cr::ProcStarttime(pid);
+    if (cur_start < 0) {
+        fprintf(stderr, "Error: PID %d no longer exists\n", pid);
+        return false;
+    }
+    if (adv.starttime != cur_start) {
+        fprintf(stderr, "Error: starttime mismatch for PID %d (advertised %lld, current %lld) — "
+                        "PID reuse, refusing to signal\n", pid, adv.starttime, cur_start);
+        return false;
+    }
+    if (adv.ctl[0] && strcmp(adv.ctl, ctl_dir) != 0)
+        fprintf(stderr, "Warning: advertisement names ctl=%s, ours is %s (same backing store, "
+                        "different mount points?)\n", adv.ctl, ctl_dir);
+    return true;
+}
+
 // Polls for FINISH with a deadline: a dead or wedged workload must fail this
 // invocation, not hang it (and the agent behind it) forever.
 bool WaitFinished(ShareMemComm* comm) {
@@ -314,14 +363,45 @@ int main(int argc, char* argv[]) {
     assert(pid != 0);
     if (criu_pid == 0) criu_pid = pid;
 
+    // A configured-but-broken ctl path is refused HERE, loudly.
+    // (The .so falls back to legacy instead — it must not die — so the
+    // coordinator is where the misconfiguration surfaces.)
+    bool ctl_mode = false;
+    const char* ctl_dir = gpu_cr::CtlDir(&ctl_mode);
+    const char* ctl_env = getenv("GPU_CR_CTL_PATH");
+    if (ctl_env && ctl_env[0] && !ctl_mode) {
+        fprintf(stderr, "Error: GPU_CR_CTL_PATH=%s is missing or not tmpfs-backed "
+                        "(mount-order shadowing?) — refusing to operate\n", ctl_env);
+        exit(kExitRefused);
+    }
+
+    // Pre-signal gate: never kill() a PID whose .so hasn't
+    // advertised readiness in our ctl dir — covers not-loaded, env
+    // mismatch, older libraries and PID reuse in one check. The
+    // gate-to-signal window is a narrow, accepted TOCTOU: the starttime
+    // check excludes reuse, and SignalOrDie fails crisply if the target
+    // vanishes inside it.
+    if (ctl_mode && !CheckAdvertisement(ctl_dir, pid))
+        exit(kExitRefused);
+
     ShareMemComm *comm = new ShareMemComm(pid);
     comm->setup();
 
     // Serialize concurrent cr_clients against the same PID for the whole
-    // op: nothing else orders two writers of selective_req. The control
-    // file was opened with open(O_CREAT) by setup(), and an inode lock
-    // faults no hugetlb pages, so it stays safe with a zero hugepages
-    // request; a failed flock warns and proceeds (historical behavior).
+    // op: nothing else orders two writers of selective_req.
+    // Fixed order, legacy lock first: the legacy file is
+    // taken with open(O_CREAT)+flock only — an inode lock faults no
+    // hugetlb pages, so it stays safe with a zero hugepages request.
+    if (ctl_mode) {
+        char legacy_lock_path[512];
+        snprintf(legacy_lock_path, sizeof(legacy_lock_path), "%s/control-%d", gpu_cr::DataDir(), pid);
+        int legacy_lock_fd = open(legacy_lock_path, O_CREAT | O_RDWR | O_CLOEXEC, 0644);
+        if (legacy_lock_fd >= 0) {
+            if (flock(legacy_lock_fd, LOCK_EX) != 0)
+                fprintf(stderr, "Warning: flock(%s) failed: %s\n", legacy_lock_path, strerror(errno));
+            // held (with the fd) until process exit
+        }
+    }
     if (flock(comm->fd_control, LOCK_EX) != 0)
         fprintf(stderr, "Warning: flock(control-%d) failed: %s\n", pid, strerror(errno));
 
@@ -330,8 +410,10 @@ int main(int argc, char* argv[]) {
     // armed handlers — a signaled op would just burn the FINISH timeout,
     // and a dest-path restore served from the per-PID buffer would replay
     // stale bytes into GPU memory, which no post-op check can undo.
-    // Full-process ops stay ungated (historical behavior).
-    if (selective_spec &&
+    // Full-process ops stay ungated (historical behavior). In ctl mode
+    // the advertisement already proved the library is armed, without
+    // needing a prior -i.
+    if (selective_spec && !ctl_mode &&
         comm->control->selective_ready != gpu_cr::kSelectiveReady) {
         fprintf(stderr, "Error: vGPU.so has not published selective support "
                         "(run -i first, or fix the preloaded library)\n");

--- a/third_party/gpu-cr/coordinator/cr_client.cpp
+++ b/third_party/gpu-cr/coordinator/cr_client.cpp
@@ -198,7 +198,10 @@ bool ValidateDestDump(const char* path) {
 // a readiness advertisement into OUR ctl dir. Presence in this dir proves
 // shared backing (the only way the file got here); proto proves the
 // library level; starttime kills the PID-reuse case, where the signal
-// would terminate an innocent recycled PID. Path equality is a warning
+// would terminate an innocent recycled PID; the file's owner uid must
+// match the target process's uid — on a shared ctl dir a co-tenant under
+// another uid cannot vouch for a victim PID (and the sticky bit keeps it
+// from replacing the victim's real advert). Path equality is a warning
 // only (same tmpfs may be mounted at different container paths).
 bool CheckAdvertisement(const char* ctl_dir, int pid) {
     char path[512];
@@ -207,6 +210,25 @@ bool CheckAdvertisement(const char* ctl_dir, int pid) {
     if (!f) {
         fprintf(stderr, "Error: no readiness advertisement at %s — vGPU.so not loaded in PID %d, "
                         "GPU_CR_CTL_PATH mismatch, or a library without ctl support\n", path, pid);
+        return false;
+    }
+    // fstat the OPEN file (no rename/replace TOCTOU) against /proc/<pid>,
+    // whose st_uid is the target's effective uid.
+    struct stat adv_st, proc_st;
+    char proc_path[64];
+    snprintf(proc_path, sizeof(proc_path), "/proc/%d", pid);
+    if (fstat(fileno(f), &adv_st) != 0 || stat(proc_path, &proc_st) != 0) {
+        fclose(f);
+        fprintf(stderr, "Error: cannot stat advertisement %s or %s (%s)\n",
+                path, proc_path, strerror(errno));
+        return false;
+    }
+    if (adv_st.st_uid != proc_st.st_uid) {
+        fclose(f);
+        fprintf(stderr, "Error: advertisement %s owned by uid %u but PID %d runs as uid %u — "
+                        "forged or stale advert, refusing to signal\n",
+                path, static_cast<unsigned>(adv_st.st_uid), pid,
+                static_cast<unsigned>(proc_st.st_uid));
         return false;
     }
     char buf[600] = "";

--- a/third_party/gpu-cr/src/backend/backend.h
+++ b/third_party/gpu-cr/src/backend/backend.h
@@ -18,7 +18,11 @@ public:
     void* host_buf_ptr = nullptr;
     int fd_host = -1;
 
-    std::mutex fs_mutex;
+    // Guards tmp_buf creation/publication only (setup(), deferred-mode
+    // get_tmp_buf()). Distinct from vGPU.cpp's global fs_mutex, which is
+    // the op-scope lock handlers hold across whole checkpoint/restore
+    // operations — the two must never be conflated.
+    std::mutex buf_mutex;
 
     int id;
 

--- a/third_party/gpu-cr/src/backend/mmap_backend.cpp
+++ b/third_party/gpu-cr/src/backend/mmap_backend.cpp
@@ -27,14 +27,15 @@ ShareMem::ShareMem(int id) : Backend(id), id(id) {
 ShareMem::~ShareMem() {
 }
 
-// Map the dump buffer. fatal=true keeps the historical exit() behavior
-// for eager setup; fatal=false returns nullptr so a caller can fail the
-// op cleanly instead of killing the workload.
+// Map (or lazily materialize) the dump buffer. fatal=true keeps the
+// historical exit() behavior for eager setup; fatal=false (deferred-mode
+// materialization, which runs in signal-handler context off get_tmp_buf)
+// returns nullptr so the caller can fail the op cleanly via op_status.
 void* ShareMem::map_dump_buffer(bool fatal) {
     char shm_name[512];
     const char* export_file_path = std::getenv("EXPORT_FILE_PATH");
     bool use_file_backend = (export_file_path != nullptr);
-    size_t size = SHM_SIZE;
+    size_t size = SHM_SIZE; // runtime config
 
     if (use_file_backend) {
         snprintf(shm_name, sizeof(shm_name), "%s/ckpt-%d.data", export_file_path, id);
@@ -75,9 +76,9 @@ void* ShareMem::map_dump_buffer(bool fatal) {
     if (buf == MAP_FAILED) {
         fprintf(stderr, "%s failed: %s\n",
                 use_file_backend ? "mmap (file backend)" : "mmap with hugepages", strerror(errno));
-        fprintf(stderr, "[ShareMem] configured dump-buffer size is %zu MiB (build-time SHM_SIZE_GB); "
-                        "check it against the pod's hugepages-2Mi request and the node pool size\n",
-                        size >> 20);
+        fprintf(stderr, "[ShareMem] configured dump-buffer size is %zu MiB (GPU_CR_SHM_GB/MB, default "
+                        "= build SHM_SIZE_GB); check it against the pod's hugepages-2Mi request and "
+                        "the node pool size\n", size >> 20);
         if (fatal) exit(EXIT_FAILURE);
         return nullptr;
     }
@@ -95,10 +96,17 @@ void ShareMem::setup() {
     const char* export_file_path = std::getenv("EXPORT_FILE_PATH");
     bool use_file_backend = (export_file_path != nullptr);
 
-    // tmp_buf
-    fs_mutex.lock();
-    tmp_buf = map_dump_buffer(/*fatal=*/true);
-    fs_mutex.unlock();
+    // tmp_buf. Deferred mode (GPU_CR_SHM_*=0): skip the dump
+    // buffer entirely — -o-only deployments never need it; a buffer-path
+    // op materializes it at the 64MiB floor via get_tmp_buf().
+    if (gpu_cr::Config().shm_deferred) {
+        fprintf(stderr, "[ShareMem] dump buffer DEFERRED (GPU_CR_SHM=0): created on first buffer-path op at %zu MiB\n",
+                static_cast<size_t>(SHM_SIZE >> 20));
+    } else {
+        fs_mutex.lock();
+        tmp_buf = map_dump_buffer(/*fatal=*/true);
+        fs_mutex.unlock();
+    }
 
     // host_buf — follow same backend selection as the main staging buffer.
     if (use_file_backend) {
@@ -129,6 +137,21 @@ void ShareMem::setup() {
 }
 
 void* ShareMem::get_tmp_buf() {
+    // Deferred-mode lazy materialization: first buffer-path op
+    // (legacy dump/restore, full C/R, or an IPC verb's scratch blocks)
+    // creates the buffer at the floor size. Non-fatal: callers must
+    // null-check and fail the op cleanly (op_status) — this runs in
+    // signal-handler context and must not kill the workload on ENOMEM.
+    // Every deferred-mode access to tmp_buf goes through fs_mutex
+    // (setup() never touches it in this mode); the non-deferred read
+    // stays lock-free — setup() wrote the pointer once, before any op
+    // path or handler existed.
+    if (gpu_cr::Config().shm_deferred) {
+        std::lock_guard<std::mutex> lock(fs_mutex);
+        if (tmp_buf == nullptr)
+            tmp_buf = map_dump_buffer(/*fatal=*/false);
+        return tmp_buf;
+    }
     return tmp_buf;
 }
 

--- a/third_party/gpu-cr/src/backend/mmap_backend.cpp
+++ b/third_party/gpu-cr/src/backend/mmap_backend.cpp
@@ -103,9 +103,9 @@ void ShareMem::setup() {
         fprintf(stderr, "[ShareMem] dump buffer DEFERRED (GPU_CR_SHM=0): created on first buffer-path op at %zu MiB\n",
                 static_cast<size_t>(SHM_SIZE >> 20));
     } else {
-        fs_mutex.lock();
+        buf_mutex.lock();
         tmp_buf = map_dump_buffer(/*fatal=*/true);
-        fs_mutex.unlock();
+        buf_mutex.unlock();
     }
 
     // host_buf — follow same backend selection as the main staging buffer.
@@ -142,12 +142,21 @@ void* ShareMem::get_tmp_buf() {
     // creates the buffer at the floor size. Non-fatal: callers must
     // null-check and fail the op cleanly (op_status) — this runs in
     // signal-handler context and must not kill the workload on ENOMEM.
-    // Every deferred-mode access to tmp_buf goes through fs_mutex
+    // Every deferred-mode access to tmp_buf goes through buf_mutex
     // (setup() never touches it in this mode); the non-deferred read
     // stays lock-free — setup() wrote the pointer once, before any op
-    // path or handler existed.
+    // path or handler existed. try_lock, not lock: if the CR signal
+    // lands on a thread that is itself mid-materialization (an IPC verb
+    // holding buf_mutex), a blocking lock would deadlock the handler —
+    // contention instead fails THIS op cleanly, same contract as the
+    // gpu_mem_mutex EBUSY path.
     if (gpu_cr::Config().shm_deferred) {
-        std::lock_guard<std::mutex> lock(fs_mutex);
+        std::unique_lock<std::mutex> lock(buf_mutex, std::try_to_lock);
+        if (!lock.owns_lock()) {
+            fprintf(stderr, "[ShareMem] dump buffer busy (materialization in flight "
+                            "on the signaled thread?); failing this op\n");
+            return nullptr;
+        }
         if (tmp_buf == nullptr)
             tmp_buf = map_dump_buffer(/*fatal=*/false);
         return tmp_buf;

--- a/third_party/gpu-cr/src/gpu_cr_config.h
+++ b/third_party/gpu-cr/src/gpu_cr_config.h
@@ -18,8 +18,10 @@
 //            Σ destination files.
 //   GPU_CR_STAGING_MB               each of the two DMA staging buffers
 //
-// The coordinator maps worker buffers at its own SHM_SIZE, so the
-// coordinator and its workers must run with identical GPU_CR_* env.
+// The coordinator maps only the fixed header window of each worker
+// buffer (see multi_cr_client) and treats the worker-ftruncate'd file
+// size as authoritative (fstat-checked), so the coordinator and its
+// workers may run with different GPU_CR_* env.
 //
 // No upper clamp: the hugepage pool is the real bound and mmap reports
 // ENOMEM honestly. The only "too big" that is rejected at parse time is

--- a/third_party/gpu-cr/src/vGPU.cpp
+++ b/third_party/gpu-cr/src/vGPU.cpp
@@ -1154,11 +1154,16 @@ int get_id() {
     bool ctl_mode = false;
     const char* ctl_dir = gpu_cr::CtlDir(&ctl_mode);
     snprintf(id_name, sizeof(id_name), "%s/control", ctl_dir);
-    int fd_id = open(id_name, O_CREAT | O_RDWR, 0755);
+    // Same cross-UID policy as the per-PID control files: the counter is
+    // shared by every workload on this ctl dir, and a 0755 first-creator
+    // mode would refuse O_RDWR to a later workload under a different uid.
+    // fchmod bypasses the umask; best-effort (non-owners cannot chmod).
+    int fd_id = open(id_name, O_CREAT | O_RDWR, 0777);
     if (fd_id < 0) {
         perror("open()");
         exit(EXIT_FAILURE);
     }
+    fchmod(fd_id, 0777);
     // The counter is a single atomic int: on the ctl tmpfs one 4KiB page
     // suffices (and frees the hugepage the legacy layout pinned); on
     // hugetlbfs the historical 2MiB sizing is kept.

--- a/third_party/gpu-cr/src/vGPU.cpp
+++ b/third_party/gpu-cr/src/vGPU.cpp
@@ -19,6 +19,7 @@
 
 #include "common.h"
 #include "cr_signal_guard.h"
+#include "ctl_path.h"
 #include "dump_format.h"
 #include "comm/comm.h"
 #include "backend/backend.h"
@@ -497,8 +498,9 @@ double ckpt_selective(const SelectiveCrRequest* req) {
             return -1;
         }
         fs_capacity = SHM_SIZE;
-        // Same clean pre-op failure as the dest path instead of the
-        // historical mid-loop exit(-1).
+        // The legacy buffer is env-shrinkable now — same clean
+        // pre-op failure as the dest path instead of the historical
+        // mid-loop exit(-1).
         if (dump_total > fs_capacity) {
             fprintf(stderr, "[vGPU-SELECTIVE-CKPT] Error: selective checkpoint needs %zu MiB but the "
                             "dump buffer is %zu MiB (raise GPU_CR_SHM_MB / GPU_CR_SHM_GB); failing cleanly\n",
@@ -1149,21 +1151,32 @@ double restore_ptr_and_content_selective(const SelectiveCrRequest* req) {
 
 int get_id() {
     char id_name[512];
-    const char* ctl_dir = std::getenv("EXPORT_FILE_PATH");
-    if (!ctl_dir) ctl_dir = "/mnt/huge-ckpt";
+    bool ctl_mode = false;
+    const char* ctl_dir = gpu_cr::CtlDir(&ctl_mode);
     snprintf(id_name, sizeof(id_name), "%s/control", ctl_dir);
     int fd_id = open(id_name, O_CREAT | O_RDWR, 0755);
     if (fd_id < 0) {
         perror("open()");
         exit(EXIT_FAILURE);
     }
+    // The counter is a single atomic int: on the ctl tmpfs one 4KiB page
+    // suffices (and frees the hugepage the legacy layout pinned); on
+    // hugetlbfs the historical 2MiB sizing is kept.
+    size_t id_size = ctl_mode ? 4096 : HUGE_PAGE_SIZE;
     // Set file size before mmap to avoid Bus error
-    if (ftruncate(fd_id, HUGE_PAGE_SIZE) < 0) {
+    if (ftruncate(fd_id, id_size) < 0) {
         perror("ftruncate()");
         exit(EXIT_FAILURE);
     }
+    if (ctl_mode) {
+        int rc = posix_fallocate(fd_id, 0, static_cast<off_t>(id_size));
+        if (rc != 0) {
+            fprintf(stderr, "posix_fallocate(%s): %s (ctl tmpfs full?)\n", id_name, strerror(rc));
+            exit(EXIT_FAILURE);
+        }
+    }
     std::atomic<int>* id_ptr = static_cast<std::atomic<int>*>(
-        mmap(nullptr, HUGE_PAGE_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, fd_id, 0));
+        mmap(nullptr, id_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd_id, 0));
     if (id_ptr == MAP_FAILED) {
         perror("mmap()");
         exit(EXIT_FAILURE);
@@ -1185,9 +1198,9 @@ void init_CR() {
 
     // Write PID -> ID mapping file. write(2), not stdio: buffered stdio
     // silently produces an EMPTY file on hugetlbfs (the historical pid_map
-    // bug).
-    const char* ctl_dir = std::getenv("EXPORT_FILE_PATH");
-    if (!ctl_dir) ctl_dir = "/mnt/huge-ckpt";
+    // bug); on the ctl tmpfs plain writes just work.
+    bool ctl_mode = false;
+    const char* ctl_dir = gpu_cr::CtlDir(&ctl_mode);
     char map_name[512];
     snprintf(map_name, sizeof(map_name), "%s/pid_map_%d", ctl_dir, getpid());
     int fd_map = open(map_name, O_CREAT | O_TRUNC | O_WRONLY, 0666);
@@ -1660,7 +1673,7 @@ __attribute__((constructor)) void init() {
     // Resolve buffer config FIRST — a function-local-static
     // singleton invoked here (not a second ELF constructor, whose order vs
     // this one would be unspecified). Signal handlers only read the cache.
-    gpu_cr::Config();
+    const gpu_cr::BufConfig& buf_cfg = gpu_cr::Config();
 
     fprintf(stderr, "[vGPU] Library loaded! Registering signal handlers...\n");
     fprintf(stderr, "[vGPU] Multi-GPU CR support enabled (IPC hook mode)\n");
@@ -1680,4 +1693,27 @@ __attribute__((constructor)) void init() {
         ipc_validate_all_mappings("ON-DEMAND");
         fflush(stderr);
     });
+
+    // Readiness advertisement: written LAST, in the same constructor that
+    // installs the handlers, so its existence proves every handler above
+    // is in place before any coordinator can see the file — cr_client
+    // refuses to kill() without it. starttime makes the file
+    // self-invalidating across PID reuse. Never written in legacy mode (a
+    // disk-backed dir could be shadowed by a later tmpfs mount, stranding
+    // a stale advertisement). Failures are logged, never fatal: this must
+    // not take down the workload.
+    {
+        bool ctl_mode = false;
+        const char* ctl_dir = gpu_cr::CtlDir(&ctl_mode);
+        if (ctl_mode) {
+            // shm_mb/staging_mb/deferred: additive keys so the
+            // agent can OBSERVE workload buffer sizing and cross-check it
+            // against pod hugepage requests — closing the observability
+            // corner of the three-way consistency triangle.
+            if (gpu_cr::WriteAdvertisement(ctl_dir, getpid(), buf_cfg.shm_size >> 20,
+                                           buf_cfg.staging_size >> 20, buf_cfg.shm_deferred))
+                fprintf(stderr, "[vGPU] ctl-ready advertisement written: %s/ctl-ready-%d\n",
+                        ctl_dir, getpid());
+        }
+    }
 }

--- a/third_party/gpu-cr/tests/README.md
+++ b/third_party/gpu-cr/tests/README.md
@@ -101,27 +101,31 @@ reports through the same `ctest` front end as the unit tier.
 
 Function-level coverage of two layers:
 
-- **Code added on top of upstream**: dump-format validation, consume-once
-  FINISH bookkeeping, region-spec parsing, and wire-layout guards.
+- **Code added on top of upstream**: buffer-size config parsing,
+  control-path resolution and advertisement round-trip, dump-format
+  validation, granule clamping, consume-once FINISH bookkeeping,
+  region-spec parsing, and wire-layout guards.
 - **The upstream-baseline functions themselves**: the 2MB rounding macro,
   signal numbers and wire structs (`common_baseline_test`), the
   ShareMemComm control channel (`share_mem_comm_test`), the ShareMem
   dump/staging buffer mapping via the file backend (`mmap_backend_test`),
-  and the UDS SCM_RIGHTS fd exchange (`ipc_fd_exchange_test`).
-  `createGPU()` and the CUDA/HIP hook layers need a driver link, so they
-  stay covered by the integration and e2e tiers.
+  the UDS SCM_RIGHTS fd exchange (`ipc_fd_exchange_test`), and
+  `memcpy_multi` (`memcpy_multi_test`). `createGPU()` and the CUDA/HIP
+  hook layers need a driver link, so they stay covered by the
+  integration and e2e tiers.
 
 ## 2. Integration tests — `tests/integration/` (no GPU, Linux)
 
 `cr_client_integration_test.sh` drives the **real `cr_client` binary**
 against `fake_workload`, a GPU-free stand-in for the vGPU.so side that
-reuses the production control-channel code (ShareMemComm, FINISH
-bookkeeping, dump validator). Covers the control-file flow,
+reuses the production control-channel code (ShareMemComm, advertisement
+writer, FINISH bookkeeping, dump validator). Covers ctl (env-configured
+AND zero-config `<data>/ctl` discovery) and legacy modes,
 destination-path checkpoint/restore, torn-dump refusal, op_status
 propagation (including the "never freeze after a failed checkpoint" gate),
-timeouts, not-ready refusals, and the documented exit codes
-(0 OK / 1 usage / 2 op failed / 3 refused pre-signal — not-ready gate or
-dead target / 4 timeout).
+timeouts, PID-reuse refusal, not-ready refusals, and the documented exit
+codes (0 OK / 1 usage / 2 op failed / 3 refused pre-signal — not-ready
+gate, missing advertisement, or dead target / 4 timeout).
 
 Two contract points the suite pins, worth knowing when driving
 `cr_client` from the agent:
@@ -142,11 +146,21 @@ ctest -R cr_client_integration --output-on-failure
 The full per-case matrix (setup, invocation, expected exit) lives in
 [`tests/integration/README.md`](integration/README.md).
 
+Optionally, both GPU-free tiers in one shot on Google Cloud Build (not
+required — see "What you need"; no image published):
+
+```sh
+gcloud builds submit --config cloudbuild-test.yaml .
+```
+
 ## 3. End-to-end — `tests/e2e/run_e2e.sh` (GPU node)
 
 A real CUDA workload (`pattern_workload`) under `LD_PRELOAD=vGPU-NVIDIA.so`
 goes through destination-path selective C/R, buffer-path selective C/R, and
-full C/R, gating on **byte-identical GPU memory after every restore**.
+full C/R, gating on **byte-identical GPU memory after every restore**. The
+final gate (G8) reruns a dest-path round trip with `GPU_CR_CTL_PATH` unset
+on both sides, proving the zero-config `<store>/ctl` discovery path on the
+production nested-tmpfs layout (skipped when `$STORE/ctl` is not tmpfs).
 
 ## 4. Performance regression — `tests/e2e/perf_regression.sh` (GPU node)
 

--- a/third_party/gpu-cr/tests/e2e/e2e-pod.yaml
+++ b/third_party/gpu-cr/tests/e2e/e2e-pod.yaml
@@ -53,7 +53,10 @@ spec:
     - |
       set -e
       export STORE=/mnt/huge-ckpt
-      export GPU_CR_CTL_PATH=/var/run/gpu-cr-ctl
+      # Env-configured ctl mode for the main pass; the tmpfs is mounted
+      # NESTED at $STORE/ctl (production layout), so the G8 gate can prove
+      # zero-config discovery against the very same backing.
+      export GPU_CR_CTL_PATH=/mnt/huge-ckpt/ctl
       /opt/gpu-cr/e2e/run_e2e.sh
       unset GPU_CR_CTL_PATH
       /opt/gpu-cr/e2e/perf_regression.sh \
@@ -79,6 +82,9 @@ spec:
         hugepages-2Mi: 16Gi
         memory: 8Gi
     volumeMounts:
+    # ctl nests INSIDE the store (production layout for zero-config
+    # discovery); keep huge-ckpt listed first so the runtime mounts the
+    # parent before the nested path.
     - {name: huge-ckpt, mountPath: /mnt/huge-ckpt}
-    - {name: ctl, mountPath: /var/run/gpu-cr-ctl}
+    - {name: ctl, mountPath: /mnt/huge-ckpt/ctl}
     - {name: baseline, mountPath: /baseline}

--- a/third_party/gpu-cr/tests/e2e/e2e_lib.sh
+++ b/third_party/gpu-cr/tests/e2e/e2e_lib.sh
@@ -67,8 +67,11 @@ stop_workload() {
     # hugetlbfs pages are freed only when the backing files go away: purge
     # the per-run buffers or back-to-back runs exhaust the pool. NOTE:
     # clears every ckpt-*/control*/pid_map_* under $STORE — point STORE
-    # at a dedicated volume, not a shared store.
-    rm -f "$STORE"/ckpt-* "$STORE"/control* "$STORE"/pid_map_* 2>/dev/null
+    # at a dedicated volume, not a shared store. $STORE/ctl is the
+    # zero-config discovery dir (harmless no-op when absent).
+    rm -f "$STORE"/ckpt-* "$STORE"/control* "$STORE"/pid_map_* \
+          "$STORE"/ctl/control* "$STORE"/ctl/pid_map_* \
+          "$STORE"/ctl/ctl-ready-* 2>/dev/null
     WL_PID=""
     return 0
 }

--- a/third_party/gpu-cr/tests/e2e/perf_regression.sh
+++ b/third_party/gpu-cr/tests/e2e/perf_regression.sh
@@ -83,8 +83,12 @@ echo "perf regression: ${NUM_BUFFERS}x${BUFFER_MB}MiB buffers, $ITERS iters, thr
 
 # Perf tests run in the legacy (no-ctl) layout: the e9bbb52 baseline
 # predates the ctl-path control plane and both variants must see identical
-# plumbing.
+# plumbing. Unsetting the env is not enough on the nested-ctl pod layout —
+# the candidate would zero-config-discover $STORE/ctl — so dumps move to a
+# ctl-free subdirectory of the store (same hugetlbfs, no ctl/ inside).
 unset GPU_CR_CTL_PATH
+STORE="$STORE/perf-legacy"
+mkdir -p "$STORE"
 
 BASE=$(measure baseline "$BASELINE_SO" "$BASELINE_CLIENT") || exit 1
 CAND=$(measure candidate "$CANDIDATE_SO" "$CANDIDATE_CLIENT") || exit 1

--- a/third_party/gpu-cr/tests/e2e/run_e2e.sh
+++ b/third_party/gpu-cr/tests/e2e/run_e2e.sh
@@ -16,9 +16,13 @@
 #       E2E_FULL_TOGGLE=1 and a real cuda-checkpoint is on PATH)
 #   G7  below-floor GPU_CR_SHM_MB warns at load and falls back to the
 #       build default; the workload stays healthy
+#   G8  zero-config ctl discovery: with NO GPU_CR_CTL_PATH anywhere, a
+#       tmpfs-backed $STORE/ctl is found by both sides and a dest-path
+#       C/R round-trips byte-identically (skipped, not failed, when
+#       $STORE/ctl is not a tmpfs — e.g. the baseline pod layout)
 #
 # Required env: CR_CLIENT, WORKLOAD, VGPU_SO, STORE.
-# Optional env: E2E_NUM_BUFFERS, E2E_BUFFER_MB,
+# Optional env: GPU_CR_CTL_PATH, E2E_NUM_BUFFERS, E2E_BUFFER_MB,
 #               GPU_CR_SHM_MB (defaults to a size fitting the buffers),
 #               CR_TIMEOUT (seconds per cr_client call, default 120).
 set -u
@@ -41,7 +45,50 @@ gate() {
     if "$@"; then echo "PASS: $name"; PASS=$((PASS+1));
     else echo "FAIL: $name"; FAIL=$((FAIL+1)); fi
 }
-cr() { env EXPORT_FILE_PATH="$STORE" timeout "${CR_TIMEOUT:-120}" "$CR_CLIENT" "$@"; }
+cr() { env EXPORT_FILE_PATH="$STORE" \
+          ${GPU_CR_CTL_PATH:+GPU_CR_CTL_PATH="$GPU_CR_CTL_PATH"} \
+          timeout "${CR_TIMEOUT:-120}" "$CR_CLIENT" "$@"; }
+
+# The dump buffer is the one ckpt-<id>.data under $STORE that is not the
+# -host staging file; its extent is the ftruncate the workload performed
+# from the cached env config. A shared/dirty $STORE may hold dump files
+# from earlier runs, so the check is bound to THIS workload: snapshot the
+# store before init and judge only files that appeared after — exactly one
+# must, and its extent must match.
+#
+# The snapshot itself fails CLOSED: an empty store is a legitimate empty
+# snapshot, but an unreadable $STORE or unwritable snapshot file aborts
+# the run — with a missing snapshot every pre-existing file would look
+# new to dump_extent_ok, and a stale file could satisfy (or wrongly
+# fail) the extent gate.
+record_store_files() {
+    : > "$RUN/store-pre" || { echo "FATAL: cannot write $RUN/store-pre" >&2; exit 1; }
+    [ -r "$STORE" ] && [ -x "$STORE" ] || { echo "FATAL: cannot read $STORE" >&2; exit 1; }
+    local f
+    for f in "$STORE"/ckpt-*.data; do
+        [ -e "$f" ] || continue    # unmatched glob literal
+        printf '%s\n' "$f" >> "$RUN/store-pre" \
+            || { echo "FATAL: cannot write $RUN/store-pre" >&2; exit 1; }
+    done
+}
+dump_extent_ok() {
+    local f sz found=""
+    for f in "$STORE"/ckpt-*.data; do
+        case "$f" in *-host.data) continue ;; esac
+        [ -e "$f" ] || continue
+        grep -qxF "$f" "$RUN/store-pre" 2>/dev/null && continue
+        if [ -n "$found" ]; then
+            echo "multiple new dump files: $found, $f" >&2
+            return 1
+        fi
+        found=$f
+    done
+    [ -n "$found" ] || { echo "no new dump-buffer file under $STORE" >&2; return 1; }
+    sz=$(stat -c %s "$found" 2>/dev/null) || { echo "stat $found failed" >&2; return 1; }
+    [ "$sz" -eq "$SHM_BYTES" ] && return 0
+    echo "dump file $found: $sz bytes, expected $SHM_BYTES" >&2
+    return 1
+}
 
 # The dump buffer is the one ckpt-<id>.data under $STORE that is not the
 # -host staging file; its extent is the ftruncate the workload performed
@@ -135,6 +182,37 @@ gate "G7a below-floor value warns" \
 gate "G7b falls back to build default" \
     grep -qF "MiB (build default)" "$RUN/workload.stderr"
 gate "G7c workload healthy after fallback" wl_cmd verify
+
+# G8: zero-config ctl discovery. Restart the workload with GPU_CR_CTL_PATH
+# scrubbed on BOTH sides; the .so and cr_client must independently find the
+# tmpfs at $STORE/ctl through EXPORT_FILE_PATH alone (the consumer-side
+# contract of the discovery design). Environments without a nested ctl
+# tmpfs (baseline pod layout, bare runs) skip rather than fail.
+CTL_CAND="$STORE/ctl"
+# stat -f -c %T is GNU coreutils (fine in the CUDA/Ubuntu e2e image); on
+# busybox/BSD stat this prints nothing and G8 skips — adjust if the suite
+# ever moves off a GNU userland.
+if [ "$(stat -f -c %T "$CTL_CAND" 2>/dev/null)" = "tmpfs" ]; then
+    stop_workload
+    cr8() { env -u GPU_CR_CTL_PATH EXPORT_FILE_PATH="$STORE" \
+                timeout "${CR_TIMEOUT:-120}" "$CR_CLIENT" "$@"; }
+    GPU_CR_CTL_PATH="" start_workload "$VGPU_SO" \
+        E2E_NUM_BUFFERS="$NUM_BUFFERS" E2E_BUFFER_MB="$BUFFER_MB" \
+        GPU_CR_SHM_MB="$SHM_MB" || exit 1
+    gate "G8a advert discovered under \$STORE/ctl" \
+        test -f "$CTL_CAND/ctl-ready-$WL_PID"
+    gate "G8b init (no ctl env)" cr8 -i -p "$WL_PID"
+    DUMP8="$STORE/e2e-dump-disc.bin"
+    rm -f "$DUMP8"
+    gate "G8c dest-path selective ckpt (no ctl env)" \
+        cr8 -c -p "$WL_PID" -s "$WL_REGIONS" -o "$DUMP8"
+    gate "G8d dest-path selective restore (no ctl env)" \
+        cr8 -r -p "$WL_PID" -s "$WL_REGIONS" -o "$DUMP8"
+    gate "G8e verify after discovery restore" wl_cmd verify
+    rm -f "$DUMP8"
+else
+    echo "SKIP: G8 zero-config discovery ($CTL_CAND is not tmpfs-backed)"
+fi
 
 stop_workload
 echo

--- a/third_party/gpu-cr/tests/integration/README.md
+++ b/third_party/gpu-cr/tests/integration/README.md
@@ -23,6 +23,12 @@ stub that records having been invoked, so freeze/thaw behavior is
 observable without a driver. Exit-code contract asserted throughout:
 0 OK / 1 usage / 2 op failed / 3 refused pre-signal / 4 timeout.
 
+In this tree the suite runs the shared cases under the **ctl-mode env**
+(`EXPORT_FILE_PATH` + `GPU_CR_CTL_PATH`, the "ctl:" prefix in test
+names) and adds ctl-plane sections: advertisement gating, broken ctl
+paths, zero-config `<data>/ctl` discovery, and legacy mode (env-only
+control channel).
+
 `fake_workload` knobs used by the cases below:
 
 | Env | Fake behavior |
@@ -66,6 +72,22 @@ Test cases (in script order):
 | Usage | restore from a missing file | — | `-r -s -o <nonexistent>` | 2 |
 | Dest hardening | relative `-o` refused | — | `-o rel/dump.bin` | 2 |
 | Dest hardening | symlink dest refused | `ln -s /etc/hostname <path>` | `-c -s -o <path>` | 2 (ELOOP via `O_NOFOLLOW`) |
+
+Ctl-plane, discovery, and legacy-mode cases (this tree only):
+
+| Group | Test case | Setup | `cr_client` invocation | Expected |
+|---|---|---|---|---|
+| Advertisement gate | no advertisement → refused | `FAKE_NOT_READY=1` (nothing advertised) | `-c -s` | 3 |
+| Advertisement gate | starttime mismatch (PID reuse) → refused | advert edited to `starttime=1` | `-c -s` | 3 |
+| Broken ctl path | non-tmpfs `GPU_CR_CTL_PATH` refused | `GPU_CR_CTL_PATH` on disk-backed fs | `-c -s` | 3 |
+| Broken ctl path | missing `GPU_CR_CTL_PATH` dir refused | `GPU_CR_CTL_PATH=/nonexistent-ctl` | `-c -s` | 3 |
+| Discovery | advert + control channel land on `<data>/ctl` | no ctl env at all (tmpfs data dir) | `-i` | 0; both files under `<data>/ctl` |
+| Discovery | dest-path selective ckpt/restore | no ctl env | `-c -s -o`, `-r -s -o` | 0 each |
+| Discovery | starttime mismatch → refused | advert edited to `starttime=1` | `-c -s` | 3 |
+| Legacy mode | init / buffer ckpt / dest-path ckpt | `EXPORT_FILE_PATH` only | `-i`, `-c -s`, `-c -s -o` | 0 each |
+
+The five not-ready refusal rows in the main table run in legacy mode in
+this tree (ctl mode refuses earlier, at the advertisement gate).
 
 File-existence assertions (`dump created`, toggle-marker checks, the
 timeout artifact) count as separate pass/fail lines in the script's

--- a/third_party/gpu-cr/tests/integration/README.md
+++ b/third_party/gpu-cr/tests/integration/README.md
@@ -79,6 +79,7 @@ Ctl-plane, discovery, and legacy-mode cases (this tree only):
 |---|---|---|---|---|
 | Advertisement gate | no advertisement → refused | `FAKE_NOT_READY=1` (nothing advertised) | `-c -s` | 3 |
 | Advertisement gate | starttime mismatch (PID reuse) → refused | advert edited to `starttime=1` | `-c -s` | 3 |
+| Advertisement gate | owner uid mismatch (forged advert) → refused | advert `chown`ed to 65534 (root-only; skipped elsewhere) | `-c -s` | 3 |
 | Broken ctl path | non-tmpfs `GPU_CR_CTL_PATH` refused | `GPU_CR_CTL_PATH` on disk-backed fs | `-c -s` | 3 |
 | Broken ctl path | missing `GPU_CR_CTL_PATH` dir refused | `GPU_CR_CTL_PATH=/nonexistent-ctl` | `-c -s` | 3 |
 | Discovery | advert + control channel land on `<data>/ctl` | no ctl env at all (tmpfs data dir) | `-i` | 0; both files under `<data>/ctl` |

--- a/third_party/gpu-cr/tests/integration/cr_client_integration_test.sh
+++ b/third_party/gpu-cr/tests/integration/cr_client_integration_test.sh
@@ -2,10 +2,10 @@
 # Integration tests for cr_client against the GPU-free fake workload.
 #
 # Exercises the real control-channel protocol end to end on Linux without
-# a GPU: destination-path checkpoint/restore, dump validation, op_status
-# propagation (including the cuda-checkpoint toggle gate), timeouts, and
-# not-ready refusals. Asserts the documented exit codes: 0 OK,
-# 1 usage, 2 op failed, 3 refused, 4 timeout.
+# a GPU: advertisement gating, destination-path checkpoint/restore, dump
+# validation, op_status propagation (including the cuda-checkpoint toggle
+# gate), timeouts, and not-ready refusals. Asserts the documented exit
+# codes: 0 OK, 1 usage, 2 op failed, 3 refused, 4 timeout.
 #
 # Usage: cr_client_integration_test.sh <cr_client> <fake_workload>
 set -u
@@ -14,6 +14,12 @@ CR_CLIENT=$(readlink -f "$1")
 FAKE=$(readlink -f "$2")
 
 WORK=$(mktemp -d /tmp/gpu-cr-it-data.XXXXXX)
+CTL=$(mktemp -d /dev/shm/gpu-cr-it-ctl.XXXXXX)
+# Zero-config discovery data dir: on tmpfs, so its plain ctl/ subdir
+# satisfies the containing-filesystem statfs gate — the same predicate a
+# nested tmpfs mount satisfies in production.
+DISC=$(mktemp -d /dev/shm/gpu-cr-it-disc.XXXXXX)
+mkdir "$DISC/ctl"
 STUB_DIR=$(mktemp -d /tmp/gpu-cr-it-stub.XXXXXX)
 TOGGLE_MARKER="$STUB_DIR/toggled"
 cat > "$STUB_DIR/cuda-checkpoint" <<EOF
@@ -32,7 +38,7 @@ FAIL=0
 
 cleanup() {
     stop_fake
-    rm -rf "$WORK" "$STUB_DIR"
+    rm -rf "$WORK" "$CTL" "$DISC" "$STUB_DIR"
 }
 trap cleanup EXIT
 
@@ -59,7 +65,7 @@ stop_fake() {
         wait "$FAKE_PID" 2>/dev/null
         FAKE_PID=""
     fi
-    rm -f "$WORK"/control* "$WORK"/dump* "$WORK"/fake.log \
+    rm -f "$CTL"/* "$WORK"/control* "$WORK"/dump* "$WORK"/fake.log \
           "$TOGGLE_MARKER" 2>/dev/null
     return 0
 }
@@ -90,14 +96,14 @@ expect_no_file() {
     else echo "FAIL: $1 (unexpected $2)"; FAIL=$((FAIL + 1)); fi
 }
 
-ENV="EXPORT_FILE_PATH=$WORK"
+CTL_ENV="EXPORT_FILE_PATH=$WORK GPU_CR_CTL_PATH=$CTL"
 REGIONS="0x7f0000000000:4096,0x7f0000100000:8192"
 
-# --- happy paths -------------------------------------------------------------
-start_fake $ENV
-check "init"                    0 env $ENV "$CR_CLIENT" -i -p "$FAKE_PID"
-check "dest-path selective ckpt" 0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
-expect_file "dump created" "$WORK/dump.bin"
+# --- ctl mode: happy paths -------------------------------------------------
+start_fake $CTL_ENV
+check "ctl: init"                    0 env $CTL_ENV "$CR_CLIENT" -i -p "$FAKE_PID"
+check "ctl: dest-path selective ckpt" 0 env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+expect_file "ctl: dump created" "$WORK/dump.bin"
 # The target writes the dump (the .so opens dest_path O_RDWR, no O_CREAT),
 # and cr_client may run as root while the target does not: the precreate
 # must hand the inode to the target's owner and pin mode 0600. Without the
@@ -111,37 +117,37 @@ if [ "$dump_owner" = "$target_owner" ] && [ "$dump_mode" = "600" ]; then
 else
     echo "FAIL: precreated dest owner/mode (uid $dump_owner vs target $target_owner, mode $dump_mode)"; FAIL=$((FAIL + 1))
 fi
-check "dest-path selective restore" 0 env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
-check "buffer selective ckpt"   0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
-check "full ckpt"               0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID"
-check "full restore (stub toggle)" 0 env $ENV "$CR_CLIENT" -r -p "$FAKE_PID"
-expect_file "cuda-checkpoint toggled on success" "$TOGGLE_MARKER"
+check "ctl: dest-path selective restore" 0 env $CTL_ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+check "ctl: buffer selective ckpt"   0 env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+check "ctl: full ckpt"               0 env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID"
+check "ctl: full restore (stub toggle)" 0 env $CTL_ENV "$CR_CLIENT" -r -p "$FAKE_PID"
+expect_file "ctl: cuda-checkpoint toggled on success" "$TOGGLE_MARKER"
 
 # --- -b (buffer-only) never touches cuda-checkpoint --------------------------
-start_fake $ENV
-check "full ckpt -b"            0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -b
-expect_no_file "-b ckpt did not toggle" "$TOGGLE_MARKER"
-check "full restore -b"         0 env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -b
-expect_no_file "-b restore did not toggle" "$TOGGLE_MARKER"
+start_fake $CTL_ENV
+check "ctl: full ckpt -b"            0 env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -b
+expect_no_file "ctl: -b ckpt did not toggle" "$TOGGLE_MARKER"
+check "ctl: full restore -b"         0 env $CTL_ENV "$CR_CLIENT" -r -p "$FAKE_PID" -b
+expect_no_file "ctl: -b restore did not toggle" "$TOGGLE_MARKER"
 
 # --- torn dump is refused post-checkpoint ----------------------------------
-start_fake $ENV FAKE_SKIP_COMMIT=1
-check "torn dump: ckpt fails validation" 2 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+start_fake $CTL_ENV FAKE_SKIP_COMMIT=1
+check "torn dump: ckpt fails validation" 2 env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
 
 # --- restore refuses a torn dump (fake mirrors .so via ValidateDumpFd) -----
-start_fake $ENV
+start_fake $CTL_ENV
 head -c 100 /dev/zero > "$WORK/torn.bin"
-check "torn dump: restore refused"   2 env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/torn.bin"
+check "torn dump: restore refused"   2 env $CTL_ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/torn.bin"
 
 # --- op_status propagation --------------------------------------------------
-start_fake $ENV FAKE_OP_STATUS=28    # ENOSPC
-check "op_status: selective ckpt surfaces failure" 2 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
-check "op_status: full ckpt fails cleanly" 2 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID"
+start_fake $CTL_ENV FAKE_OP_STATUS=28    # ENOSPC
+check "op_status: selective ckpt surfaces failure" 2 env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+check "op_status: full ckpt fails cleanly" 2 env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID"
 expect_no_file "op_status: NOT frozen after a failed ckpt" "$TOGGLE_MARKER"
 # Restore thaws before the op outcome is known (upstream ordering: the
 # in-process handler needs a live CUDA context), so a failed restore
 # still exits 2 but the toggle has already run.
-check "op_status: full restore fails cleanly" 2 env $ENV "$CR_CLIENT" -r -p "$FAKE_PID"
+check "op_status: full restore fails cleanly" 2 env $CTL_ENV "$CR_CLIENT" -r -p "$FAKE_PID"
 expect_file "op_status: restore thawed before the failed op" "$TOGGLE_MARKER"
 
 # --- recycled destination is truncated at precreate --------------------------
@@ -149,10 +155,10 @@ expect_file "op_status: restore thawed before the failed op" "$TOGGLE_MARKER"
 # to the new file: after a smaller dump to the same path, the file must
 # shrink (O_TRUNC), or a torn write could false-validate against leftover
 # marker bytes.
-start_fake $ENV
-check "recycle setup: 2-region dump"  0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/recycle.bin"
+start_fake $CTL_ENV
+check "recycle setup: 2-region dump"  0 env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/recycle.bin"
 big_size=$(stat -c %s "$WORK/recycle.bin")
-check "recycled dest: smaller dump"   0 env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "0x7f0000000000:4096" -o "$WORK/recycle.bin"
+check "recycled dest: smaller dump"   0 env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "0x7f0000000000:4096" -o "$WORK/recycle.bin"
 small_size=$(stat -c %s "$WORK/recycle.bin")
 if [ "$small_size" -lt "$big_size" ]; then
     echo "ok:   recycled dest truncated ($big_size -> $small_size bytes)"; PASS=$((PASS + 1))
@@ -161,55 +167,95 @@ else
 fi
 
 # --- timeout ----------------------------------------------------------------
-start_fake $ENV FAKE_NO_FINISH=1
+start_fake $CTL_ENV FAKE_NO_FINISH=1
 check "timeout: wedged workload fails the op" 4 \
-    env $ENV GPU_CR_OP_TIMEOUT_SEC=2 "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+    env $CTL_ENV GPU_CR_OP_TIMEOUT_SEC=2 "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
 
 # --- timeout leaves an uncommitted dest artifact ------------------------------
 # Pins the exit-4 on-disk contract: the precreated dest survives, carries no
 # commit marker, and a later restore must refuse it.
-start_fake $ENV FAKE_NO_FINISH=1 FAKE_SKIP_COMMIT=1
+start_fake $CTL_ENV FAKE_NO_FINISH=1 FAKE_SKIP_COMMIT=1
 check "timeout: dest-path ckpt fails" 4 \
-    env $ENV GPU_CR_OP_TIMEOUT_SEC=2 "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/t4.bin"
+    env $CTL_ENV GPU_CR_OP_TIMEOUT_SEC=2 "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/t4.bin"
 expect_file "timeout leaves the precreated dest" "$WORK/t4.bin"
-start_fake $ENV
+start_fake $CTL_ENV
 check "timeout artifact: restore refuses the unmarked dump" 2 \
-    env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/t4.bin"
+    env $CTL_ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/t4.bin"
 
-# --- not-ready .so: selective ops refused pre-signal -------------------------
-start_fake $ENV FAKE_NOT_READY=1
+# --- advertisement gating ----------------------------------------------------
+start_fake $CTL_ENV FAKE_NOT_READY=1     # not-ready .so: no advertisement written
+check "gate: no advertisement -> refused" 3 env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+
+start_fake $CTL_ENV
+ADV="$CTL/ctl-ready-$FAKE_PID"
+sed -i 's/starttime=[0-9]*/starttime=1/' "$ADV"
+check "gate: starttime mismatch (PID reuse) -> refused" 3 env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+
+# --- broken ctl path is refused loudly ---------------------------------------
+start_fake "EXPORT_FILE_PATH=$WORK"      # fake in legacy mode
+check "gate: non-tmpfs GPU_CR_CTL_PATH -> refused" 3 \
+    env EXPORT_FILE_PATH="$WORK" GPU_CR_CTL_PATH="$WORK" "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+check "gate: missing GPU_CR_CTL_PATH dir -> refused" 3 \
+    env EXPORT_FILE_PATH="$WORK" GPU_CR_CTL_PATH=/nonexistent-ctl "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+
+# --- zero-config discovery: NO env, ctl plane found at <data>/ctl -----------
+# The whole point of discovery: both sides run with nothing but
+# EXPORT_FILE_PATH and still agree on a tmpfs control plane.
+start_fake "EXPORT_FILE_PATH=$DISC"
+expect_file "discovery: advert written to <data>/ctl" "$DISC/ctl/ctl-ready-$FAKE_PID"
+check "discovery: init" 0 env EXPORT_FILE_PATH="$DISC" "$CR_CLIENT" -i -p "$FAKE_PID"
+expect_file "discovery: control channel on <data>/ctl" "$DISC/ctl/control-$FAKE_PID"
+check "discovery: dest-path selective ckpt" 0 \
+    env EXPORT_FILE_PATH="$DISC" "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$DISC/dump.bin"
+check "discovery: dest-path selective restore" 0 \
+    env EXPORT_FILE_PATH="$DISC" "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$DISC/dump.bin"
+# The advertisement gate (here: PID reuse) holds without env too.
+sed -i 's/starttime=[0-9]*/starttime=1/' "$DISC/ctl/ctl-ready-$FAKE_PID"
+check "discovery: starttime mismatch -> refused" 3 \
+    env EXPORT_FILE_PATH="$DISC" "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+rm -rf "$DISC"/ctl/* "$DISC"/dump.bin "$DISC"/control-*
+
+# --- legacy mode -------------------------------------------------------------
+start_fake "EXPORT_FILE_PATH=$WORK"
+check "legacy: init"                  0 env EXPORT_FILE_PATH="$WORK" "$CR_CLIENT" -i -p "$FAKE_PID"
+check "legacy: buffer selective ckpt" 0 env EXPORT_FILE_PATH="$WORK" "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+check "legacy: dest-path ckpt with proto published" 0 \
+    env EXPORT_FILE_PATH="$WORK" "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+
+# --- not-ready .so (legacy mode): selective ops refused pre-signal -----------
+start_fake "EXPORT_FILE_PATH=$WORK" FAKE_NOT_READY=1
 check "not-ready .so: dest-path op refused pre-signal" 3 \
-    env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+    env EXPORT_FILE_PATH="$WORK" "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
 check "not-ready .so: buffer selective op refused pre-signal" 3 \
-    env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+    env EXPORT_FILE_PATH="$WORK" "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
 # The gate's worst case: a dest-path restore served from the stale per-PID
 # buffer would replay old bytes into GPU memory — must refuse pre-signal.
 check "not-ready .so: dest-path restore refused pre-signal" 3 \
-    env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
+    env EXPORT_FILE_PATH="$WORK" "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/dump.bin"
 check "not-ready .so: buffer selective restore refused pre-signal" 3 \
-    env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS"
+    env EXPORT_FILE_PATH="$WORK" "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS"
 # Full-process ops stay ungated: a silent .so (no op_status) keeps
 # historical tolerance.
 check "not-ready .so: full ckpt keeps historical behavior" 0 \
-    env $ENV "$CR_CLIENT" -c -p "$FAKE_PID"
+    env EXPORT_FILE_PATH="$WORK" "$CR_CLIENT" -c -p "$FAKE_PID"
 
 # --- usage errors ------------------------------------------------------------
-check "usage: -o without -s"          1 env $ENV "$CR_CLIENT" -c -o "$WORK/dump.bin" -p 1
-check "usage: -s without -c or -r"    1 env $ENV "$CR_CLIENT" -i -p 1 -s "$REGIONS"
-check "usage: -o path too long"       1 env $ENV "$CR_CLIENT" -c -p 1 -s "$REGIONS" \
+check "usage: -o without -s"          1 env $CTL_ENV "$CR_CLIENT" -c -o "$WORK/dump.bin" -p 1
+check "usage: -s without -c or -r"    1 env $CTL_ENV "$CR_CLIENT" -i -p 1 -s "$REGIONS"
+check "usage: -o path too long"       1 env $CTL_ENV "$CR_CLIENT" -c -p 1 -s "$REGIONS" \
     -o "/$(printf 'a%.0s' $(seq 1 300))"
-start_fake $ENV
+start_fake $CTL_ENV
 check "usage: malformed -s fails at parse" 1 \
-    env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "bogus"
+    env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "bogus"
 check "usage: restore from missing file" 2 \
-    env $ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/nonexistent.bin"
+    env $CTL_ENV "$CR_CLIENT" -r -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/nonexistent.bin"
 
 # --- destination hardening ----------------------------------------------------
 check "dest: relative -o refused" 2 \
-    env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "rel/dump.bin"
+    env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "rel/dump.bin"
 ln -s /etc/hostname "$WORK/link.bin"
 check "dest: symlink dest refused (ELOOP)" 2 \
-    env $ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/link.bin"
+    env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS" -o "$WORK/link.bin"
 
 echo
 echo "cr_client integration: $PASS passed, $FAIL failed"

--- a/third_party/gpu-cr/tests/integration/cr_client_integration_test.sh
+++ b/third_party/gpu-cr/tests/integration/cr_client_integration_test.sh
@@ -191,6 +191,21 @@ ADV="$CTL/ctl-ready-$FAKE_PID"
 sed -i 's/starttime=[0-9]*/starttime=1/' "$ADV"
 check "gate: starttime mismatch (PID reuse) -> refused" 3 env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
 
+# --- forged advertisement: owner uid mismatch -> refused ----------------------
+# A co-tenant on a shared ctl dir cannot vouch for a victim PID: the advert
+# must be owned by the same uid the target process runs as. chown needs
+# root, so skip (never fail) elsewhere — the Docker gate runs as root.
+if [ "$(id -u)" = 0 ]; then
+    start_fake $CTL_ENV
+    # forge: right content, wrong owner (recompute the path — start_fake
+    # gave us a fresh FAKE_PID and a fresh advert)
+    chown 65534:65534 "$CTL/ctl-ready-$FAKE_PID"
+    check "gate: advert owner mismatch (forged) -> refused" 3 \
+        env $CTL_ENV "$CR_CLIENT" -c -p "$FAKE_PID" -s "$REGIONS"
+else
+    echo "SKIP: forged-advert scenario (needs root for chown)"
+fi
+
 # --- broken ctl path is refused loudly ---------------------------------------
 start_fake "EXPORT_FILE_PATH=$WORK"      # fake in legacy mode
 check "gate: non-tmpfs GPU_CR_CTL_PATH -> refused" 3 \

--- a/third_party/gpu-cr/tests/integration/fake_workload.cpp
+++ b/third_party/gpu-cr/tests/integration/fake_workload.cpp
@@ -1,7 +1,8 @@
 // GPU-free stand-in for the vGPU.so side of the control channel, used by
 // the cr_client integration tests. It reuses the REAL product pieces —
-// ShareMemComm, FinishOpControls, ValidateDumpFd — and fakes only the
-// GPU work (dump extents are pattern bytes instead of VRAM).
+// ShareMemComm, gpu_cr::Config, WriteAdvertisement, FinishOpControls,
+// ValidateDumpFd — and fakes only the GPU work (dump extents are pattern
+// bytes instead of VRAM).
 //
 // Behavior knobs (env):
 //   FAKE_OP_STATUS   errno-style status to report at FINISH (default 0)
@@ -22,6 +23,7 @@
 #include <unistd.h>
 
 #include "common.h"
+#include "ctl_path.h"
 #include "dump_format.h"
 #include "comm/comm.h"
 
@@ -129,9 +131,18 @@ int main() {
   const char* st = getenv("FAKE_OP_STATUS");
   if (st) g_fake_status = atoi(st);
 
+  const gpu_cr::BufConfig& cfg = gpu_cr::Config();
+
   g_comm = new ShareMemComm(getpid());
   g_comm->setup();
   if (!g_not_ready) g_comm->control->selective_ready = gpu_cr::kSelectiveReady;
+
+  bool ctl_mode = false;
+  const char* ctl_dir = gpu_cr::CtlDir(&ctl_mode);
+  if (ctl_mode && !g_not_ready) {
+    gpu_cr::WriteAdvertisement(ctl_dir, getpid(), cfg.shm_size >> 20,
+                               cfg.staging_size >> 20, cfg.shm_deferred);
+  }
 
   signal(CR_INIT_SIGNAL, SignalHandler);
   signal(CR_CKPT_SIGNAL, SignalHandler);
@@ -146,7 +157,7 @@ int main() {
     }
   }
 
-  fprintf(stderr, "[fake-workload] ready, pid=%d not_ready=%d\n",
-          getpid(), g_not_ready ? 1 : 0);
+  fprintf(stderr, "[fake-workload] ready, pid=%d ctl_mode=%d not_ready=%d\n",
+          getpid(), ctl_mode ? 1 : 0, g_not_ready ? 1 : 0);
   for (;;) pause();
 }

--- a/third_party/gpu-cr/tests/unit/mmap_backend_deferred_test.cpp
+++ b/third_party/gpu-cr/tests/unit/mmap_backend_deferred_test.cpp
@@ -1,0 +1,112 @@
+// Deferred dump-buffer mode (GPU_CR_SHM_MB=0) of the ShareMem backend:
+// setup() skips the dump buffer entirely, the first get_tmp_buf()
+// materializes it at the 64MiB floor, and a failed materialization
+// returns nullptr instead of killing the process. Own test binary:
+// gpu_cr::Config() is a process-cached singleton, so deferred mode
+// cannot coexist with the eager-mode suite in gpu_cr_unit_tests.
+// Exercised through the file backend (EXPORT_FILE_PATH). Linux-only.
+
+#include "backend/backend.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <string>
+
+#include "common.h"
+#include "gtest/gtest.h"
+
+namespace gpu_cr {
+namespace {
+
+// Pin deferred mode (and a small staging size — setup() still maps the
+// host buffer eagerly) into the cached Config() singleton at static-init
+// time, before any test-time Config() call could cache other values.
+const bool kDeferredEnvPinned = [] {
+  setenv("GPU_CR_SHM_MB", "0", 1);
+  setenv("GPU_CR_STAGING_MB", "128", 1);
+  return Config().shm_deferred && Config().shm_size == kShmFloorBytes &&
+         Config().staging_size == (128UL << 20);
+}();
+
+class MmapBackendDeferredTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_TRUE(kDeferredEnvPinned);
+    strcpy(dir_, "/tmp/gpu-cr-mmap-deferred-XXXXXX");
+    ASSERT_NE(mkdtemp(dir_), nullptr);
+    setenv("EXPORT_FILE_PATH", dir_, 1);
+  }
+
+  void TearDown() override {
+    unlink(DumpPath(kId).c_str());
+    unlink(HostPath(kId).c_str());
+    rmdir(dir_);
+    unsetenv("EXPORT_FILE_PATH");
+  }
+
+  std::string DumpPath(int id) const {
+    return std::string(dir_) + "/ckpt-" + std::to_string(id) + ".data";
+  }
+  std::string HostPath(int id) const {
+    return std::string(dir_) + "/ckpt-" + std::to_string(id) + "-host.data";
+  }
+
+  static constexpr int kId = 21;
+  char dir_[64];
+};
+
+// setup() must neither create nor map the dump buffer; the host staging
+// buffer is still mapped eagerly.
+TEST_F(MmapBackendDeferredTest, SetupSkipsDumpBuffer) {
+  ShareMem backend(kId);
+  backend.setup();
+
+  EXPECT_EQ(backend.tmp_buf, nullptr);
+  struct stat st;
+  EXPECT_NE(stat(DumpPath(kId).c_str(), &st), 0);
+
+  ASSERT_EQ(stat(HostPath(kId).c_str(), &st), 0);
+  EXPECT_EQ(static_cast<size_t>(st.st_size),
+            Config().staging_size * STAGING_BUF_NUM);
+  EXPECT_NE(backend.get_host_buffer(), nullptr);
+}
+
+// The first buffer-path op materializes the buffer at the floor size
+// with a freshly reset header; later calls hand out the same mapping.
+TEST_F(MmapBackendDeferredTest, FirstGetTmpBufMaterializesAtFloor) {
+  ShareMem backend(kId);
+  backend.setup();
+
+  void* buf = backend.get_tmp_buf();
+  ASSERT_NE(buf, nullptr);
+
+  struct stat st;
+  ASSERT_EQ(stat(DumpPath(kId).c_str(), &st), 0);
+  EXPECT_EQ(static_cast<size_t>(st.st_size), kShmFloorBytes);
+
+  shared_mem_fs* fs = static_cast<shared_mem_fs*>(buf);
+  EXPECT_EQ(fs->file_num, 0u);
+  EXPECT_EQ(fs->current_offset, ROUND_UP_2MB(sizeof(shared_mem_fs)));
+
+  EXPECT_EQ(backend.get_tmp_buf(), buf);
+}
+
+// The non-fatal contract: a failed materialization reports nullptr and
+// leaves the process alive; once the data dir is usable again the next
+// buffer-path op retries and succeeds.
+TEST_F(MmapBackendDeferredTest, FailedMaterializationIsNonFatalAndRetries) {
+  ShareMem backend(kId);
+  backend.setup();  // The host buffer needs the good dir (fatal path).
+
+  setenv("EXPORT_FILE_PATH", "/nonexistent-gpu-cr-unit-dir", 1);
+  EXPECT_EQ(backend.get_tmp_buf(), nullptr);
+
+  setenv("EXPORT_FILE_PATH", dir_, 1);
+  EXPECT_NE(backend.get_tmp_buf(), nullptr);
+}
+
+}  // namespace
+}  // namespace gpu_cr

--- a/third_party/gpu-cr/tests/unit/mmap_backend_deferred_test.cpp
+++ b/third_party/gpu-cr/tests/unit/mmap_backend_deferred_test.cpp
@@ -94,6 +94,21 @@ TEST_F(MmapBackendDeferredTest, FirstGetTmpBufMaterializesAtFloor) {
   EXPECT_EQ(backend.get_tmp_buf(), buf);
 }
 
+// The try_lock contract: if buf_mutex is already held (a materialization
+// in flight on another thread — or, in the real library, on the very
+// thread a CR signal interrupted), the op fails cleanly with nullptr
+// instead of blocking; once the lock is free the next op succeeds.
+TEST_F(MmapBackendDeferredTest, ContendedMaterializationFailsCleanly) {
+  ShareMem backend(kId);
+  backend.setup();
+
+  backend.buf_mutex.lock();
+  EXPECT_EQ(backend.get_tmp_buf(), nullptr);
+  backend.buf_mutex.unlock();
+
+  EXPECT_NE(backend.get_tmp_buf(), nullptr);
+}
+
 // The non-fatal contract: a failed materialization reports nullptr and
 // leaves the process alive; once the data dir is usable again the next
 // buffer-path op retries and succeeds.

--- a/third_party/gpu-cr/tests/unit/mmap_backend_test.cpp
+++ b/third_party/gpu-cr/tests/unit/mmap_backend_test.cpp
@@ -20,9 +20,22 @@
 namespace gpu_cr {
 namespace {
 
+// Pin small buffer sizes (floors: 64MiB dump, 128MiB staging) and
+// capture them into the cached gpu_cr::Config() singleton at static-init
+// time — gpu_cr_config_test's fixture scrubs these env vars, so waiting
+// until the first test-time Config() call would fall back to the 25GiB
+// build default and fallocate that per test.
+const bool kBufEnvPinned = [] {
+  setenv("GPU_CR_SHM_MB", "64", 1);
+  setenv("GPU_CR_STAGING_MB", "128", 1);
+  return Config().shm_size == (64UL << 20) &&
+         Config().staging_size == (128UL << 20);
+}();
+
 class MmapBackendTest : public ::testing::Test {
  protected:
   void SetUp() override {
+    ASSERT_TRUE(kBufEnvPinned);
     strcpy(dir_, "/tmp/gpu-cr-mmap-backend-XXXXXX");
     ASSERT_NE(mkdtemp(dir_), nullptr);
     setenv("EXPORT_FILE_PATH", dir_, 1);
@@ -73,11 +86,11 @@ TEST_F(MmapBackendTest, FilesCreatedAtConfiguredSizes) {
 
   struct stat st;
   ASSERT_EQ(stat(DumpPath(3).c_str(), &st), 0);
-  EXPECT_EQ(static_cast<size_t>(st.st_size), static_cast<size_t>(SHM_SIZE));
+  EXPECT_EQ(static_cast<size_t>(st.st_size), Config().shm_size);
 
   ASSERT_EQ(stat(HostPath(3).c_str(), &st), 0);
   EXPECT_EQ(static_cast<size_t>(st.st_size),
-            static_cast<size_t>(STAGING_BUF_SIZE) * STAGING_BUF_NUM);
+            Config().staging_size * STAGING_BUF_NUM);
 }
 
 TEST_F(MmapBackendTest, BuffersAreWritable) {
@@ -95,9 +108,9 @@ TEST_F(MmapBackendTest, BuffersAreWritable) {
   ASSERT_NE(host, nullptr);
   // Touch both staging slots.
   host[0] = 0x11;
-  host[STAGING_BUF_SIZE] = 0x22;
+  host[Config().staging_size] = 0x22;
   EXPECT_EQ(host[0], 0x11);
-  EXPECT_EQ(host[STAGING_BUF_SIZE], 0x22);
+  EXPECT_EQ(host[Config().staging_size], 0x22);
 }
 
 TEST_F(MmapBackendTest, GettersAreStable) {

--- a/third_party/gpu-cr/tests/unit/share_mem_comm_test.cpp
+++ b/third_party/gpu-cr/tests/unit/share_mem_comm_test.cpp
@@ -58,6 +58,7 @@ TEST_F(ShareMemCommTest, BaseCommIsInert) {
 TEST_F(ShareMemCommTest, SetupCreatesControlFile) {
   ShareMemComm comm(111);
   comm.setup();
+  EXPECT_GE(comm.fd_control, 0);  // kept open so callers can flock the op
 
   struct stat st;
   ASSERT_EQ(stat(ControlPath(111).c_str(), &st), 0);
@@ -166,8 +167,9 @@ TEST_F(ShareMemCommTest, MessageConstantsDistinct) {
                              RESTORE_MSG,       FINISH_MSG,
                              IPC_TEARDOWN_MSG,  IPC_EXPORT_MSG,
                              IPC_IMPORT_MSG,    NCCL_SUSPEND_MSG,
-                             NCCL_RESUME_MSG};
-  EXPECT_EQ(msgs.size(), 9u);
+                             NCCL_RESUME_MSG,   SELECTIVE_CKPT_MSG,
+                             SELECTIVE_RESTORE_MSG};
+  EXPECT_EQ(msgs.size(), 11u);
 }
 
 // setup() keeps the historical fatal-exit contract when the data dir is


### PR DESCRIPTION
## What does this PR do?

The merged selective-checkpoint PRs each shipped independently; this PR adds the pieces that need two of them in the same tree:

  1. **Deferred dump buffers (#173 × #185).** `GPU_CR_SHM_MB=0` skips creating the dump buffer at load. If a buffer-path op needs it, `get_tmp_buf()` materializes it lazily at a 64 MiB floor — non-fatally: on failure the op reports through `op_status` instead of exiting.
  2. **ctl-mode, workload side (#191 × #196 × #173).** ctl-mode is active when a tmpfs control directory exists (`GPU_CR_CTL_PATH`, or #191's `<store>/ctl` discovery).
  `vGPU.so` then keeps its control files (`control` id counter, `pid_map`) there instead of on the hugetlbfs store, and writes a readiness advertisement — `starttime` plus its
  buffer sizes — as the last statement of the constructor that installs its signal handlers.
  3. **ctl-mode, coordinator side (#191 × #189).** `cr_client` verifies that advertisement — present, protocol level, `starttime` vs `/proc` — before sending any CR signal, and refuses a configured-but-broken `GPU_CR_CTL_PATH` with a documented exit code. The two-lock ordering #189 excluded returns here, guarded by ctl-mode, where the two lock
  files are provably distinct (the same-inode deadlock exists only in legacy mode, which stays single-lock).
  4. **Coordinator env independence (#173 × #189).** The coordinator maps only the fixed header window of each worker buffer and trusts the worker's fstat-checked file size, so coordinator and workers may run different `GPU_CR_*` env.
  5. **Tests only the composed tree can run.** A dedicated deferred-mode unit binary (the config is a process-cached singleton); the integration suite in ctl-mode plus refusal scenarios (no advertisement / PID reuse / broken path → exit 3, no signal sent); e2e env plumbing with #173's below-floor gate renumbered G3→G7; and G8 gates exercising #191's zero-config discovery with the ctl env scrubbed on both sides.
  6. **Glue.** README guidance (`-o`-only deployments should set `GPU_CR_SHM_MB=0`, sizing rule in `gpu_cr_config.h`) and `share_mem` unit assertions with no single-PR home.


<!-- Describe the changes and their purpose -->

## Why is this change needed?

 - **Memory budget.** The agent's memory-regions backend drives every selective checkpoint through destination-path (`-o`) dumps, which never touch the dump buffer — so (1) lets serving pods drop the per-workload buffer reservation entirely, turning buffer footprint into a per-deployment Helm knob instead of a compile-time cost, with a stray buffer-path op degrading to a clean RPC error rather than a dead workload. (2) removes the control plane's hugepage cost on top (the id counter shrinks from a 2 MiB hugepage
  to a 4 KiB page).
  - **Signal safety.** Park/resume orchestration must never signal a pod whose preloader isn't ready (mid-restart) or a PID that was recycled; (2) makes readiness observable and (3) makes the agent's `cr_client` refuse until it's proven — both cases now fail cleanly into the agent's state machine instead of corrupting a workload.
  - **Zero workload-side configuration.** Because the ctl tmpfs nests inside the store the agent already mounts, (2) keeps the workload contract at exactly `LD_PRELOAD` + `EXPORT_FILE_PATH` — no new env or volumes on serving pods.
  - **One agent image.** (4) means the agent's `cr_client` and its workloads don't need matching env, so a single image serves deployments with heterogeneous buffer configs and the Helm chart mirrors nothing.
  - **CI-pinned guarantees.** (5) pins the exact refusal semantics the agent's state machine depends on and proves the zero-config discovery contract on the nested-tmpfs pod layout production actually deploys; (6) documents the recommended `-o`-only configuration so deployers find it.

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [X] Unit tests added/updated
- [X] Integration/e2e tests added/updated
- [X] Manual testing performed

## Checklist

- [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added runtime configuration for checkpoint and staging buffer sizes through environment variables.
  - Added deferred dump-buffer mode, allowing buffer allocation only when needed.
  - Added automatic control-path discovery through the checkpoint store’s `ctl` directory.
  - Added readiness verification before control operations, including protection against stale or reused process IDs.

- **Bug Fixes**
  - Detects insufficient storage during setup instead of failing midway through a dump.
  - Reports clear failures for invalid or unavailable control paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->